### PR TITLE
M2 4493 activity items tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ def before():
 
 
 def after():
-    for alembic_cfg in alembic_configs:
+    for alembic_cfg in alembic_configs[::-1]:
         command.downgrade(alembic_cfg, "base")
     os.environ.pop("PYTEST_APP_TESTING")
 

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,15 @@ from alembic import command
 from alembic.config import Config
 from pytest_asyncio import is_async_test
 
+pytest_plugins = [
+    "apps.activities.tests.fixtures.configs",
+    "apps.activities.tests.fixtures.response_values",
+    "apps.activities.tests.fixtures.items",
+    "apps.activities.tests.fixtures.conditional_logic",
+    "apps.activities.tests.fixtures.scores_reports",
+]
+
+
 alembic_configs = [Config("alembic.ini"), Config("alembic_arbitrary.ini")]
 
 
@@ -33,3 +42,9 @@ def pytest_sessionstart():
 
 def pytest_sessionfinish():
     after()
+
+
+@pytest.fixture
+def remote_image() -> str:
+    # TODO: add support for localimages for tests
+    return "https://www.w3schools.com/css/img_5terre_wide.jpg"

--- a/src/apps/activities/crud/activity.py
+++ b/src/apps/activities/crud/activity.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import cast
 
 from sqlalchemy import delete, select, update
 from sqlalchemy.orm import Query
@@ -69,13 +70,10 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
         return result.all()
 
     async def get_by_id(self, activity_id: uuid.UUID) -> ActivitySchema:
-        query: Query = select(ActivitySchema)
-        query = query.where(ActivitySchema.id == activity_id)
-        result = await self._execute(query)
-        try:
-            return result.scalars().one_or_none()
-        except Exception as e:
-            raise e
+        activity = await self._get("id", activity_id)
+        # TODO: Fix mypy for now. Later need to make get_by_id more consistant
+        activity = cast(ActivitySchema, activity)
+        return activity
 
     # Get by applet id and activity id
     async def get_by_applet_id_and_activity_id(

--- a/src/apps/activities/crud/activity_item.py
+++ b/src/apps/activities/crud/activity_item.py
@@ -50,14 +50,6 @@ class ActivityItemsCRUD(BaseCRUD[ActivityItemSchema]):
         result = await self._execute(query)
         return result.scalars().all()
 
-    async def get_by_id(
-        self, activity_item_id: uuid.UUID
-    ) -> ActivityItemSchema:
-        query: Query = select(ActivityItemSchema)
-        query = query.where(ActivityItemSchema.id == activity_item_id)
-        result = await self._execute(query)
-        return result.scalars().one_or_none()
-
     async def get_ids_by_activity_ids(self, activity_ids: list[uuid.UUID]):
         query: Query = select(ActivityItemSchema.id)
         query = query.where(ActivityItemSchema.activity_id.in_(activity_ids))

--- a/src/apps/activities/crud/activity_item_history.py
+++ b/src/apps/activities/crud/activity_item_history.py
@@ -40,36 +40,12 @@ class ActivityItemHistoriesCRUD(BaseCRUD[ActivityItemHistorySchema]):
         result = await self._execute(query)
         return result.scalars().all()
 
-    async def retrieve_by_id_version(
-        self, id_version: str
-    ) -> ActivityItemHistorySchema:
-        """
-        This method might be redundant.
-        It is leaved there because of changes from main branch.
-        """
-
-        query: Query = select(ActivityItemHistorySchema)
-        query = query.where(ActivityItemHistorySchema.id_version == id_version)
-        result = await self._execute(query)
-        return result.scalars().one_or_none()
-
     async def get_by_activity_id_version(
         self, activity_id: str
     ) -> list[ActivityItemHistorySchema]:
         query: Query = select(ActivityItemHistorySchema)
         query = query.where(
             ActivityItemHistorySchema.activity_id == activity_id
-        )
-        query = query.order_by(ActivityItemHistorySchema.order.asc())
-        db_result = await self._execute(query)
-        return db_result.scalars().all()
-
-    async def get_by_id_versions(
-        self, id_versions: list[str]
-    ) -> list[ActivityItemHistorySchema]:
-        query: Query = select(ActivityItemHistorySchema)
-        query = query.where(
-            ActivityItemHistorySchema.id_version.in_(id_versions)
         )
         query = query.order_by(ActivityItemHistorySchema.order.asc())
         db_result = await self._execute(query)
@@ -128,7 +104,7 @@ class ActivityItemHistoriesCRUD(BaseCRUD[ActivityItemHistorySchema]):
         self, id_version: str | None
     ) -> list[ActivityItemHistorySchema | None]:
         if not id_version:
-            return []
+            return []  # pragma: no cover
         query: Query = select(ActivityItemHistorySchema)
         query = query.join(
             ActivityHistorySchema,

--- a/src/apps/activities/domain/activity_item_base.py
+++ b/src/apps/activities/domain/activity_item_base.py
@@ -111,20 +111,10 @@ class BaseActivityItem(BaseModel):
                     raise IncorrectResponseValueError(
                         type=ResponseTypeValueConfig[response_type]["value"]
                     )
-        else:
-            if (
-                value is not None
-                and type(value)
-                is not ResponseTypeValueConfig[response_type]["value"]
-            ):
-                raise IncorrectResponseValueError(
-                    type=ResponseTypeValueConfig[response_type]["value"]
-                )
-            elif (
-                type(value) is ResponseTypeValueConfig[response_type]["value"]
-            ):
-                value = None
-
+        elif value is not None:
+            raise IncorrectResponseValueError(
+                type=ResponseTypeValueConfig[response_type]["value"]
+            )
         return value
 
     @root_validator(skip_on_failure=True)
@@ -172,17 +162,15 @@ class BaseActivityItem(BaseModel):
     @validator("conditional_logic")
     def validate_conditional_logic(cls, value, values):
         response_type = values.get("response_type")
-        if value is not None:
-            # check if response type is correct
-            if response_type not in [
-                ResponseType.SINGLESELECT,
-                ResponseType.MULTISELECT,
-                ResponseType.SLIDER,
-                ResponseType.TEXT,
-                ResponseType.TIME,
-                ResponseType.TIMERANGE,  # TODO add support???
-            ]:
-                raise IncorrectConditionLogicItemTypeError()
+        if value is not None and response_type not in [
+            ResponseType.SINGLESELECT,
+            ResponseType.MULTISELECT,
+            ResponseType.SLIDER,
+            ResponseType.TEXT,
+            ResponseType.TIME,
+            ResponseType.TIMERANGE,
+        ]:
+            raise IncorrectConditionLogicItemTypeError()
 
         return value
 

--- a/src/apps/activities/domain/custom_validation.py
+++ b/src/apps/activities/domain/custom_validation.py
@@ -151,20 +151,6 @@ def validate_score_and_sections(values: dict):
                         raise IncorrectSectionPrintItemTypeError()
 
             if report.conditional_logic:
-                if hasattr(report.conditional_logic, "items_print"):
-                    for item in report.conditional_logic.items_print:
-                        if item not in item_names:
-                            raise IncorrectSectionPrintItemError()
-                        else:
-                            if items[
-                                item_names.index(item)
-                            ].response_type not in [
-                                ResponseType.SINGLESELECT,
-                                ResponseType.MULTISELECT,
-                                ResponseType.SLIDER,
-                                ResponseType.TEXT,
-                            ]:
-                                raise IncorrectSectionPrintItemTypeError()
                 if hasattr(report.conditional_logic, "conditions"):
                     for item in report.conditional_logic.conditions:
                         dependency_conditions = (

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -97,13 +97,8 @@ class SingleSelectionValues(PublicModel):
         return validate_options_value(value)
 
 
-class MultiSelectionValues(PublicModel):
-    palette_name: str | None
-    options: list[_SingleSelectionValue]
-
-    @validator("options")
-    def validate_options(cls, value):
-        return validate_options_value(value)
+class MultiSelectionValues(SingleSelectionValues, PublicModel):
+    pass
 
 
 class SliderValueAlert(PublicModel):
@@ -272,10 +267,6 @@ class AudioValues(PublicModel):
 
 class AudioPlayerValues(PublicModel):
     file: str | None = Field(default=None)
-
-    # @validator("file")
-    # def validate_file(cls, value):
-    #     return validate_audio(value)
 
 
 ResponseValueConfigOptions = [

--- a/src/apps/activities/domain/reusable_item_choices.py
+++ b/src/apps/activities/domain/reusable_item_choices.py
@@ -18,9 +18,6 @@ class _ReusableItemChoiceBase(BaseModel):
     token_value: conint(gt=-2147483648, lt=2147483647)  # type: ignore
     input_type: InputType
 
-    def __str__(self) -> str:
-        return f"{self.token_name}: {self.token_value}"
-
 
 class PublicReusableItemChoice(_ReusableItemChoiceBase, PublicModel):
     """Public item template data model."""

--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -136,7 +136,7 @@ class ScoresAndReports(PublicModel):
         return value
 
     @classmethod
-    def __validate_sections(csl, value):  # noqa
+    def __validate_sections(cls, value):  # noqa
         if value:
             # check if there are duplicate section names
             section_names = [section.name for section in value]

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -6,7 +6,6 @@ from apps.activities.domain.activity import (
     ActivityDuplicate,
     ActivityLanguageWithItemsMobileDetailPublic,
     ActivitySingleLanguageDetail,
-    ActivitySingleLanguageMobileDetailPublic,
     ActivitySingleLanguageWithItemsDetail,
 )
 from apps.activities.domain.activity_create import (
@@ -306,33 +305,6 @@ class ActivityService:
                     report_included_item_name=schema.report_included_item_name,
                     performance_task_type=schema.performance_task_type,
                     is_performance_task=schema.is_performance_task,
-                )
-            )
-        return activities
-
-    async def get_single_language_by_applet_id_mobile(
-        self, applet_id: uuid.UUID, language: str
-    ) -> list[ActivitySingleLanguageMobileDetailPublic]:
-        schemas = await ActivitiesCRUD(self.session).get_by_applet_id(
-            applet_id, is_reviewable=False
-        )
-        activities = []
-        for schema in schemas:
-            activities.append(
-                ActivitySingleLanguageMobileDetailPublic(
-                    id=schema.id,
-                    name=schema.name,
-                    description=self._get_by_language(
-                        schema.description, language
-                    ),
-                    image=schema.image,
-                    is_reviewable=schema.is_reviewable,
-                    is_skippable=schema.is_skippable,
-                    show_all_at_once=schema.show_all_at_once,
-                    is_hidden=schema.is_hidden,
-                    response_is_editable=schema.response_is_editable,
-                    order=schema.order,
-                    splash_screen=schema.splash_screen,
                 )
             )
         return activities

--- a/src/apps/activities/services/activity_history.py
+++ b/src/apps/activities/services/activity_history.py
@@ -80,25 +80,11 @@ class ActivityHistoryService:
         service = ActivityChangeService(prev_version, self._version)
         return service.get_changes(activities)
 
-    async def get_by_history_ids(
-        self, activity_ids: list[str]
-    ) -> list[ActivityHistory]:
-        schemas = await ActivityHistoriesCRUD(self.session).get_by_ids(
-            activity_ids
-        )
-        return [ActivityHistory.from_orm(schema) for schema in schemas]
-
     async def activities_list(self) -> list[ActivityHistory]:
         schemas = await ActivityHistoriesCRUD(
             self.session
         ).retrieve_activities_by_applet_version(self._applet_id_version)
         return [ActivityHistory.from_orm(schema) for schema in schemas]
-
-    async def get_by_id(self, activity_id: uuid.UUID) -> ActivityHistory:
-        schema = await ActivityHistoriesCRUD(self.session).get_by_id(
-            f"{activity_id}_{self._version}"
-        )
-        return ActivityHistory.from_orm(schema)
 
     async def get_full(
         self, non_performance=False

--- a/src/apps/activities/tests/fixtures/conditional_logic.py
+++ b/src/apps/activities/tests/fixtures/conditional_logic.py
@@ -1,0 +1,23 @@
+import pytest
+
+from apps.activities.domain.conditional_logic import ConditionalLogic, Match
+from apps.activities.domain.conditions import (
+    ConditionType,
+    EqualCondition,
+    ValuePayload,
+)
+from apps.activities.tests.utils import DEFAULT_ITEM_NAME
+
+
+@pytest.fixture
+def condition_equal() -> EqualCondition:
+    return EqualCondition(
+        item_name=DEFAULT_ITEM_NAME,
+        type=ConditionType.EQUAL,
+        payload=ValuePayload(value=1),
+    )
+
+
+@pytest.fixture
+def conditional_logic(condition_equal: EqualCondition) -> ConditionalLogic:
+    return ConditionalLogic(match=Match.ALL, conditions=[condition_equal])

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -1,0 +1,130 @@
+import pytest
+
+from apps.activities.domain.response_type_config import (
+    AdditionalResponseOption,
+    DateConfig,
+    DrawingConfig,
+    MultiSelectionConfig,
+    MultiSelectionRowsConfig,
+    SingleSelectionConfig,
+    SingleSelectionRowsConfig,
+    SliderConfig,
+    SliderRowsConfig,
+    TextConfig,
+)
+
+
+@pytest.fixture
+def additional_response_option() -> AdditionalResponseOption:
+    return AdditionalResponseOption(
+        text_input_option=False, text_input_required=False
+    )
+
+
+@pytest.fixture
+def single_select_config(
+    additional_response_option: AdditionalResponseOption,
+) -> SingleSelectionConfig:
+    return SingleSelectionConfig(
+        randomize_options=False,
+        timer=0,
+        add_scores=False,
+        add_tokens=False,
+        set_alerts=False,
+        add_tooltip=False,
+        set_palette=False,
+        remove_back_button=False,
+        skippable_item=False,
+        additional_response_option=additional_response_option,
+    )
+
+
+@pytest.fixture
+def multi_select_config(single_select_config) -> MultiSelectionConfig:
+    data = single_select_config.dict()
+    return MultiSelectionConfig(**data)
+
+
+@pytest.fixture
+def slider_config(
+    additional_response_option: AdditionalResponseOption,
+) -> SliderConfig:
+    return SliderConfig(
+        timer=0,
+        add_scores=False,
+        set_alerts=False,
+        remove_back_button=False,
+        skippable_item=False,
+        show_tick_marks=False,
+        show_tick_labels=False,
+        continuous_slider=False,
+        additional_response_option=additional_response_option,
+    )
+
+
+@pytest.fixture
+def date_config(
+    additional_response_option: AdditionalResponseOption,
+) -> DateConfig:
+    return DateConfig(
+        remove_back_button=False,
+        skippable_item=False,
+        timer=0,
+        additional_response_option=additional_response_option,
+    )
+
+
+@pytest.fixture
+def text_config() -> TextConfig:
+    return TextConfig(
+        remove_back_button=False,
+        skippable_item=False,
+        correct_answer_required=False,
+        numerical_response_required=False,
+        response_data_identifier=False,
+        response_required=False,
+    )
+
+
+@pytest.fixture
+def drawing_config(
+    additional_response_option: AdditionalResponseOption,
+) -> DrawingConfig:
+    return DrawingConfig(
+        remove_back_button=False,
+        remove_undo_button=False,
+        additional_response_option=additional_response_option,
+        skippable_item=False,
+        timer=0,
+    )
+
+
+@pytest.fixture
+def slider_rows_config() -> SliderRowsConfig:
+    return SliderRowsConfig(
+        remove_back_button=False,
+        skippable_item=False,
+        add_scores=False,
+        set_alerts=False,
+        timer=0,
+    )
+
+
+@pytest.fixture
+def single_select_row_config() -> SingleSelectionRowsConfig:
+    return SingleSelectionRowsConfig(
+        timer=0,
+        add_scores=False,
+        set_alerts=False,
+        add_tooltip=False,
+        add_tokens=None,
+        remove_back_button=False,
+        skippable_item=False,
+    )
+
+
+@pytest.fixture
+def multi_select_row_config(
+    single_select_row_config: SingleSelectionRowsConfig,
+) -> MultiSelectionRowsConfig:
+    return MultiSelectionRowsConfig(**single_select_row_config.dict())

--- a/src/apps/activities/tests/fixtures/items.py
+++ b/src/apps/activities/tests/fixtures/items.py
@@ -1,0 +1,122 @@
+import pytest
+
+from apps.activities.domain.activity_create import ActivityItemCreate
+from apps.activities.domain.response_type_config import (
+    MultiSelectionConfig,
+    MultiSelectionRowsConfig,
+    ResponseType,
+    SingleSelectionConfig,
+    SingleSelectionRowsConfig,
+    SliderConfig,
+    SliderRowsConfig,
+    TextConfig,
+)
+from apps.activities.domain.response_values import (
+    MultiSelectionRowsValues,
+    MultiSelectionValues,
+    SingleSelectionRowsValues,
+    SingleSelectionValues,
+    SliderRowsValues,
+    SliderValues,
+)
+from apps.activities.tests.utils import BaseItemData
+
+
+@pytest.fixture
+def base_item_data() -> BaseItemData:
+    return BaseItemData()
+
+
+@pytest.fixture
+def single_select_item_create(
+    base_item_data: BaseItemData,
+    single_select_config: SingleSelectionConfig,
+    single_select_response_values: SingleSelectionValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        response_type=ResponseType.SINGLESELECT,
+        response_values=single_select_response_values,
+        config=single_select_config,
+        **base_item_data.dict(),
+    )
+
+
+@pytest.fixture
+def multi_select_item_create(
+    base_item_data: BaseItemData,
+    multi_select_config: MultiSelectionConfig,
+    multi_select_reponse_values: MultiSelectionValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        response_type=ResponseType.MULTISELECT,
+        response_values=multi_select_reponse_values,
+        config=multi_select_config,
+        **base_item_data.dict(),
+    )
+
+
+@pytest.fixture
+def slider_item_create(
+    base_item_data: BaseItemData,
+    slider_config: SliderConfig,
+    slider_response_values: SliderValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        response_type=ResponseType.SLIDER,
+        response_values=slider_response_values,
+        config=slider_config,
+        **base_item_data.dict(),
+    )
+
+
+@pytest.fixture
+def single_select_row_item_create(
+    base_item_data: BaseItemData,
+    single_select_row_config: SingleSelectionRowsConfig,
+    single_select_row_response_values: SingleSelectionRowsValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        config=single_select_row_config,
+        response_values=single_select_row_response_values,
+        response_type=ResponseType.SINGLESELECTROWS,
+    )
+
+
+@pytest.fixture
+def multi_select_row_item_create(
+    base_item_data: BaseItemData,
+    multi_select_row_config: MultiSelectionRowsConfig,
+    multi_select_row_response_values: MultiSelectionRowsValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        config=multi_select_row_config,
+        response_values=multi_select_row_response_values,
+        response_type=ResponseType.MULTISELECTROWS,
+    )
+
+
+@pytest.fixture
+def slider_rows_item_create(
+    base_item_data: BaseItemData,
+    slider_rows_config: SliderRowsConfig,
+    slider_rows_response_values: SliderRowsValues,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.SLIDERROWS,
+        response_values=slider_rows_response_values,
+        config=slider_rows_config,
+    )
+
+
+@pytest.fixture
+def text_item_create(
+    text_config: TextConfig, base_item_data: BaseItemData
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.TEXT,
+        config=text_config,
+    )

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -1,0 +1,141 @@
+import uuid
+from typing import cast
+
+import pytest
+
+from apps.activities.domain.response_values import (
+    DrawingValues,
+    MultiSelectionRowsValues,
+    MultiSelectionValues,
+    NumberSelectionValues,
+    SingleSelectionRowsValues,
+    SingleSelectionValues,
+    SliderRowsValue,
+    SliderRowsValues,
+    SliderValueAlert,
+    SliderValues,
+    _SingleSelectionDataOption,
+    _SingleSelectionDataRow,
+    _SingleSelectionOption,
+    _SingleSelectionRow,
+    _SingleSelectionValue,
+)
+
+
+@pytest.fixture
+def single_select_response_values() -> SingleSelectionValues:
+    return SingleSelectionValues(
+        palette_name=None,
+        options=[
+            _SingleSelectionValue(
+                id=str(uuid.uuid4()),
+                text="text",
+                image=None,
+                score=None,
+                tooltip=None,
+                is_hidden=False,
+                color=None,
+                value=0,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def multi_select_reponse_values(
+    single_select_response_values: SingleSelectionValues,
+) -> MultiSelectionValues:
+    data = single_select_response_values.dict()
+    return MultiSelectionValues(**data)
+
+
+@pytest.fixture
+def slider_value_alert() -> SliderValueAlert:
+    return SliderValueAlert(
+        value=0, min_value=None, max_value=None, alert="alert"
+    )
+
+
+@pytest.fixture
+def slider_response_values() -> SliderValues:
+    return SliderValues(
+        min_label=None,
+        max_label=None,
+        scores=None,
+        alerts=None,
+    )
+
+
+@pytest.fixture
+def number_select_response_values() -> NumberSelectionValues:
+    return NumberSelectionValues()
+
+
+@pytest.fixture
+def drawing_response_values(remote_image: str) -> DrawingValues:
+    return DrawingValues(
+        drawing_background=remote_image, drawing_example=remote_image
+    )
+
+
+@pytest.fixture
+def slider_rows_response_values() -> SliderRowsValues:
+    return SliderRowsValues(
+        rows=[
+            SliderRowsValue(
+                id=str(uuid.uuid4()),
+                min_label=None,
+                max_label=None,
+                label="label",
+            )
+        ]
+    )
+
+
+@pytest.fixture
+def single_select_row_option() -> _SingleSelectionOption:
+    return _SingleSelectionOption(id=str(uuid.uuid4()), text="text")
+
+
+@pytest.fixture
+def single_select_row() -> _SingleSelectionRow:
+    return _SingleSelectionRow(id=str(uuid.uuid4()), row_name="row_name")
+
+
+@pytest.fixture
+def signle_select_row_data_option(
+    single_select_row_option: _SingleSelectionOption,
+) -> _SingleSelectionDataOption:
+    option_id = cast(str, single_select_row_option.id)
+    return _SingleSelectionDataOption(option_id=option_id)
+
+
+@pytest.fixture
+def single_select_row_data_row(
+    single_select_row: _SingleSelectionRow,
+    signle_select_row_data_option: _SingleSelectionDataOption,
+) -> _SingleSelectionDataRow:
+    row_id = cast(str, single_select_row.id)
+    return _SingleSelectionDataRow(
+        row_id=row_id, options=[signle_select_row_data_option]
+    )
+
+
+@pytest.fixture
+def single_select_row_response_values(
+    single_select_row_option: _SingleSelectionOption,
+    single_select_row: _SingleSelectionRow,
+    single_select_row_data_row: _SingleSelectionDataRow,
+) -> SingleSelectionRowsValues:
+    return SingleSelectionRowsValues(
+        rows=[single_select_row],
+        options=[single_select_row_option],
+        data_matrix=[single_select_row_data_row],
+    )
+
+
+@pytest.fixture
+def multi_select_row_response_values(
+    single_select_row_response_values: SingleSelectionRowsValues,
+) -> MultiSelectionRowsValues:
+    return MultiSelectionRowsValues(**single_select_row_response_values.dict())

--- a/src/apps/activities/tests/fixtures/scores_reports.py
+++ b/src/apps/activities/tests/fixtures/scores_reports.py
@@ -1,0 +1,85 @@
+import pytest
+
+from apps.activities.domain.conditional_logic import Match
+from apps.activities.domain.conditions import (
+    ConditionType,
+    EqualCondition,
+    ValuePayload,
+)
+from apps.activities.domain.scores_reports import (
+    CalculationType,
+    ReportType,
+    Score,
+    ScoreConditionalLogic,
+    ScoresAndReports,
+    Section,
+    Subscale,
+    SubscaleCalculationType,
+    SubscaleItem,
+    SubscaleItemType,
+    SubscaleSetting,
+)
+
+SCORE_ID = "not_uuid_testscore"
+
+
+@pytest.fixture
+def score_conditional_logic() -> ScoreConditionalLogic:
+    return ScoreConditionalLogic(
+        name="test",
+        id="not_uuid_test",
+        match=Match.ALL,
+        conditions=[
+            EqualCondition(
+                item_name=SCORE_ID,
+                payload=ValuePayload(value=1),
+                type=ConditionType.EQUAL,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def score() -> Score:
+    return Score(
+        type=ReportType.score,
+        name="testscore",
+        id=SCORE_ID,
+        calculation_type=CalculationType.SUM,
+    )
+
+
+@pytest.fixture
+def section() -> Section:
+    return Section(type=ReportType.section, name="testsection")
+
+
+@pytest.fixture
+def scores_and_reports(score: Score, section: Section) -> ScoresAndReports:
+    return ScoresAndReports(
+        generate_report=True,
+        show_score_summary=True,
+        reports=[score, section],
+    )
+
+
+@pytest.fixture
+def subscale_item() -> SubscaleItem:
+    return SubscaleItem(name="activity_item_1", type=SubscaleItemType.ITEM)
+
+
+@pytest.fixture
+def subscale(subscale_item: SubscaleItem) -> Subscale:
+    return Subscale(
+        name="test subscale name",
+        scoring=SubscaleCalculationType.AVERAGE,
+        items=[subscale_item],
+    )
+
+
+@pytest.fixture
+def subscale_setting(subscale: Subscale) -> SubscaleSetting:
+    return SubscaleSetting(
+        calculate_total_score=SubscaleCalculationType.AVERAGE,
+        subscales=[subscale],
+    )

--- a/src/apps/activities/tests/unit/domain/test_activity_item_create.py
+++ b/src/apps/activities/tests/unit/domain/test_activity_item_create.py
@@ -1,0 +1,307 @@
+from typing import cast
+
+import pytest
+
+from apps.activities import errors
+from apps.activities.domain.activity_create import ActivityItemCreate
+from apps.activities.domain.response_type_config import (
+    DrawingConfig,
+    ResponseType,
+    TextConfig,
+)
+from apps.activities.domain.response_values import (
+    DrawingValues,
+    NumberSelectionValues,
+    SingleSelectionRowsValues,
+    SingleSelectionValues,
+)
+from apps.activities.tests.utils import BaseItemData
+from apps.shared.domain.custom_validations import InvalidImageError
+
+
+def test_create_activity_item_conditional_logic_not_valid_response_type_config(
+    base_item_data, date_config, conditional_logic
+) -> None:
+    with pytest.raises(errors.IncorrectConditionLogicItemTypeError):
+        ActivityItemCreate(
+            **base_item_data.dict(),
+            config=date_config,
+            response_type=ResponseType.DATE,
+            conditional_logic=conditional_logic,
+            response_values=None,
+        )
+
+
+def test_create_activity_item_conditional_logic_can_not_be_hidden(
+    base_item_data,
+    single_select_config,
+    conditional_logic,
+    single_select_response_values,
+) -> None:
+    base_item_data.is_hidden = True
+    with pytest.raises(errors.HiddenWhenConditionalLogicSetError):
+        ActivityItemCreate(
+            **base_item_data.dict(),
+            config=single_select_config,
+            conditional_logic=conditional_logic,
+            response_values=single_select_response_values,
+            response_type=ResponseType.SINGLESELECT,
+        )
+
+
+def test_create_activity_item_slider_alerts_provided_but_set_alerts_not_set(
+    slider_item_create, slider_value_alert
+):
+    data = slider_item_create.dict()
+    data["response_values"]["alerts"] = [slider_value_alert.dict()]
+    data["config"]["set_alerts"] = False
+    with pytest.raises(errors.AlertFlagMissingSliderItemError):
+        ActivityItemCreate(**data)
+
+
+def test_create_activity_item_slider_alerts_not_valid_alert_value(
+    slider_item_create, slider_value_alert
+):
+    data = slider_item_create.dict()
+    alert_data = slider_value_alert.dict()
+    alert_data["value"] = None
+    data["response_values"]["alerts"] = [alert_data]
+    data["config"]["set_alerts"] = True
+    with pytest.raises(errors.SliderMinMaxValueError):
+        ActivityItemCreate(**data)
+
+
+@pytest.mark.parametrize("min_value,max_value", ((1, None), (None, 1)))
+def test_create_activity_item_slider_alerts_not_valid_alert_min_max_values(
+    slider_item_create, slider_value_alert, min_value, max_value
+):
+    data = slider_item_create.dict()
+    alert_data = slider_value_alert.dict()
+    alert_data["min_value"] = min_value
+    alert_data["max_value"] = max_value
+    data["response_values"]["alerts"] = [alert_data]
+    data["config"]["set_alerts"] = True
+    data["config"]["continuous_slider"] = True
+    with pytest.raises(errors.SliderMinMaxValueError):
+        ActivityItemCreate(**data)
+
+
+def test_create_activity_item_slider_alerts_min_value_greater_then_max_value(
+    slider_item_create, slider_value_alert
+):
+    data = slider_item_create.dict()
+    alert_data = slider_value_alert.dict()
+    alert_data["min_value"] = 10
+    alert_data["max_value"] = 0
+    data["response_values"]["alerts"] = [alert_data]
+    data["config"]["set_alerts"] = True
+    data["config"]["continuous_slider"] = True
+    with pytest.raises(errors.MinValueError):
+        ActivityItemCreate(**data)
+
+
+def test_create_activity_item_slider_min_value_greater_then_max_value(
+    slider_item_create,
+):
+    data = slider_item_create.dict()
+    data["response_values"]["min_value"] = 10
+    data["response_values"]["max_value"] = 0
+    with pytest.raises(errors.MinValueError):
+        ActivityItemCreate(**data)
+
+
+def test_create_activity_item_slider_rows_with_alerts_value_is_none(
+    slider_rows_item_create, slider_value_alert
+):
+    slider_value_alert.value = None
+    alert_data = slider_value_alert.dict()
+    data = slider_rows_item_create.dict()
+    data["response_values"]["rows"][0]["alerts"] = [alert_data]
+    with pytest.raises(errors.SliderRowsValueError):
+        ActivityItemCreate(**data)
+
+
+def test_create_activity_item_slider_rows_with_alerts_value_is_not_none_but_alerts_not_set(  # noqa: E501
+    slider_rows_item_create, slider_value_alert
+):
+    alert_data = slider_value_alert.dict()
+    slider_rows_item_create.config.set_alerts = False
+    data = slider_rows_item_create.dict()
+    data["response_values"]["rows"][0]["alerts"] = [alert_data]
+    with pytest.raises(errors.AlertFlagMissingSliderItemError):
+        ActivityItemCreate(**data)
+
+
+@pytest.mark.parametrize(
+    "fixture_name,", ("single_select_item_create", "multi_select_item_create")
+)
+def test_create_activity_item_single_multi_select_alert_is_not_none_but_set_alerts_not_set(  # noqa: E501
+    request,
+    fixture_name,
+) -> None:
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["config"]["set_alerts"] = False
+    data["response_values"]["options"][0]["alert"] = "alert"
+    with pytest.raises(errors.AlertFlagMissingSingleMultiRowItemError):
+        ActivityItemCreate(**data)
+
+
+@pytest.mark.parametrize(
+    "fixture_name,",
+    ("single_select_row_item_create", "multi_select_row_item_create"),
+)
+def test_create_activity_item_single_multi_select_row_alert_is_not_none_but_set_alerts_not_set(  # noqa: E501
+    request,
+    fixture_name,
+) -> None:
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["config"]["set_alerts"] = False
+    data["response_values"]["data_matrix"][0]["options"][0]["alert"] = "alert"
+    with pytest.raises(errors.AlertFlagMissingSingleMultiRowItemError):
+        ActivityItemCreate(**data)
+
+
+def test_single_select_row_response_values_not_valid_data_matrix_len_does_not_equal_len_rows(  # noqa: E501
+    single_select_row_response_values: SingleSelectionRowsValues,
+):
+    data = single_select_row_response_values.dict()
+    data["data_matrix"] = []
+    with pytest.raises(errors.InvalidDataMatrixError):
+        SingleSelectionRowsValues(**data)
+
+
+def test_single_select_row_response_values_not_valid_data_matrix_len_options_does_not_equal_len_per_row(  # noqa: E501
+    single_select_row_response_values: SingleSelectionRowsValues,
+):
+    data = single_select_row_response_values.dict()
+    data["data_matrix"][0]["options"] = []
+    with pytest.raises(errors.InvalidDataMatrixByOptionError):
+        SingleSelectionRowsValues(**data)
+
+
+def test_number_selection_response_values_min_value_greater_than_max_value(
+    number_select_response_values,
+):
+    data = number_select_response_values.dict()
+    data["min_value"], data["max_value"] = data["max_value"], data["min_value"]
+    with pytest.raises(errors.MinValueError):
+        NumberSelectionValues(**data)
+
+
+def test_number_selection_response_values_min_value_is_equal_max_value(
+    number_select_response_values,
+):
+    data = number_select_response_values.dict()
+    data["min_value"], data["max_value"] = 0, 0
+    with pytest.raises(errors.MinValueError):
+        NumberSelectionValues(**data)
+
+
+@pytest.mark.parametrize(
+    "field_name,value",
+    (
+        ("drawing_example", "notfile"),
+        ("drawing_example", "badextenstion.xxx"),
+        ("drawing_background", "notfile"),
+        ("drawing_background", "badextenstion.xxx"),
+    ),
+)
+def test_drawing_response_values_image_name_does_not_start_with_http(
+    drawing_response_values: DrawingValues, field_name: str, value: str
+):
+    data = drawing_response_values.dict()
+    data[field_name] = value
+    with pytest.raises(InvalidImageError):
+        DrawingValues(**data)
+
+
+def test_create_item_with_drawing_response_values(
+    drawing_response_values: DrawingValues,
+    drawing_config: DrawingConfig,
+    base_item_data: BaseItemData,
+    remote_image: str,
+):
+    item = ActivityItemCreate(
+        response_type=ResponseType.DRAWING,
+        config=drawing_config,
+        response_values=drawing_response_values,
+        **base_item_data.dict(),
+    )
+    item.response_values = cast(DrawingValues, item.response_values)
+    assert item.response_values.drawing_background == remote_image
+    assert item.response_values.drawing_example == remote_image
+
+
+def test_create_item_with_drawing_response_values_images_are_none(
+    drawing_config: DrawingConfig,
+    base_item_data: BaseItemData,
+):
+    item = ActivityItemCreate(
+        response_type=ResponseType.DRAWING,
+        config=drawing_config,
+        response_values=DrawingValues(
+            drawing_background=None, drawing_example=None
+        ),
+        **base_item_data.dict(),
+    )
+    item.response_values = cast(DrawingValues, item.response_values)
+    assert item.response_values.drawing_background is None
+    assert item.response_values.drawing_example is None
+
+
+def test_create_item_single_select_row_option_with_image(
+    single_select_row_item_create: ActivityItemCreate, remote_image: str
+):
+    single_select_row_item_create.response_values = cast(
+        SingleSelectionRowsValues,
+        single_select_row_item_create.response_values,
+    )
+    single_select_row_item_create.response_values.options[
+        0
+    ].image = remote_image
+    data = single_select_row_item_create.dict()
+    item = ActivityItemCreate(**data)
+    item.response_values = cast(
+        SingleSelectionRowsValues, item.response_values
+    )
+    assert item.response_values.options[0].image == remote_image
+
+
+def test_create_item_single_select_row_row_with_image(
+    single_select_row_item_create: ActivityItemCreate, remote_image: str
+):
+    single_select_row_item_create.response_values = cast(
+        SingleSelectionRowsValues,
+        single_select_row_item_create.response_values,
+    )
+    single_select_row_item_create.response_values.rows[
+        0
+    ].row_image = remote_image
+    data = single_select_row_item_create.dict()
+    item = ActivityItemCreate(**data)
+    item.response_values = cast(
+        SingleSelectionRowsValues, item.response_values
+    )
+    assert item.response_values.rows[0].row_image == remote_image
+
+
+def test_text_item_config_correct_anser_required(
+    text_config: TextConfig,
+):
+    data = text_config.dict()
+    data["correct_answer"] = None
+    data["correct_answer_required"] = True
+    with pytest.raises(errors.CorrectAnswerRequiredError):
+        TextConfig(**data)
+
+
+def test_activity_item_create_response_values_not_none_for_non_response_response_type(  # noqa: E501
+    text_item_create: ActivityItemCreate,
+    single_select_response_values: SingleSelectionValues,
+):
+    data = text_item_create.dict()
+    data["response_values"] = single_select_response_values.dict()
+    with pytest.raises(errors.IncorrectResponseValueError):
+        ActivityItemCreate(**data)

--- a/src/apps/activities/tests/unit/domain/test_scores_reports.py
+++ b/src/apps/activities/tests/unit/domain/test_scores_reports.py
@@ -1,0 +1,108 @@
+from typing import cast
+
+import pytest
+
+from apps.activities import errors
+from apps.activities.domain.scores_reports import (
+    Score,
+    ScoreConditionalLogic,
+    ScoresAndReports,
+    Subscale,
+    SubscaleSetting,
+)
+
+
+@pytest.mark.parametrize(
+    "fixture_name, error",
+    (
+        ("score", errors.DuplicateScoreNameError),
+        ("section", errors.DuplicateSectionNameError),
+    ),
+)
+def test_duplicated_name_is_not_allowed(
+    scores_and_reports: ScoresAndReports, request, fixture_name: str, error
+):
+    model = request.getfixturevalue(fixture_name)
+    copy = model.copy(deep=True)
+    data = scores_and_reports.dict()
+    data["reports"].append(copy.dict())
+    with pytest.raises(error):
+        ScoresAndReports(**data)
+
+
+def test_duplicated_id_for_score_is_not_allowed(
+    scores_and_reports: ScoresAndReports, score: Score
+):
+    copy = score.copy(deep=True)
+    # make name unique for test because we want to test the same ids not names
+    copy.name = score.name + "1"
+    data = scores_and_reports.dict()
+    data["reports"].append(copy.dict())
+    with pytest.raises(errors.DuplicateScoreIdError):
+        ScoresAndReports(**data)
+
+
+def test_score_and_reports_duplicated_name_in_conditional_logic_is_not_allowed_for_score(  # noqa: E501
+    scores_and_reports: ScoresAndReports,
+    score: Score,
+    score_conditional_logic: ScoreConditionalLogic,
+):
+    copy = score_conditional_logic.copy(deep=True)
+    copy.id = score_conditional_logic.id + "1"
+    score_data = score.dict()
+    score_data["conditional_logic"] = [
+        score_conditional_logic.dict(),
+        copy.dict(),
+    ]
+    data = scores_and_reports.dict()
+    data["reports"] = [score_data]
+    with pytest.raises(errors.DuplicateScoreConditionNameError):
+        ScoresAndReports(**data)
+
+
+def test_score_and_reports_duplicated_id_in_conditional_logic_is_not_allowed_for_score(  # noqa: E501
+    scores_and_reports: ScoresAndReports,
+    score: Score,
+    score_conditional_logic: ScoreConditionalLogic,
+):
+    copy = score_conditional_logic.copy(deep=True)
+    copy.name = score_conditional_logic.name + "1"
+    score_data = score.dict()
+    score_data["conditional_logic"] = [
+        score_conditional_logic.dict(),
+        copy.dict(),
+    ]
+    data = scores_and_reports.dict()
+    data["reports"] = [score_data]
+    with pytest.raises(errors.DuplicateScoreConditionIdError):
+        ScoresAndReports(**data)
+
+
+def test_duplicated_name_for_subscale_settings_is_not_allowed(
+    subscale_setting: SubscaleSetting, subscale: Subscale
+):
+    copy = subscale.copy(deep=True)
+    subscale_setting.subscales = cast(list, subscale_setting.subscales)
+    subscale_setting.subscales.append(copy)
+    data = subscale_setting.dict()
+    with pytest.raises(errors.DuplicateSubscaleNameError):
+        SubscaleSetting(**data)
+
+
+def test_score_duplicated_item_score_are_not_allowed(score: Score):
+    data = score.dict()
+    data["items_score"] = ["duplicate", "duplicate"]
+    with pytest.raises(errors.DuplicateScoreItemNameError):
+        Score(**data)
+
+
+def test_score_conditional_logic_condition_item_name_is_not_the_same_with_score_id(  # noqa: E501
+    score: Score,
+    score_conditional_logic: ScoreConditionalLogic,
+):
+    data = score.dict()
+    conditional_logic_data = score_conditional_logic.dict()
+    conditional_logic_data["conditions"][0]["item_name"] = score.id + "1"
+    data["conditional_logic"] = [conditional_logic_data]
+    with pytest.raises(errors.ScoreConditionItemNameError):
+        Score(**data)

--- a/src/apps/activities/tests/utils.py
+++ b/src/apps/activities/tests/utils.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+
+from apps.shared.domain import InternalModel
+
+DEFAULT_ITEM_NAME = "test"
+
+
+class BaseItemData(InternalModel):
+    """We use this model just for annotations"""
+
+    name: str = DEFAULT_ITEM_NAME
+    question: dict[str, str] = Field(default_factory=dict)
+    is_hidden: bool = False

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -2987,7 +2987,7 @@ class TestActivityItems(BaseTest):
     )
     async def test_create_applet_single_multi_select_response_values_id_duplicate_error(  # noqa: E501
         self, applet_minimal_data, response_type
-    ) -> None:
+    ):
         await self.client.login(
             self.login_url, "tom@mindlogger.com", "Test1234!"
         )
@@ -3011,4 +3011,24 @@ class TestActivityItems(BaseTest):
         assert (
             resp.json()["result"][0]["message"]
             == activity_errors.DuplicateActivityItemOptionIdError.message
+        )
+
+    @rollback
+    async def test_update_applet_duplicated_activity_item_name_is_not_allowed(
+        self, applet_minimal_data
+    ):
+        item = copy.deepcopy(applet_minimal_data["activities"][0]["items"][0])
+        applet_minimal_data["activities"][0]["items"].append(item)
+        resp = await self.client.put(
+            self.applet_detail_url.format(
+                pk="92917a56-d586-4613-b7aa-991f2c4b15b1"
+            ),
+            data=applet_minimal_data,
+        )
+        assert resp.status_code == 422
+        result = resp.json()["result"]
+        assert len(result) == 1
+        assert (
+            result[0]["message"]
+            == activity_errors.DuplicateActivityItemNameNameError.message
         )


### PR DESCRIPTION
- M2-4494: Fix error in alembic migrations downgrade
- M2-4493: Remove unused code in activities services, crud
- M2-4493: Add unit tests for domain validation, add base fixtures
- M2-4493: Add test to validate item name during appet updating
