### PR TITLE
M2-5332: Update password reset email subject

### DIFF
--- a/src/apps/users/services/core.py
+++ b/src/apps/users/services/core.py
@@ -74,13 +74,11 @@ class PasswordRecoveryService:
         # Default to web frontend
         frontend_base = settings.service.urls.frontend.web_base
         password_recovery_page = settings.service.urls.frontend.web_password_recovery_send
-        subject = "MindLogger"
 
         if content_source == MindloggerContentSource.admin:
             # Change to admin frontend if the request came from there
             frontend_base = settings.service.urls.frontend.admin_base
             password_recovery_page = settings.service.urls.frontend.admin_password_recovery_send
-            subject = "MindLogger Admin"
 
         url = (
             f"https://{frontend_base}"
@@ -92,7 +90,7 @@ class PasswordRecoveryService:
 
         message = MessageSchema(
             recipients=[user.email_encrypted],
-            subject=subject,
+            subject="Password reset",
             body=service.get_template(
                 path="reset_password_en",
                 email=user.email_encrypted,

--- a/src/apps/users/tests/test_password.py
+++ b/src/apps/users/tests/test_password.py
@@ -148,7 +148,7 @@ class TestPassword:
         assert password_recovery_request.email in keys[0]
         assert len(TestMail.mails) == 5
         assert TestMail.mails[0].recipients[0] == password_recovery_request.email
-        assert TestMail.mails[0].subject == "MindLogger"
+        assert TestMail.mails[0].subject == "Password reset"
 
         response = await client.post(
             url=self.password_recovery_url,
@@ -181,7 +181,7 @@ class TestPassword:
         assert password_recovery_request.email in keys[0]
         assert len(TestMail.mails) == 7
         assert TestMail.mails[0].recipients[0] == password_recovery_request.email
-        assert TestMail.mails[0].subject == "MindLogger"
+        assert TestMail.mails[0].subject == "Password reset"
 
         response = await client.post(
             url=self.password_recovery_url,

--- a/src/apps/users/tests/test_password.py
+++ b/src/apps/users/tests/test_password.py
@@ -82,7 +82,7 @@ class TestPassword:
         assert password_recovery_request.email in keys[0]
         assert len(TestMail.mails) == 1
         assert TestMail.mails[0].recipients[0] == password_recovery_request.email
-        assert TestMail.mails[0].subject == "MindLogger"
+        assert TestMail.mails[0].subject == "Password reset"
 
         response = await client.post(
             url=self.password_recovery_url,
@@ -115,7 +115,7 @@ class TestPassword:
         assert password_recovery_request.email in keys[0]
         assert len(TestMail.mails) == 3
         assert TestMail.mails[0].recipients[0] == password_recovery_request.email
-        assert TestMail.mails[0].subject == "MindLogger Admin"
+        assert TestMail.mails[0].subject == "Password reset"
 
         response = await client.post(
             url=self.password_recovery_url,


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5332](https://mindlogger.atlassian.net/browse/M2-5332)

This PR updates the password reset email subject line to read "Password reset", as suggested in the ticket.

### 📸 Screenshots

> [!NOTE]
> Pay attention to the subject line

#### Before

<img width="360" alt="Respondent web app before screenshot with subject line 'MindLogger'" src="https://github.com/ChildMindInstitute/mindlogger-backend-refactor/assets/14842108/133a99b9-13f4-4510-82e4-814c6232544e"> <img width="360" alt="Admin web app before screenshot with subject line 'MindLogger Admin'" src="https://github.com/ChildMindInstitute/mindlogger-backend-refactor/assets/14842108/578d26d1-bd11-4392-af95-08b77c07567f">

#### After

<img width="480" alt="Screenshot with subject line 'Password reset'" src="https://github.com/ChildMindInstitute/mindlogger-backend-refactor/assets/14842108/b691d9d0-b6e4-4fbc-91ad-a69d0b96199d">

### 🪤 Peer Testing

1. Start up the API server and the admin web app.
2. Navigate to the forgot password page in the admin web app
3. Enter your email address and send the request
4. Open the [local mailhog](http://localhost:8025/) and check the link in the email
    **Expected outcome:** The subject line should say "Password reset"
5. Repeat steps 1-4 for the respondent web app