### PR TITLE
M2-4662:add last_seen to respondent_info

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -961,7 +961,7 @@ class AnswerService:
 
         return count
 
-    async def fill_last_activity(
+    async def fill_last_activity_workspace_respondent(
         self,
         respondents: list[WorkspaceRespondent],
         applet_id: uuid.UUID | None = None,
@@ -971,6 +971,14 @@ class AnswerService:
         for respondent in respondents:
             respondent.last_seen = result.get(respondent.id)
         return respondents
+
+    async def fill_last_activity_respondent_info(
+        self,
+        respondent_id: uuid.UUID,
+        applet_id: uuid.UUID,
+    ) -> dict[uuid.UUID, datetime.datetime]:
+        result = await AnswersCRUD(self.answer_session).get_last_activity([respondent_id], applet_id)
+        return result
 
 
 class ReportServerService:

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -246,7 +246,9 @@ async def workspace_respondents_list(
     await CheckAccessService(session, user.id).check_workspace_respondent_list_access(owner_id)
 
     data, total = await service.get_workspace_respondents(owner_id, None, deepcopy(query_params))
-    respondents = await AnswerService(session=session, arbitrary_session=answer_session).fill_last_activity(data)
+    respondents = await AnswerService(
+        session=session, arbitrary_session=answer_session
+    ).fill_last_activity_workspace_respondent(data)
     return ResponseMulti(result=respondents, count=total)
 
 
@@ -264,9 +266,9 @@ async def workspace_applet_respondents_list(
     await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
     data, total = await service.get_workspace_respondents(owner_id, applet_id, deepcopy(query_params))
-    respondents = await AnswerService(session=session, arbitrary_session=answer_session).fill_last_activity(
-        data, applet_id
-    )
+    respondents = await AnswerService(
+        session=session, arbitrary_session=answer_session
+    ).fill_last_activity_workspace_respondent(data, applet_id)
     return ResponseMulti(result=respondents, count=total)
 
 
@@ -398,6 +400,12 @@ async def workspace_applet_get_respondent(
     await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
     respondent_info = await UserAppletAccessService(session, user.id, applet_id).get_respondent_info(
-        respondent_id, applet_id, owner_id, answer_session
+        respondent_id, applet_id, owner_id
     )
+    # get last activity time
+    result = await AnswerService(session=session, arbitrary_session=answer_session).fill_last_activity_respondent_info(
+        respondent_id, applet_id
+    )
+    respondent_info.last_seen = result.get(respondent_id)
+
     return Response(result=respondent_info)

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -391,12 +391,13 @@ async def workspace_applet_get_respondent(
     respondent_id: uuid.UUID,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
+    answer_session=Depends(get_answer_session_by_owner_id),
 ) -> Response[RespondentInfoPublic]:
     await AppletService(session, user.id).exist_by_id(applet_id)
     await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
     await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
     respondent_info = await UserAppletAccessService(session, user.id, applet_id).get_respondent_info(
-        respondent_id, applet_id, owner_id
+        respondent_id, applet_id, owner_id, answer_session
     )
     return Response(result=respondent_info)

--- a/src/apps/workspaces/domain/user_applet_access.py
+++ b/src/apps/workspaces/domain/user_applet_access.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 
 from pydantic import Field
@@ -137,3 +138,4 @@ class RespondentExportData(InternalModel):
 class RespondentInfoPublic(PublicModel):
     nickname: str | None
     secret_user_id: str
+    last_seen: datetime.datetime | None

--- a/src/apps/workspaces/service/user_applet_access.py
+++ b/src/apps/workspaces/service/user_applet_access.py
@@ -1,9 +1,7 @@
 import uuid
 
 from asyncpg.exceptions import UniqueViolationError
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.answers.crud.answers import AnswersCRUD
 from apps.applets.crud import UserAppletAccessCRUD
 from apps.applets.domain import Role, UserAppletAccess
 from apps.invitations.constants import InvitationStatus
@@ -334,7 +332,6 @@ class UserAppletAccessService:
         respondent_id: uuid.UUID,
         applet_id: uuid.UUID,
         owner_id: uuid.UUID,
-        answer_session: AsyncSession,
     ) -> RespondentInfoPublic:
         crud = UserAppletAccessCRUD(self.session)
         respondent_schema = await crud.get_respondent_by_applet_and_owner(respondent_id, applet_id, owner_id)
@@ -349,11 +346,6 @@ class UserAppletAccessService:
         else:
             respondent_info = RespondentInfoPublic(nickname=respondent_schema.nickname, secret_user_id=None)
 
-        # get last activity time
-        result = await AnswersCRUD(answer_session if answer_session else self.session).get_last_activity(
-            [respondent_id], applet_id
-        )
-        respondent_info.last_seen = result.get(respondent_id)
         return respondent_info
 
     async def has_role(self, role: str) -> bool:

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -697,11 +697,12 @@ class TestWorkspaces(BaseTest):
         assert res.status_code == 200
         body = res.json()
         respondent = body.get("result", {})
-        assert len(respondent) == 2
+        assert len(respondent) == 3
         # encrypted "hFywashKw+KlcDPazIy5QHz4AdkTOYkD28Q8+dpeDDA=" nickname
         # is 'Mindlogger ChildMindInstitute'
         assert respondent["nickname"] == "Mindlogger ChildMindInstitute"
         assert respondent["secretUserId"] == ("f0dd4996-e0eb-461f-b2f8-ba873a674782")
+        assert respondent["lastSeen"] is None
 
     async def test_applet_get_respondent_not_found(self, client, tom):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")


### PR DESCRIPTION
resolves: M2-4662

### Objective
To add last_seen information into respondent info for EP which is used in the review tab in DataVis `/workspaces/{workspaceId}/applets/{appletId}/respondents/{respondentId}`
### Notes
Review Date needs to default to the last date when any Activity in the Applet was completed if The Review Date and Activity and Response Time have not been selected