### PR TITLE
M2-5008: change the default value of auto-advance

### DIFF
--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -72,7 +72,7 @@ class _SelectionConfig(_ScreenConfig, PublicModel):
 
 
 class SingleSelectionConfig(_SelectionConfig, PublicModel):
-    auto_advance: bool = False
+    auto_advance: bool = True
 
 
 class MultiSelectionConfig(_SelectionConfig, PublicModel):

--- a/src/apps/activities/tests/unit/test_activity_item_change.py
+++ b/src/apps/activities/tests/unit/test_activity_item_change.py
@@ -431,7 +431,7 @@ def test_initial_single_selection_config_change(
         "Tokens was disabled",
         "Add Text Input Option was disabled",
         "Input Required was disabled",
-        "Auto Advance was disabled",
+        "Auto Advance was enabled",
     ]
     assert changes == exp_changes
 
@@ -531,7 +531,7 @@ def test_initial_version_changes(
         "Tokens was disabled",
         "Add Text Input Option was disabled",
         "Input Required was disabled",
-        "Auto Advance was disabled",
+        "Auto Advance was enabled",
     ]
     changes = item_change_service.get_changes_insert(new_item)
     assert changes == single_select_exp_changes


### PR DESCRIPTION
resolves: M2-5008

### Objective
Change default value of auto_advance flag for single selection item type. 

### Notes
Since the implementation of the feature, requirements of the feature have changed, so the bug arose. 

New requirements: https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/421199873/Auto-advance+setting+for+Single+Selection+Item+Type

Old requirements: https://mindlogger.atlassian.net/wiki/pages/viewpage.action?pageId=421199873&pageVersion=6
