### PR TITLE
M2-4476: Make value is optional

### DIFF
--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -68,7 +68,7 @@ class _SingleSelectionValue(PublicModel):
     is_hidden: bool = Field(default=False)
     color: Color | None = None
     alert: str | None = None
-    value: int
+    value: int | None = None
 
     @validator("image")
     def validate_image(cls, value):


### PR DESCRIPTION
Value is optional because after adding subscales can appear items with
response types 'singleSelect' and 'multiSelect' without value. In this
case we set value automatically
