### PR TITLE
M2-5203: Distinguish between web and admin for password reset email

### DIFF
--- a/src/apps/users/services/core.py
+++ b/src/apps/users/services/core.py
@@ -19,6 +19,7 @@ from apps.users.services import PasswordRecoveryCache
 from config import settings
 from infrastructure.cache import CacheNotFound
 from infrastructure.cache.domain import CacheEntry
+from infrastructure.http.domain import MindloggerContentSource
 
 __all__ = ["PasswordRecoveryService"]
 
@@ -28,7 +29,14 @@ class PasswordRecoveryService:
         self._cache: PasswordRecoveryCache = PasswordRecoveryCache()
         self.session = session
 
-    async def send_password_recovery(self, schema: PasswordRecoveryRequest) -> PublicUser:
+    async def send_password_recovery(
+        self,
+        schema: PasswordRecoveryRequest,
+        content_source: MindloggerContentSource,
+    ) -> PublicUser:
+
+        # encrypted_email = encrypt(bytes(schema.email, "utf-8")).hex()
+
         user: User = await UsersCRUD(self.session).get_by_email(schema.email)
 
         if user.email_encrypted != schema.email:
@@ -66,8 +74,18 @@ class PasswordRecoveryService:
 
         exp = settings.authentication.password_recover.expiration // 60
 
+        # Default to web frontend
+        frontend_base_url = settings.service.urls.frontend.web_base
+        if content_source == MindloggerContentSource.admin:
+            # Change to admin frontend if the request came from there
+            frontend_base_url = settings.service.urls.frontend.admin_base
+
+        base_url_with_protocol = frontend_base_url
+        if not base_url_with_protocol.startswith("http"):
+            base_url_with_protocol = f"https://{base_url_with_protocol}"
+
         url = (
-            f"https://{settings.service.urls.frontend.web_base}"
+            f"{base_url_with_protocol}"
             f"/{settings.service.urls.frontend.password_recovery_send}"
             f"?key={password_recovery_info.key}"
             f"&email="

--- a/src/apps/users/services/core.py
+++ b/src/apps/users/services/core.py
@@ -34,9 +34,6 @@ class PasswordRecoveryService:
         schema: PasswordRecoveryRequest,
         content_source: MindloggerContentSource,
     ) -> PublicUser:
-
-        # encrypted_email = encrypt(bytes(schema.email, "utf-8")).hex()
-
         user: User = await UsersCRUD(self.session).get_by_email(schema.email)
 
         if user.email_encrypted != schema.email:

--- a/src/apps/users/services/core.py
+++ b/src/apps/users/services/core.py
@@ -72,17 +72,13 @@ class PasswordRecoveryService:
         exp = settings.authentication.password_recover.expiration // 60
 
         # Default to web frontend
-        frontend_base_url = settings.service.urls.frontend.web_base
+        frontend_base = settings.service.urls.frontend.web_base
         if content_source == MindloggerContentSource.admin:
             # Change to admin frontend if the request came from there
-            frontend_base_url = settings.service.urls.frontend.admin_base
-
-        base_url_with_protocol = frontend_base_url
-        if not base_url_with_protocol.startswith("http"):
-            base_url_with_protocol = f"https://{base_url_with_protocol}"
+            frontend_base = settings.service.urls.frontend.admin_base
 
         url = (
-            f"{base_url_with_protocol}"
+            f"https://{frontend_base}"
             f"/{settings.service.urls.frontend.password_recovery_send}"
             f"?key={password_recovery_info.key}"
             f"&email="


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5203](https://mindlogger.atlassian.net/browse/M2-5203)

This PR updates the password recovery route, enabling the distinction between the web and admin frontends for the password reset email.

Currently when a forgot password request comes in, the link in the reset email is always pointing to the respondent web app. This changes that to make use of the `Mindlogger-Content-Source` HTTP header to distinguish between the two and use the proper link as configured in the settings.

### 🪤 Peer Testing

To test this change, modify your `.env` file with the following values

```shell
SERVICE__URLS__FRONTEND__WEB_BASE="http://localhost:5173"
SERVICE__URLS__FRONTEND__ADMIN_BASE="http://localhost:3000"
```

1. Start up the API server and the admin web app.
2. Navigate to the forgot password page in the admin web app
3. Enter your email address and send the request
4. Open the [local mailhog](http://localhost:8025/) and check the link in the email
    **Expected outcome:** The link should be in the format `http://localhost:3000/password-recovery?key=a5263fd7-9eb3-305c-868c-2e172ab4cad5&email=someone@example.com`, where `http://localhost:3000` is the base URL of the admin app