### PR TITLE
M2-2282: Exclude applets without encryption for answers

### DIFF
--- a/src/apps/applets/crud/applets.py
+++ b/src/apps/applets/crud/applets.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     null,
     or_,
     select,
+    text,
     true,
     update,
 )
@@ -191,6 +192,12 @@ class AppletsCRUD(BaseCRUD[AppletSchema]):
             )
         query = query.where(AppletSchema.id.in_(accessible_applets_query))
         query = query.where(AppletSchema.is_deleted == False)  # noqa: E712
+        # Exclude edge case when after transfering applets ownership
+        # applet can be shown in applet list for owner in mobile or web
+        # without encryption
+        query = query.where(
+            func.jsonb_typeof(AppletSchema.encryption) != text("'null'"),
+        )
         query = paging(query, query_params.page, query_params.limit)
         result: Result = await self._execute(query)
         return result.scalars().all()
@@ -220,6 +227,12 @@ class AppletsCRUD(BaseCRUD[AppletSchema]):
             )
         query = query.where(AppletSchema.id.in_(accessible_applets_query))
         query = query.where(AppletSchema.is_deleted == False)  # noqa: E712
+        # Exclude edge case when after transfering applets ownership
+        # applet can be shown in applet list for owner in mobile or web
+        # without encryption
+        query = query.where(
+            func.jsonb_typeof(AppletSchema.encryption) != text("'null'"),
+        )
         result: Result = await self._execute(query)
         return result.scalars().first() or 0
 

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -429,9 +429,14 @@ class AppletService:
         self, language: str, query_params: QueryParams
     ) -> list[AppletSingleLanguageInfo]:
         roles: str = query_params.filters.pop("roles")
-
+        # Exclude edge case when after transfering applets ownership
+        # applet can be shown in applet list for owner in mobile or web
+        # without encryption
         schemas = await AppletsCRUD(self.session).get_applets_by_roles(
-            self.user_id, list(map(Role, roles.split(","))), query_params
+            self.user_id,
+            list(map(Role, roles.split(","))),
+            query_params,
+            exclude_without_encryption=True,
         )
         theme_ids = [schema.theme_id for schema in schemas if schema.theme_id]
         themes = []
@@ -477,7 +482,10 @@ class AppletService:
     ) -> int:
         roles: str = query_params.filters.pop("roles")
         count = await AppletsCRUD(self.session).get_applets_by_roles_count(
-            self.user_id, roles.split(","), query_params
+            self.user_id,
+            roles.split(","),
+            query_params,
+            exclude_without_encryption=True,
         )
         return count
 

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -55,7 +55,7 @@ class TestApplet(BaseTest):
                 "publicKey": "publicKey",
                 "prime": "privateKey",
                 "base": "[2]",
-                "accountId": "07216053-3974-4d60-ab8c-457793246a68",
+                "accountId": "7484f34a-3acc-4ee6-8a94-fd7299502fa1",
             },
             "description": {"en": "Central granddaughter unfortunate"},
             "about": {"en": "channels indexing noisily"},
@@ -974,7 +974,7 @@ class TestApplet(BaseTest):
         assert TestMail.mails[0].subject == "Applet duplicate success!"
 
         response = await self.client.get(self.applet_list_url)
-        assert len(response.json()["result"]) == 5
+        assert len(response.json()["result"]) == 4
         assert response.json()["result"][0]["displayName"] == "New name"
 
         response = await self.client.post(
@@ -1121,21 +1121,17 @@ class TestApplet(BaseTest):
         response = await self.client.get(self.applet_list_url)
 
         assert response.status_code == 200, response.json()
-        assert len(response.json()["result"]) == 4
+        assert len(response.json()["result"]) == 3
         assert (
             response.json()["result"][0]["id"]
-            == "92917a56-d586-4613-b7aa-991f2c4b15b4"
-        )
-        assert (
-            response.json()["result"][1]["id"]
             == "92917a56-d586-4613-b7aa-991f2c4b15b5"
         )
         assert (
-            response.json()["result"][2]["id"]
+            response.json()["result"][1]["id"]
             == "92917a56-d586-4613-b7aa-991f2c4b15b2"
         )
         assert (
-            response.json()["result"][3]["id"]
+            response.json()["result"][2]["id"]
             == "92917a56-d586-4613-b7aa-991f2c4b15b1"
         )
 

--- a/src/apps/schedule/tests/test_schedule.py
+++ b/src/apps/schedule/tests/test_schedule.py
@@ -579,7 +579,7 @@ class TestSchedule(BaseTest):
         response = await self.client.get(self.schedule_user_url)
 
         assert response.status_code == 200
-        assert response.json()["count"] == 4
+        assert response.json()["count"] == 6
 
     @rollback
     async def test_schedule_get_user_by_applet(self):

--- a/src/apps/schedule/tests/test_schedule.py
+++ b/src/apps/schedule/tests/test_schedule.py
@@ -579,7 +579,7 @@ class TestSchedule(BaseTest):
         response = await self.client.get(self.schedule_user_url)
 
         assert response.status_code == 200
-        assert response.json()["count"] == 6
+        assert response.json()["count"] == 4
 
     @rollback
     async def test_schedule_get_user_by_applet(self):


### PR DESCRIPTION
Exclude applets from applet list in web and mobile without encryption
(password) after transfer ownership. It should avoid applets owner to answer on
questions from "not ready" applet.
