### PR TITLE
M2-5386 Add respondent list filters by user_id, secret_id

### DIFF
--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -54,6 +54,8 @@ __all__ = ["UserAppletAccessCRUD"]
 class _AppletUsersFilter(Filtering):
     role = FilterField(UserAppletAccessSchema.role)
     shell = FilterField(UserSchema.id, method_name="null")
+    user_id = FilterField(UserSchema.id)
+    respondent_secret_id = FilterField(SubjectSchema.secret_user_id)
 
 
 class _WorkspaceRespondentOrdering(Ordering):

--- a/src/apps/workspaces/filters.py
+++ b/src/apps/workspaces/filters.py
@@ -1,3 +1,5 @@
+import uuid
+
 from apps.shared.query_params import BaseQueryParams
 from apps.workspaces.domain.constants import Role
 
@@ -5,4 +7,6 @@ from apps.workspaces.domain.constants import Role
 class WorkspaceUsersQueryParams(BaseQueryParams):
     role: Role | None
     shell: bool | None
+    user_id: uuid.UUID | None = None
+    respondent_secret_id: str | None = None
     ordering = "-isPinned,-createdAt"

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -440,6 +440,35 @@ class TestWorkspaces(BaseTest):
         assert data["count"] == 0
         assert not data["result"]
 
+    async def test_get_workspace_applet_respondents_filters(
+        self,
+        client,
+        tom,
+        applet_one,
+        tom_applet_one_subject: Subject,
+        lucy: User,
+        applet_one_lucy_respondent,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+
+        url = self.workspace_applet_respondents_list.format(
+            owner_id=tom.id,
+            applet_id=str(applet_one.id),
+        )
+
+        response = await client.get(url, {"userId": str(lucy.id)})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["result"][0]["id"] == str(lucy.id)
+
+        response = await client.get(url, {"respondentSecretId": str(tom_applet_one_subject.secret_user_id)})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["result"][0]["id"] == str(tom.id)
+        assert data["result"][0]["secretIds"][0] == str(tom_applet_one_subject.secret_user_id)
+
     async def test_get_workspace_respondent_accesses(self, client, tom, lucy, applet_one_lucy_respondent):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
         response = await client.get(


### PR DESCRIPTION
resolves: [M2-5386](https://mindlogger.atlassian.net/browse/M2-5386)
