### PR TITLE
M2-4622: Change nickname source from user_applet_access to subject

### DIFF
--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -1173,9 +1173,10 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
         owner_id: uuid.UUID,
     ) -> tuple[str, str] | None:
         query: Query = select(
-            UserAppletAccessSchema.nickname,
+            SubjectSchema.nickname,
             SubjectSchema.secret_user_id
         )
+        query = query.select_from(UserAppletAccessSchema)
         query = query.where(
             UserAppletAccessSchema.owner_id == owner_id,
             UserAppletAccessSchema.applet_id == applet_id,


### PR DESCRIPTION
resolves: M2-4622

### Objective
The correct result for obtaining respondent details (/workspaces/${ownerId}/applets/${appletId}/respondents/${respondentId}) should involve updating the secret user ID and nickname with data from the corresponding subject.

