### PR TITLE
M2-5085: Update copy for reset password email

### DIFF
--- a/src/apps/mailing/static/templates/blocks/write_us_en.html
+++ b/src/apps/mailing/static/templates/blocks/write_us_en.html
@@ -1,7 +1,5 @@
-    <tr>
-        <td style="padding-bottom: 1%">
-            If you have had any issues creating an account or joining someone else’s applet, please
-            <a href="https://mindlogger.atlassian.net/servicedesk/customer/portal/1/group/1/create/12">write
-                to us</a> for help.
-        </td>
-    </tr>
+<tr>
+    <td style="padding-bottom: 1%">
+        Need help? <a href="https://mindlogger.atlassian.net/servicedesk/customer/portals">Visit our Help Center</a>.
+    </td>
+</tr>

--- a/src/apps/mailing/static/templates/reset_password_en.html
+++ b/src/apps/mailing/static/templates/reset_password_en.html
@@ -1,41 +1,34 @@
 <html style="max-width: 700px" lang="en">
-<body>
-{% include 'header.html' %}
-<table style="padding: 0">
-    <tr>
-        <td style="padding-bottom: 1%">
-            A password reset has been requested. Please use this <a href="{{url}}">link</a> to reset your password.
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-bottom: 1%">
-            The link will expire in 15 minutes.
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-bottom: 1%">
-            If you did not initiate this temporary access request, you can ignore this email.
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-bottom: 1%">
-            Please be aware that if you update your password, the data that has been previously recorded will be deleted.
-        </td>
-    </tr>
-{% include 'blocks/write_us_en.html' %}
-    <tr>
-        <td style="padding-bottom: 1%">
-            Thanks,
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-bottom: 1%">
-            Team MindLogger
-        </td>
-    </tr>
 
-</table>
-{% include 'footers/footer_contact_us_en.html' %}
+<body>
+    {% include 'header.html' %}
+    <table style="padding: 0">
+        <tr>
+            <td style="padding-bottom: 1%">
+                We received a request to reset your password.
+            </td>
+        </tr>
+        <tr>
+            <td style="padding-bottom: 1%">
+                <a href="{{url}}">Click this link</a> to reset your password now. The link will expire in 15 minutes.
+            </td>
+        </tr>
+        <tr>
+            <td style="padding-bottom: 1%">
+                If you did not make this request, you can ignore this email.
+            </td>
+        </tr>
+        <tr>
+            <td style="padding-bottom: 1%">
+                After updating your password, you won’t see your past data in the app. But don’t worry, we still have it.
+            </td>
+        </tr>
+        {% include 'blocks/write_us_en.html' %}
+        <tr>
+            <td style="padding-bottom: 1%">– The MindLogger Team</td>
+        </tr>
+    </table>
+    {% include 'footers/footer_contact_us_en.html' %}
 </body>
 
 </html>


### PR DESCRIPTION
resolves: M2-5085

### Objective

Update copy for reset password email

### Notes

~Confirm if the new "Visit our Help Center" is correct.~
Seems to be correct because other emails also mention the use of the new URL

### Follow up tasks

### Screenshots

<img width="709" alt="Screenshot 2024-02-08 at 15 06 46" src="https://github.com/ChildMindInstitute/mindlogger-backend-refactor/assets/85007/537f7d4f-151a-490d-bc03-5d5be6981808">
