### PR TITLE
M2-5282: Add new env var to set allow_origin_regex CORS setting

### DIFF
--- a/src/config/cors.py
+++ b/src/config/cors.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, validator
 
@@ -7,6 +7,7 @@ __all__ = ["CorsSettings"]
 
 class CorsSettings(BaseModel):
     allow_origins: list[AnyHttpUrl | Literal["*"]] = ["*"]
+    allow_origin_regex: Optional[str] = None
     allow_methods: list[str] = ["*"]
     allow_headers: list[str] = ["*"]
     allow_credentials: bool = True

--- a/src/middlewares/cors.py
+++ b/src/middlewares/cors.py
@@ -11,6 +11,7 @@ class CORSMiddleware(_CORSMiddleware):
 
 cors_options: dict = {
     "allow_origins": settings.cors.allow_origins,
+    "allow_origin_regex": settings.cors.allow_origin_regex,
     "allow_credentials": settings.cors.allow_credentials,
     "allow_methods": settings.cors.allow_methods,
     "allow_headers": settings.cors.allow_headers,


### PR DESCRIPTION
resolves: [M2-5282](https://mindlogger.atlassian.net/browse/M2-5282)

### Objective
Allow new frontend preview environment access API, setting a env vars like CORS__ALLOW_ORIGIN_REGEX=https:\/\/.*\.amplifyapp\.com  allowing amplify domain in CORS

### Notes
AWS Amplify have a limitation do create sub subdomain in a custom domain, so it cannot create eg. pr-5282.admin.cmiml.net sub subdomain.
The subdomain for preview environment follow the pattern pr-<pr number>.<app id>.amplifyapp.com



[M2-5282]: https://mindlogger.atlassian.net/browse/M2-5282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ