### PR TITLE
M2-4826: Password health check endpoint fixes

### DIFF
--- a/src/apps/users/api/password.py
+++ b/src/apps/users/api/password.py
@@ -1,8 +1,4 @@
-import uuid
-from typing import Annotated
-
-from fastapi import Body, Depends, Query
-from pydantic import Required
+from fastapi import Body, Depends
 from starlette import status
 
 from apps.authentication.deps import get_current_user
@@ -14,6 +10,7 @@ from apps.users.cruds.user import UsersCRUD
 from apps.users.domain import (
     ChangePasswordRequest,
     PasswordRecoveryApproveRequest,
+    PasswordRecoveryHealthCheckRequest,
     PasswordRecoveryRequest,
     PublicUser,
     User,
@@ -113,12 +110,12 @@ async def password_recovery_approve(
 
 
 async def password_recovery_healthcheck(
-    email: Annotated[str, Query(max_length=100)] = Required,
-    key: Annotated[uuid.UUID | str, Query(max_length=36)] = Required,
+    schema: PasswordRecoveryHealthCheckRequest = Body(...),
 ):
     """General endpoint to get the password recovery healthcheck."""
 
     try:
-        await PasswordRecoveryCache().get(email, key)
+        cached = await PasswordRecoveryCache().get(schema.email, schema.key)
+        return Response[dict](result=cached.instance)
     except CacheNotFound:
         raise PasswordRecoveryHealthCheckNotValid()

--- a/src/apps/users/api/password.py
+++ b/src/apps/users/api/password.py
@@ -1,4 +1,8 @@
-from fastapi import Body, Depends
+import uuid
+from typing import Annotated
+
+from fastapi import Body, Depends, Query
+from pydantic import Required
 from starlette import status
 
 from apps.authentication.deps import get_current_user
@@ -10,7 +14,6 @@ from apps.users.cruds.user import UsersCRUD
 from apps.users.domain import (
     ChangePasswordRequest,
     PasswordRecoveryApproveRequest,
-    PasswordRecoveryHealthCheckRequest,
     PasswordRecoveryRequest,
     PublicUser,
     User,
@@ -110,12 +113,13 @@ async def password_recovery_approve(
 
 
 async def password_recovery_healthcheck(
-    schema: PasswordRecoveryHealthCheckRequest = Body(...),
+    email: Annotated[str, Query(max_length=100)] = Required,
+    key: Annotated[uuid.UUID | str, Query(max_length=36)] = Required,
 ):
     """General endpoint to get the password recovery healthcheck."""
 
     try:
-        cached = await PasswordRecoveryCache().get(schema.email, schema.key)
+        cached = await PasswordRecoveryCache().get(email, key)
         return Response[dict](result=cached.instance)
     except CacheNotFound:
         raise PasswordRecoveryHealthCheckNotValid()

--- a/src/apps/users/domain.py
+++ b/src/apps/users/domain.py
@@ -1,7 +1,6 @@
 import uuid
-from typing import Annotated
 
-from pydantic import BaseModel, EmailStr, Field, Required, root_validator
+from pydantic import BaseModel, EmailStr, Field, root_validator
 
 from apps.shared.domain import InternalModel, PublicModel
 from apps.shared.domain.custom_validations import lowercase_email
@@ -130,8 +129,3 @@ class PasswordRecoveryApproveRequest(InternalModel):
     email: EmailStr
     key: uuid.UUID
     password: str
-
-
-class PasswordRecoveryHealthCheckRequest(InternalModel):
-    email: Annotated[str, Field(max_length=100)] = Required
-    key: Annotated[uuid.UUID | str, Field(max_length=36)] = Required

--- a/src/apps/users/domain.py
+++ b/src/apps/users/domain.py
@@ -1,6 +1,7 @@
 import uuid
+from typing import Annotated
 
-from pydantic import BaseModel, EmailStr, Field, root_validator
+from pydantic import BaseModel, EmailStr, Field, Required, root_validator
 
 from apps.shared.domain import InternalModel, PublicModel
 from apps.shared.domain.custom_validations import lowercase_email
@@ -129,3 +130,8 @@ class PasswordRecoveryApproveRequest(InternalModel):
     email: EmailStr
     key: uuid.UUID
     password: str
+
+
+class PasswordRecoveryHealthCheckRequest(InternalModel):
+    email: Annotated[str, Field(max_length=100)] = Required
+    key: Annotated[uuid.UUID | str, Field(max_length=36)] = Required


### PR DESCRIPTION
resolves: M2-4826

### Objective

- Update password health check endpoint to accept json body instead of query
- Fix not returning found cached data on success (was returning `null`)

### Notes

Usage:
Trigger the password flow using `/users/me/password/recover` with:
```json
{
  "email": "user@email.com"
}
```
and then use `/users/me/password/recover/healthcheck` with:
```json
{
  "email": "user@email.com",
  "key": "<key_from_password_recover>"
}
```

**Valid result password link:**
```json
{
  "result": {
    "email": "user@email.com",
    "user_id": "...",
    "key": "..."
  }
}
```

**Invalid password link:**
```json
{
  "result": [
    {
      "message": "Invalid or Expired Link.",
      "type": "NOT_FOUND",
      "path": []
    }
  ]
}
```

### Follow up tasks
