### PR TITLE
M2-5045: patch for setting auto_advance true for existing items, for new ones - false 

### DIFF
--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -72,7 +72,7 @@ class _SelectionConfig(_ScreenConfig, PublicModel):
 
 
 class SingleSelectionConfig(_SelectionConfig, PublicModel):
-    auto_advance: bool = True
+    auto_advance: bool = False
 
 
 class MultiSelectionConfig(_SelectionConfig, PublicModel):
@@ -425,9 +425,7 @@ ResponseTypeValueConfig = {}
 index = 0
 
 for response_type in ResponseType:
-    zipped_type_value = list(
-        zip(ResponseValueConfigOptions, ResponseTypeConfigOptions)
-    )
+    zipped_type_value = list(zip(ResponseValueConfigOptions, ResponseTypeConfigOptions))
 
     ResponseTypeValueConfig[response_type] = {
         "config": zipped_type_value[index][1],

--- a/src/apps/activities/tests/unit/test_activity_item_change.py
+++ b/src/apps/activities/tests/unit/test_activity_item_change.py
@@ -161,9 +161,7 @@ def test_initial_single_selection_values_change(
 ) -> None:
     service = ResponseOptionChangeService()
     changes: list[str] = []
-    service.check_changes(
-        ResponseType.SINGLESELECT, single_selection_values, changes
-    )
+    service.check_changes(ResponseType.SINGLESELECT, single_selection_values, changes)
     assert changes == ["o1 | 0 option was added"]
 
 
@@ -377,8 +375,7 @@ def test_conditional_logic_added(conditional_logic: ConditionalLogic):
     item_name = condition.item_name
     value = condition.payload.value  # type: ignore
     assert changes == [
-        f"{parent_name}: If All: "
-        f"{item_name} {condition_type} {value} was added"
+        f"{parent_name}: If All: " f"{item_name} {condition_type} {value} was added"
     ]
 
 
@@ -431,7 +428,7 @@ def test_initial_single_selection_config_change(
         "Tokens was disabled",
         "Add Text Input Option was disabled",
         "Input Required was disabled",
-        "Auto Advance was enabled",
+        "Auto Advance was disabled",
     ]
     assert changes == exp_changes
 
@@ -531,7 +528,7 @@ def test_initial_version_changes(
         "Tokens was disabled",
         "Add Text Input Option was disabled",
         "Input Required was disabled",
-        "Auto Advance was enabled",
+        "Auto Advance was disabled",
     ]
     changes = item_change_service.get_changes_insert(new_item)
     assert changes == single_select_exp_changes

--- a/src/apps/shared/commands/patch_commands.py
+++ b/src/apps/shared/commands/patch_commands.py
@@ -28,6 +28,12 @@ PatchRegister.register(
     description="Populate user_id column in declined/approved invitations",
     manage_session=False,
 )
+PatchRegister.register(
+    file_path="m2_5045_auto_advance.py",
+    task_id="M2-5045",
+    description="Set auto_advance=True to all existing singleSelect items without auto_advance flag",  # noqa : E501
+    manage_session=False,
+)
 
 
 app = typer.Typer()
@@ -113,9 +119,7 @@ async def exec_patch(patch: Patch, owner_id: Optional[uuid.UUID]):
 
     arbitrary_session_maker = None
     if arbitrary:
-        arbitrary_session_maker = session_manager.get_session(
-            arbitrary.database_uri
-        )
+        arbitrary_session_maker = session_manager.get_session(arbitrary.database_uri)
 
     session_maker = session_manager.get_session()
 
@@ -145,9 +149,7 @@ async def exec_patch(patch: Patch, owner_id: Optional[uuid.UUID]):
         try:
             # run main from the file
             patch_file = importlib.import_module(
-                str(__package__)
-                + ".patches."
-                + patch.file_path.replace(".py", ""),
+                str(__package__) + ".patches." + patch.file_path.replace(".py", ""),
             )
 
             # if manage_session is True, pass sessions to patch_file main
@@ -159,9 +161,7 @@ async def exec_patch(patch: Patch, owner_id: Optional[uuid.UUID]):
                         if arbitrary_session_maker:
                             async with arbitrary_session_maker() as arbitrary_session:  # noqa: E501
                                 async with atomic(arbitrary_session):
-                                    await patch_file.main(
-                                        session, arbitrary_session
-                                    )
+                                    await patch_file.main(session, arbitrary_session)
                         else:
                             await patch_file.main(session)
 

--- a/src/apps/shared/commands/patches/m2_5045_auto_advance.py
+++ b/src/apps/shared/commands/patches/m2_5045_auto_advance.py
@@ -1,0 +1,24 @@
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Query
+
+from apps.activities.db.schemas import ActivityItemSchema
+from apps.activities.domain.response_type_config import ResponseType
+
+
+async def main(session: AsyncSession, *args, **kwargs):
+    query: Query = select(ActivityItemSchema)
+    query = query.where(ActivityItemSchema.response_type == ResponseType.SINGLESELECT)
+    query = query.where(
+        ActivityItemSchema.config["auto_advance"] == None  # noqa : E711
+    )
+    res = await session.execute(query)
+    single_select_items: list[ActivityItemSchema] = res.scalars().all()
+    for item in single_select_items:
+        item.config["auto_advance"] = True
+
+        await session.execute(
+            update(ActivityItemSchema)
+            .where(ActivityItemSchema.id == item.id)
+            .values(config=item.config)
+        )


### PR DESCRIPTION
resolves: M2-5045

### Objective
Create patch command for setting auto_advance for  all the existing single selection items config to true, for all new items, false by default
### Notes
Need to run command `python src/cli.py patch exec M2-5045` after deployment on each env