### PR TITLE
M2-5109: Replace internal model with public model for UserCreateRequest

### DIFF
--- a/src/apps/users/domain.py
+++ b/src/apps/users/domain.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-class UserCreateRequest(InternalModel):
+class UserCreateRequest(PublicModel):
     """This model represents user `create request` data model."""
 
     email: EmailStr

--- a/src/apps/users/tests/unit/test_user_domain.py
+++ b/src/apps/users/tests/unit/test_user_domain.py
@@ -84,3 +84,11 @@ def test_change_password_passwords_contain_whitespace(field: str, value: str):
     data[field] = value
     with pytest.raises(errors.PasswordHasSpacesError):
         domain.ChangePasswordRequest(**data)
+
+
+def test_create_user_model_with_extra_fields__extra_field_ignored(
+    base_data: BaseData,
+):
+    base_data["confirm_password"] = "confirm_passsword"
+    user = domain.UserCreateRequest(**base_data)
+    assert not hasattr(user, "confirm_password")


### PR DESCRIPTION
resolves: [M2-5109](https://mindlogger.atlassian.net/browse/M2-5109)

### Objective
Replace InternalModel with PublicModel
### Notes
Web has different SignUp comparing with admin panel and mobile version.

[M2-5109]: https://mindlogger.atlassian.net/browse/M2-5109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ