### PR TITLE
M2-5018 Migrate reviewer respondent list to subject list

### DIFF
--- a/src/apps/shared/commands/patch_commands.py
+++ b/src/apps/shared/commands/patch_commands.py
@@ -37,6 +37,11 @@ PatchRegister.register(
     task_id="M2-4613",
     description="Create subjects for pending invitations",
 )
+PatchRegister.register(
+    file_path="m2_5018_migrate_reviewer_respondents_list.py",
+    task_id="M2-5018",
+    description="Replace reviewer respondent list with subject list",
+)
 
 
 app = typer.Typer()

--- a/src/apps/shared/commands/patches/m2_5018_migrate_reviewer_respondents_list.py
+++ b/src/apps/shared/commands/patches/m2_5018_migrate_reviewer_respondents_list.py
@@ -1,0 +1,59 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+sql_invitations = """
+    with respondents as (
+        select
+            id,
+            applet_id,
+            jsonb_array_elements_text(meta->'respondents') as user_id
+        from
+            invitations i
+        where
+            role = 'reviewer'
+    ),
+    invitation_subjects as (
+        select r.id, jsonb_agg(s.id) as subjects
+        from respondents r
+        join subjects s
+            on s.user_id::text = r.user_id and s.applet_id = r.applet_id
+        group by r.id
+    )
+    update invitations
+    set meta = jsonb_set(meta, '{subjects}', invitation_subjects.subjects)
+    from invitation_subjects
+    where invitations.id = invitation_subjects.id;
+"""
+
+sql_reviewers = """
+    with reviewer_respondents as (
+        select
+            id,
+            applet_id,
+            jsonb_array_elements_text(meta->'respondents') as user_id
+        from
+            user_applet_accesses uaa
+        where
+            role = 'reviewer'
+    ),
+    reviewer_subjects as (
+        select r.id, jsonb_agg(s.id) as subjects
+        from reviewer_respondents r
+        join subjects s
+            on s.user_id::text = r.user_id and s.applet_id = r.applet_id
+        group by r.id
+    )
+    update user_applet_accesses
+    set meta = jsonb_set(meta, '{subjects}', reviewer_subjects.subjects)
+    from reviewer_subjects
+    where user_applet_accesses.id = reviewer_subjects.id
+"""
+
+
+async def main(
+    session: AsyncSession,
+    arbitrary_session: AsyncSession = None,
+    *args,
+    **kwargs,
+):
+    await session.execute(sql_invitations)
+    await session.execute(sql_reviewers)


### PR DESCRIPTION
resolves: [M2-5018](https://mindlogger.atlassian.net/browse/M2-5018)

### Objective
Migration of user_applet_accesses and invitations records with role 'reviewer' adding subjects list


[M2-5018]: https://mindlogger.atlassian.net/browse/M2-5018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ