### PR TITLE
feature/M2 5207 tests for applets api

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ from config import settings
 from infrastructure.app import create_app
 from infrastructure.database.core import build_engine
 from infrastructure.database.deps import get_session
+from infrastructure.utility import FCMNotificationTest
 
 pytest_plugins = [
     "apps.activities.tests.fixtures.configs",
@@ -197,9 +198,14 @@ def pytest_collection_modifyitems(items) -> None:
 
 
 @pytest.fixture
-def remote_image() -> str:
+def local_image_name() -> str:
+    return "test.jpg"
+
+
+@pytest.fixture
+def remote_image(local_image_name: str) -> str:
     # TODO: add support for localimages for tests
-    return "https://www.w3schools.com/css/img_5terre_wide.jpg"
+    return f"http://localhost/{local_image_name}"
 
 
 @pytest.fixture
@@ -268,3 +274,10 @@ def mock_get_session(
         new=get_session,
     )
     return mock
+
+
+@pytest.fixture
+def fcm_client() -> FCMNotificationTest:
+    client = FCMNotificationTest()
+    client.notifications.clear()
+    return client

--- a/src/apps/activities/domain/activity_item_base.py
+++ b/src/apps/activities/domain/activity_item_base.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field, root_validator, validator
 
 from apps.activities.domain.conditional_logic import ConditionalLogic
-from apps.activities.domain.response_type_config import NoneResponseType, ResponseType, ResponseTypeValueConfig
+from apps.activities.domain.response_type_config import ResponseType, ResponseTypeValueConfig
 from apps.activities.errors import (
     AlertFlagMissingSingleMultiRowItemError,
     AlertFlagMissingSliderItemError,
@@ -88,7 +88,7 @@ class BaseActivityItem(BaseModel):
         response_type = values.get("response_type")
         if not response_type:
             return value
-        if response_type not in list(NoneResponseType):
+        if response_type not in ResponseType.get_non_response_types():
             if type(value) is not ResponseTypeValueConfig[response_type]["value"]:
                 try:
                     value = ResponseTypeValueConfig[response_type]["value"](**value)

--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -324,20 +324,6 @@ class ABTrailsConfig(PublicModel):
         return value
 
 
-class NoneResponseType(str, Enum):
-    TEXT = "text"
-    MESSAGE = "message"
-    TIMERANGE = "timeRange"
-    GEOLOCATION = "geolocation"
-    PHOTO = "photo"
-    VIDEO = "video"
-    DATE = "date"
-    TIME = "time"
-    FLANKER = "flanker"
-    STABILITYTRACKER = "stabilityTracker"
-    ABTRAILS = "ABTrails"
-
-
 class ResponseType(str, Enum):
     TEXT = "text"
     SINGLESELECT = "singleSelect"
@@ -360,6 +346,22 @@ class ResponseType(str, Enum):
     FLANKER = "flanker"
     STABILITYTRACKER = "stabilityTracker"
     ABTRAILS = "ABTrails"
+
+    @classmethod
+    def get_non_response_types(cls):
+        return (
+            cls.TEXT,
+            cls.MESSAGE,
+            cls.TIMERANGE,
+            cls.GEOLOCATION,
+            cls.PHOTO,
+            cls.VIDEO,
+            cls.DATE,
+            cls.TIME,
+            cls.FLANKER,
+            cls.STABILITYTRACKER,
+            cls.ABTRAILS,
+        )
 
 
 class PerformanceTaskType(str, Enum):

--- a/src/apps/activities/tests/fixtures/activities.py
+++ b/src/apps/activities/tests/fixtures/activities.py
@@ -3,11 +3,583 @@ import uuid
 import pytest
 
 from apps.activities.domain.activity_create import ActivityCreate, ActivityItemCreate
+from apps.activities.domain.response_type_config import (
+    ABTrailsConfig,
+    ABTrailsDeviceType,
+    ABTrailsOrder,
+    BlockConfiguration,
+    BlockType,
+    ButtonConfiguration,
+    FlankerConfig,
+    InputType,
+    MessageConfig,
+    Phase,
+    ResponseType,
+    SamplingMethod,
+    StabilityTrackerConfig,
+    StimulusConfigId,
+    StimulusConfiguration,
+)
 from apps.shared.enums import Language
 
 
 @pytest.fixture
-def activity_create(single_select_item_create: ActivityItemCreate) -> ActivityCreate:
+def activity_create() -> ActivityCreate:
+    return ActivityCreate(name="test", description={Language.ENGLISH: "test"}, items=[], key=uuid.uuid4())
+
+
+@pytest.fixture
+def activity_ab_trails_ipad_create() -> ActivityCreate:
+    # All values are hardcoded on UI side. The 'key' field is random uuid
     return ActivityCreate(
-        name="test", description={Language.ENGLISH: "test"}, items=[single_select_item_create], key=uuid.uuid4()
+        name="A/B Trails iPad",
+        description={Language.ENGLISH: "A/B Trails"},
+        is_hidden=False,
+        report_included_item_name="",
+        key=uuid.uuid4(),
+        items=[
+            ActivityItemCreate(
+                question={"en": "Sample A"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FIRST),
+                name="ABTrails_tablet_1",
+            ),
+            ActivityItemCreate(
+                question={"en": "Test A"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.SECOND),
+                name="ABTrails_tablet_2",
+            ),
+            ActivityItemCreate(
+                question={"en": "Sample B"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.THIRD),
+                name="ABTrails_tablet_3",
+            ),
+            ActivityItemCreate(
+                question={"en": "Test B"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FOURTH),
+                name="ABTrails_tablet_4",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def activity_ab_trails_mobile_create() -> ActivityCreate:
+    # All values are hardcoded on UI side. The 'key' field is random uuid
+    return ActivityCreate(
+        name="A/B Trails Mobile",
+        description={Language.ENGLISH: "A/B Trails"},
+        is_hidden=False,
+        report_included_item_name="",
+        key=uuid.uuid4(),
+        items=[
+            ActivityItemCreate(
+                question={"en": "Sample A"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FIRST),
+                name="ABTrails_mobile_1",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": "Test A"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.SECOND),
+                name="ABTrails_mobile_2",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": "Sample B"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.THIRD),
+                name="ABTrails_mobile_3",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": "Test B"},
+                response_type=ResponseType.ABTRAILS,
+                response_values=None,
+                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FOURTH),
+                name="ABTrails_mobile_4",
+                is_hidden=False,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def activity_flanker_create(remote_image: str, local_image_name: str) -> ActivityCreate:
+    stimulus_id = uuid.uuid4()
+    return ActivityCreate(
+        name="Simple & Choice Reaction Time Task Builder",
+        description={Language.ENGLISH: "description"},
+        is_hidden=False,
+        report_included_item_name="",
+        is_performance_task=False,
+        key=uuid.uuid4(),
+        items=[
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_VSR_instructions",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_Practice_instructions_1",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(text="", image=remote_image, value=0),
+                        ButtonConfiguration(text="", image=remote_image, value=1),
+                    ],
+                    next_button="OK",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=75,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=True,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=False,
+                    is_first_practice=True,
+                    is_last_test=False,
+                    block_type=BlockType.PRACTICE,
+                ),
+                name="Flanker_Practice_1",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_Practice_instructions_2",
+                is_hidden=False,
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=0,
+                        ),
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=1,
+                        ),
+                    ],
+                    next_button="OK",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=75,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=True,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=False,
+                    is_first_practice=False,
+                    is_last_test=False,
+                    block_type=BlockType.PRACTICE,
+                ),
+                name="Flanker_Practice_2",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_Practice_instructions_3",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=0,
+                        ),
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=1,
+                        ),
+                    ],
+                    next_button="OK",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=75,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=True,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=True,
+                    is_first_practice=False,
+                    is_last_test=False,
+                    block_type=BlockType.PRACTICE,
+                ),
+                name="Flanker_Practice_3",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_test_instructions_1",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=0,
+                        ),
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=1,
+                        ),
+                    ],
+                    next_button="Continue",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=None,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=False,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=False,
+                    is_first_practice=False,
+                    is_last_test=False,
+                    block_type=BlockType.TEST,
+                ),
+                name="Flanker_test_1",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_test_instructions_2",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                            weight=None,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=0,
+                        ),
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=1,
+                        ),
+                    ],
+                    next_button="Continue",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=None,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=False,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=False,
+                    is_first_practice=False,
+                    is_last_test=False,
+                    block_type=BlockType.TEST,
+                ),
+                name="Flanker_test_2",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Flanker_test_instructions_3",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.FLANKER,
+                response_values=None,
+                config=FlankerConfig(
+                    stimulus_trials=[
+                        StimulusConfiguration(
+                            id=StimulusConfigId(str(stimulus_id)),
+                            image=remote_image,
+                            text=local_image_name,
+                            value=0,
+                            weight=None,
+                        )
+                    ],
+                    blocks=[
+                        BlockConfiguration(name="Block 1", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 2", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 3", order=[StimulusConfigId(str(stimulus_id))]),
+                        BlockConfiguration(name="Block 4", order=[StimulusConfigId(str(stimulus_id))]),
+                    ],
+                    buttons=[
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=0,
+                        ),
+                        ButtonConfiguration(
+                            text="",
+                            image=remote_image,
+                            value=1,
+                        ),
+                    ],
+                    next_button="Finish",
+                    fixation_duration=None,
+                    fixation_screen=None,
+                    minimum_accuracy=None,
+                    sample_size=1,
+                    sampling_method=SamplingMethod.RANDOMIZE_ORDER,
+                    show_feedback=False,
+                    show_fixation=False,
+                    show_results=True,
+                    trial_duration=3000,
+                    is_last_practice=False,
+                    is_first_practice=False,
+                    is_last_test=True,
+                    block_type=BlockType.TEST,
+                ),
+                name="Flanker_test_3",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def actvitiy_cst_gyroscope_create() -> ActivityCreate:
+    return ActivityCreate(
+        name="CST Gyroscope",
+        description={Language.ENGLISH: "description"},
+        is_hidden=False,
+        report_included_item_name="",
+        key=uuid.uuid4(),
+        items=[
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Gyroscope_General_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Gyroscope_Calibration_Practice_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.STABILITYTRACKER,
+                response_values=None,
+                config=StabilityTrackerConfig(
+                    user_input_type=InputType.GYROSCOPE,
+                    phase=Phase.PRACTICE,
+                    trials_number=3,
+                    duration_minutes=5.0,
+                    lambda_slope=20.0,
+                ),
+                name="Gyroscope_Calibration_Practice",
+            ),
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Gyroscope_Test_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.STABILITYTRACKER,
+                response_values=None,
+                config=StabilityTrackerConfig(
+                    user_input_type=InputType.GYROSCOPE,
+                    phase=Phase.TEST,
+                    trials_number=3,
+                    duration_minutes=5.0,
+                    lambda_slope=20.0,
+                ),
+                name="Gyroscope_Test",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def actvitiy_cst_touch_create() -> ActivityCreate:
+    return ActivityCreate(
+        name="CST Touch",
+        description={Language.ENGLISH: "description"},
+        is_hidden=False,
+        report_included_item_name="",
+        key=uuid.uuid4(),
+        items=[
+            ActivityItemCreate(
+                question={"en": "description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Touch_General_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": "Description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Touch_Calibration_Practice_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.STABILITYTRACKER,
+                response_values=None,
+                config=StabilityTrackerConfig(
+                    user_input_type=InputType.TOUCH,
+                    phase=Phase.PRACTICE,
+                    trials_number=3,
+                    duration_minutes=5.0,
+                    lambda_slope=20.0,
+                ),
+                name="Touch_Calibration_Practice",
+            ),
+            ActivityItemCreate(
+                question={"en": "Description"},
+                response_type=ResponseType.MESSAGE,
+                response_values=None,
+                config=MessageConfig(remove_back_button=True, timer=None),
+                name="Touch_Test_instruction",
+            ),
+            ActivityItemCreate(
+                question={"en": ""},
+                response_type=ResponseType.STABILITYTRACKER,
+                response_values=None,
+                config=StabilityTrackerConfig(
+                    user_input_type=InputType.TOUCH,
+                    phase=Phase.TEST,
+                    trials_number=3,
+                    duration_minutes=5.0,
+                    lambda_slope=20.0,
+                ),
+                name="Touch_Test",
+            ),
+        ],
     )

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -2,15 +2,25 @@ import pytest
 
 from apps.activities.domain.response_type_config import (
     AdditionalResponseOption,
+    AudioConfig,
+    AudioPlayerConfig,
     DateConfig,
+    DefaultConfig,
     DrawingConfig,
+    GeolocationConfig,
+    MessageConfig,
     MultiSelectionConfig,
     MultiSelectionRowsConfig,
+    NumberSelectionConfig,
+    PhotoConfig,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
     SliderConfig,
     SliderRowsConfig,
     TextConfig,
+    TimeConfig,
+    TimeRangeConfig,
+    VideoConfig,
 )
 
 
@@ -20,104 +30,67 @@ def additional_response_option() -> AdditionalResponseOption:
 
 
 @pytest.fixture
-def single_select_config(
-    additional_response_option: AdditionalResponseOption,
-) -> SingleSelectionConfig:
+def default_config(additional_response_option: AdditionalResponseOption) -> DefaultConfig:
+    return DefaultConfig(
+        remove_back_button=False, skippable_item=False, additional_response_option=additional_response_option, timer=0
+    )
+
+
+@pytest.fixture
+def single_select_config(default_config: DefaultConfig) -> SingleSelectionConfig:
     return SingleSelectionConfig(
         randomize_options=False,
-        timer=0,
         add_scores=False,
         add_tokens=False,
         set_alerts=False,
         add_tooltip=False,
         set_palette=False,
-        remove_back_button=False,
-        skippable_item=False,
-        additional_response_option=additional_response_option,
+        **default_config.dict(),
     )
 
 
 @pytest.fixture
-def multi_select_config(single_select_config) -> MultiSelectionConfig:
+def multi_select_config(single_select_config: SingleSelectionConfig) -> MultiSelectionConfig:
     data = single_select_config.dict()
     return MultiSelectionConfig(**data)
 
 
 @pytest.fixture
-def slider_config(
-    additional_response_option: AdditionalResponseOption,
-) -> SliderConfig:
+def slider_config(default_config: DefaultConfig) -> SliderConfig:
     return SliderConfig(
-        timer=0,
         add_scores=False,
         set_alerts=False,
-        remove_back_button=False,
-        skippable_item=False,
         show_tick_marks=False,
         show_tick_labels=False,
         continuous_slider=False,
-        additional_response_option=additional_response_option,
+        **default_config.dict(),
     )
 
 
 @pytest.fixture
-def date_config(
-    additional_response_option: AdditionalResponseOption,
-) -> DateConfig:
-    return DateConfig(
-        remove_back_button=False,
-        skippable_item=False,
-        timer=0,
-        additional_response_option=additional_response_option,
-    )
+def date_config(default_config: DefaultConfig) -> DateConfig:
+    return DateConfig(**default_config.dict())
 
 
 @pytest.fixture
-def text_config() -> TextConfig:
-    return TextConfig(
-        remove_back_button=False,
-        skippable_item=False,
-        correct_answer_required=False,
-        numerical_response_required=False,
-        response_data_identifier=False,
-        response_required=False,
-    )
+def number_selection_config(default_config: DefaultConfig) -> NumberSelectionConfig:
+    return NumberSelectionConfig(**default_config.dict())
 
 
 @pytest.fixture
-def drawing_config(
-    additional_response_option: AdditionalResponseOption,
-) -> DrawingConfig:
-    return DrawingConfig(
-        remove_back_button=False,
-        remove_undo_button=False,
-        additional_response_option=additional_response_option,
-        skippable_item=False,
-        timer=0,
-    )
+def time_config(default_config: DefaultConfig) -> TimeConfig:
+    return TimeConfig(**default_config.dict())
 
 
 @pytest.fixture
-def slider_rows_config() -> SliderRowsConfig:
-    return SliderRowsConfig(
-        remove_back_button=False,
-        skippable_item=False,
-        add_scores=False,
-        set_alerts=False,
-        timer=0,
-    )
+def time_range_config(default_config: DefaultConfig) -> TimeRangeConfig:
+    return TimeRangeConfig(**default_config.dict())
 
 
 @pytest.fixture
-def single_select_row_config() -> SingleSelectionRowsConfig:
+def single_select_row_config(default_config: DefaultConfig) -> SingleSelectionRowsConfig:
     return SingleSelectionRowsConfig(
-        timer=0,
-        add_scores=False,
-        set_alerts=False,
-        add_tooltip=False,
-        add_tokens=None,
-        remove_back_button=False,
-        skippable_item=False,
+        add_scores=False, set_alerts=False, add_tooltip=False, add_tokens=None, **default_config.dict()
     )
 
 
@@ -126,3 +99,54 @@ def multi_select_row_config(
     single_select_row_config: SingleSelectionRowsConfig,
 ) -> MultiSelectionRowsConfig:
     return MultiSelectionRowsConfig(**single_select_row_config.dict())
+
+
+@pytest.fixture
+def slider_rows_config(default_config: DefaultConfig) -> SliderRowsConfig:
+    return SliderRowsConfig(add_scores=False, set_alerts=False, **default_config.dict())
+
+
+@pytest.fixture
+def text_config(default_config: DefaultConfig) -> TextConfig:
+    return TextConfig(
+        **default_config.dict(),
+        correct_answer_required=False,
+        numerical_response_required=False,
+        response_data_identifier=False,
+        response_required=False,
+    )
+
+
+@pytest.fixture
+def drawing_config(default_config: DefaultConfig) -> DrawingConfig:
+    return DrawingConfig(remove_undo_button=False, **default_config.dict())
+
+
+@pytest.fixture
+def photo_config(default_config: DefaultConfig) -> PhotoConfig:
+    return PhotoConfig(**default_config.dict())
+
+
+@pytest.fixture
+def video_config(default_config: DefaultConfig) -> VideoConfig:
+    return VideoConfig(**default_config.dict())
+
+
+@pytest.fixture
+def geolocation_config(default_config: DefaultConfig) -> GeolocationConfig:
+    return GeolocationConfig(**default_config.dict())
+
+
+@pytest.fixture
+def audio_config(default_config: DefaultConfig) -> AudioConfig:
+    return AudioConfig(**default_config.dict())
+
+
+@pytest.fixture
+def message_config(default_config: DefaultConfig) -> MessageConfig:
+    return MessageConfig(**default_config.dict())
+
+
+@pytest.fixture
+def audio_player_config(default_config: DefaultConfig) -> AudioPlayerConfig:
+    return AudioPlayerConfig(**default_config.dict(), play_once=False)

--- a/src/apps/activities/tests/fixtures/items.py
+++ b/src/apps/activities/tests/fixtures/items.py
@@ -2,18 +2,33 @@ import pytest
 
 from apps.activities.domain.activity_create import ActivityItemCreate
 from apps.activities.domain.response_type_config import (
+    AudioConfig,
+    AudioPlayerConfig,
+    DateConfig,
+    DrawingConfig,
+    GeolocationConfig,
+    MessageConfig,
     MultiSelectionConfig,
     MultiSelectionRowsConfig,
+    NumberSelectionConfig,
+    PhotoConfig,
     ResponseType,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
     SliderConfig,
     SliderRowsConfig,
     TextConfig,
+    TimeConfig,
+    TimeRangeConfig,
+    VideoConfig,
 )
 from apps.activities.domain.response_values import (
+    AudioPlayerValues,
+    AudioValues,
+    DrawingValues,
     MultiSelectionRowsValues,
     MultiSelectionValues,
+    NumberSelectionValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
     SliderRowsValues,
@@ -45,11 +60,11 @@ def single_select_item_create(
 def multi_select_item_create(
     base_item_data: BaseItemData,
     multi_select_config: MultiSelectionConfig,
-    multi_select_reponse_values: MultiSelectionValues,
+    multi_select_response_values: MultiSelectionValues,
 ) -> ActivityItemCreate:
     return ActivityItemCreate(
         response_type=ResponseType.MULTISELECT,
-        response_values=multi_select_reponse_values,
+        response_values=multi_select_response_values,
         config=multi_select_config,
         **base_item_data.dict(),
     )
@@ -66,6 +81,47 @@ def slider_item_create(
         response_values=slider_response_values,
         config=slider_config,
         **base_item_data.dict(),
+    )
+
+
+@pytest.fixture
+def date_item_create(date_config: DateConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.DATE,
+        config=date_config,
+    )
+
+
+@pytest.fixture
+def number_selection_item_create(
+    number_selection_config: NumberSelectionConfig,
+    number_selection_response_values: NumberSelectionValues,
+    base_item_data: BaseItemData,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.NUMBERSELECT,
+        config=number_selection_config,
+        response_values=number_selection_response_values,
+    )
+
+
+@pytest.fixture
+def time_item_create(time_config: TimeConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.TIME,
+        config=time_config,
+    )
+
+
+@pytest.fixture
+def time_range_item_create(time_range_config: TimeRangeConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.TIMERANGE,
+        config=time_range_config,
     )
 
 
@@ -117,4 +173,78 @@ def text_item_create(text_config: TextConfig, base_item_data: BaseItemData) -> A
         **base_item_data.dict(),
         response_type=ResponseType.TEXT,
         config=text_config,
+    )
+
+
+@pytest.fixture
+def drawing_item_create(
+    drawing_config: DrawingConfig, drawing_response_values: DrawingValues, base_item_data: BaseItemData
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.DRAWING,
+        config=drawing_config,
+        response_values=drawing_response_values,
+    )
+
+
+@pytest.fixture
+def photo_item_create(photo_config: PhotoConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.PHOTO,
+        config=photo_config,
+    )
+
+
+@pytest.fixture
+def video_item_create(video_config: VideoConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.VIDEO,
+        config=video_config,
+    )
+
+
+@pytest.fixture
+def geolocation_item_create(geolocation_config: GeolocationConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.GEOLOCATION,
+        config=geolocation_config,
+    )
+
+
+@pytest.fixture
+def audio_item_create(
+    audio_config: AudioConfig, audio_response_values: AudioValues, base_item_data: BaseItemData
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.AUDIO,
+        config=audio_config,
+        response_values=audio_response_values,
+    )
+
+
+@pytest.fixture
+def message_item_create(message_config: MessageConfig, base_item_data: BaseItemData) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.MESSAGE,
+        config=message_config,
+    )
+
+
+@pytest.fixture
+def audio_player_item_create(
+    audio_player_config: AudioPlayerConfig,
+    audio_player_response_values: AudioPlayerValues,
+    base_item_data: BaseItemData,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.AUDIOPLAYER,
+        config=audio_player_config,
+        response_values=audio_player_response_values,
     )

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -4,6 +4,8 @@ from typing import cast
 import pytest
 
 from apps.activities.domain.response_values import (
+    AudioPlayerValues,
+    AudioValues,
     DrawingValues,
     MultiSelectionRowsValues,
     MultiSelectionValues,
@@ -42,7 +44,7 @@ def single_select_response_values() -> SingleSelectionValues:
 
 
 @pytest.fixture
-def multi_select_reponse_values(
+def multi_select_response_values(
     single_select_response_values: SingleSelectionValues,
 ) -> MultiSelectionValues:
     data = single_select_response_values.dict()
@@ -65,7 +67,7 @@ def slider_response_values() -> SliderValues:
 
 
 @pytest.fixture
-def number_select_response_values() -> NumberSelectionValues:
+def number_selection_response_values() -> NumberSelectionValues:
     return NumberSelectionValues()
 
 
@@ -133,3 +135,14 @@ def multi_select_row_response_values(
     single_select_row_response_values: SingleSelectionRowsValues,
 ) -> MultiSelectionRowsValues:
     return MultiSelectionRowsValues(**single_select_row_response_values.dict())
+
+
+@pytest.fixture
+def audio_response_values() -> AudioValues:
+    return AudioValues(max_duration=1)
+
+
+@pytest.fixture
+def audio_player_response_values() -> AudioPlayerValues:
+    # TODO: Add some audio file
+    return AudioPlayerValues(file=None)

--- a/src/apps/activities/tests/fixtures/scores_reports.py
+++ b/src/apps/activities/tests/fixtures/scores_reports.py
@@ -9,11 +9,14 @@ from apps.activities.domain.scores_reports import (
     ScoreConditionalLogic,
     ScoresAndReports,
     Section,
+    SectionConditionalLogic,
     Subscale,
     SubscaleCalculationType,
     SubscaleItem,
     SubscaleItemType,
+    SubScaleLookupTable,
     SubscaleSetting,
+    TotalScoreTable,
 )
 
 SCORE_ID = "not_uuid_testscore"
@@ -46,6 +49,20 @@ def score() -> Score:
 
 
 @pytest.fixture
+def section_conditional_logic() -> SectionConditionalLogic:
+    return SectionConditionalLogic(
+        match=Match.ALL,
+        conditions=[
+            EqualCondition(
+                item_name=SCORE_ID,
+                payload=ValuePayload(value=1),
+                type=ConditionType.EQUAL,
+            )
+        ],
+    )
+
+
+@pytest.fixture
 def section() -> Section:
     return Section(type=ReportType.section, name="testsection")
 
@@ -67,9 +84,22 @@ def subscale_item() -> SubscaleItem:
 @pytest.fixture
 def subscale(subscale_item: SubscaleItem) -> Subscale:
     return Subscale(
-        name="test subscale name",
+        name="subscale type item",
         scoring=SubscaleCalculationType.AVERAGE,
         items=[subscale_item],
+    )
+
+
+@pytest.fixture
+def subscale_item_type_subscale(subscale: Subscale) -> SubscaleItem:
+    # Depends on subscalke because name should contain subscale item
+    return SubscaleItem(name=subscale.name, type=SubscaleItemType.SUBSCALE)
+
+
+@pytest.fixture
+def subscale_with_item_type_subscale(subscale_item_type_subscale: SubscaleItem) -> Subscale:
+    return Subscale(
+        name="subscale type subscale", items=[subscale_item_type_subscale], scoring=SubscaleCalculationType.AVERAGE
     )
 
 
@@ -79,3 +109,19 @@ def subscale_setting(subscale: Subscale) -> SubscaleSetting:
         calculate_total_score=SubscaleCalculationType.AVERAGE,
         subscales=[subscale],
     )
+
+
+@pytest.fixture
+def subscale_total_score_table() -> list[TotalScoreTable]:
+    return [
+        TotalScoreTable(raw_score="0 ~ 2", optional_text="some url"),
+        TotalScoreTable(raw_score="4 ~ 20", optional_text="some url"),
+    ]
+
+
+@pytest.fixture
+def subscale_lookup_table() -> list[SubScaleLookupTable]:
+    return [
+        SubScaleLookupTable(score="10", age=10, sex="M", raw_score="1", optional_text="some url"),
+        SubScaleLookupTable(score="20", age=10, sex="F", raw_score="2", optional_text="some url"),
+    ]

--- a/src/apps/activities/tests/unit/domain/test_activity_item_create.py
+++ b/src/apps/activities/tests/unit/domain/test_activity_item_create.py
@@ -5,13 +5,23 @@ import pytest
 
 from apps.activities import errors
 from apps.activities.domain.activity_create import ActivityItemCreate
-from apps.activities.domain.response_type_config import DrawingConfig, ResponseType, TextConfig
+from apps.activities.domain.response_type_config import (
+    DateConfig,
+    DrawingConfig,
+    ResponseType,
+    SingleSelectionConfig,
+    SliderConfig,
+    SliderRowsConfig,
+    TextConfig,
+)
 from apps.activities.domain.response_values import (
     DrawingValues,
     MultiSelectionValues,
     NumberSelectionValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
+    SliderRowsValues,
+    SliderValues,
     _MultiSelectionValue,
 )
 from apps.activities.tests.utils import BaseItemData
@@ -171,18 +181,18 @@ def test_single_select_row_response_values_not_valid_data_matrix_len_options_doe
 
 
 def test_number_selection_response_values_min_value_greater_than_max_value(
-    number_select_response_values,
+    number_selection_response_values,
 ):
-    data = number_select_response_values.dict()
+    data = number_selection_response_values.dict()
     data["min_value"], data["max_value"] = data["max_value"], data["min_value"]
     with pytest.raises(errors.MinValueError):
         NumberSelectionValues(**data)
 
 
 def test_number_selection_response_values_min_value_is_equal_max_value(
-    number_select_response_values,
+    number_selection_response_values,
 ):
-    data = number_select_response_values.dict()
+    data = number_selection_response_values.dict()
     data["min_value"], data["max_value"] = 0, 0
     with pytest.raises(errors.MinValueError):
         NumberSelectionValues(**data)
@@ -287,9 +297,9 @@ def test_activity_item_create_response_values_not_none_for_non_response_response
 
 
 def test_multi_select_response_values_multiple_none_options(  # noqa: E501
-    multi_select_reponse_values: MultiSelectionValues,
+    multi_select_response_values: MultiSelectionValues,
 ):
-    data = multi_select_reponse_values.dict()
+    data = multi_select_response_values.dict()
     data["options"].append(
         _MultiSelectionValue(
             id=str(uuid.uuid4()),
@@ -319,3 +329,206 @@ def test_multi_select_response_values_multiple_none_options(  # noqa: E501
 
     with pytest.raises(errors.MultiSelectNoneOptionError):
         MultiSelectionValues(**data)
+
+
+def test_create_item__item_name_with_not_valid_character(base_item_data: BaseItemData, date_config: DateConfig):
+    name = "%_percent_not_allowed"
+    with pytest.raises(errors.IncorrectNameCharactersError):
+        ActivityItemCreate(
+            question=base_item_data.question,
+            name=name,
+            config=date_config,
+            response_type=ResponseType.DATE,
+            response_values=None,
+        )
+
+
+@pytest.mark.parametrize("field_to_delete", ("add_scores", "set_alerts"))
+def test_create_item__not_valid_config_missing_add_scores_and_set_alerts(
+    single_select_item_create, field_to_delete
+) -> None:
+    data = single_select_item_create.dict()
+    del data["config"][field_to_delete]
+    with pytest.raises(errors.IncorrectConfigError) as exc:
+        ActivityItemCreate(**data)
+    assert exc.value.message.format(type=SingleSelectionConfig)
+
+
+@pytest.mark.parametrize("response_type", (None, "NotValid"))
+def test_create_item__not_valid_response_type(single_select_item_create, response_type) -> None:
+    data = single_select_item_create.dict()
+    data["response_type"] = response_type
+    with pytest.raises(errors.IncorrectResponseValueError) as exc:
+        ActivityItemCreate(**data)
+    assert exc.value.message.format(type=ResponseType)
+
+
+@pytest.mark.parametrize("value", (None, {}))
+def test_create_single_select_item__not_valid_response_values(single_select_item_create, value):
+    data = single_select_item_create.dict()
+    data["response_values"] = value
+    with pytest.raises(errors.IncorrectResponseValueError) as exc:
+        ActivityItemCreate(**data)
+    assert exc.value.message.format(type=SingleSelectionValues)
+
+
+def test_create_item__reponse_type_absent(single_select_item_create) -> None:
+    data = single_select_item_create.dict()
+    del data["response_type"]
+    with pytest.raises(ValueError):
+        ActivityItemCreate(**data)
+
+
+@pytest.mark.parametrize("fixture_name", ("single_select_item_create", "multi_select_item_create"))
+def test_create_single_multi_select_item__add_scores_is_true_without_scores(request, fixture_name):
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["config"]["add_scores"] = True
+    with pytest.raises(errors.ScoreRequiredForResponseValueError):
+        ActivityItemCreate(**data)
+
+
+def test_create_slider_item__add_scores_is_true_without_scores(slider_item_create):
+    data = slider_item_create.dict()
+    data["config"]["add_scores"] = True
+    with pytest.raises(errors.NullScoreError):
+        ActivityItemCreate(**data)
+
+
+def test_create_slider_item__add_scores__scores_not_for_all_values(slider_item_create):
+    data = slider_item_create.dict()
+    min_val = slider_item_create.response_values.min_value
+    max_val = slider_item_create.response_values.max_value
+    scores = [i for i in range(max_val - min_val)]
+    data["config"]["add_scores"] = True
+    data["response_values"]["scores"] = scores
+    with pytest.raises(errors.InvalidScoreLengthError):
+        ActivityItemCreate(**data)
+
+
+def test_create_slider_rows_item__add_scores_is_true__no_scores(slider_rows_item_create):
+    data = slider_rows_item_create.dict()
+    data["config"]["add_scores"] = True
+    data["response_values"]["rows"][0]["scores"] = None
+    with pytest.raises(errors.NullScoreError):
+        ActivityItemCreate(**data)
+
+
+def test_create_slider_rows_item__add_scores__scores_not_for_all_values(slider_rows_item_create):
+    data = slider_rows_item_create.dict()
+    min_val = slider_rows_item_create.response_values.rows[0].min_value
+    max_val = slider_rows_item_create.response_values.rows[0].max_value
+    scores = [i for i in range(max_val - min_val)]
+    data["config"]["add_scores"] = True
+    data["response_values"]["rows"][0]["scores"] = scores
+    with pytest.raises(errors.InvalidScoreLengthError):
+        ActivityItemCreate(**data)
+
+
+@pytest.mark.parametrize(
+    "fixture_name,field",
+    (
+        ("single_select_row_item_create", "set_alerts"),
+        ("single_select_row_item_create", "add_scores"),
+        ("multi_select_row_item_create", "set_alerts"),
+        ("multi_select_row_item_create", "add_scores"),
+    ),
+)
+def test_create_single_multi_select_row_item_no_datamatrix(request, fixture_name, field):
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["config"][field] = True
+    data["response_values"]["data_matrix"] = None
+    with pytest.raises(errors.DataMatrixRequiredError):
+        ActivityItemCreate(**data)
+
+
+def test_create_slider_rows_item_with_scores(slider_rows_item_create: ActivityItemCreate):
+    slider_rows_item_create.response_values = cast(SliderRowsValues, slider_rows_item_create.response_values)
+    slider_rows_item_create.config = cast(SliderRowsConfig, slider_rows_item_create.config)
+    min_val = slider_rows_item_create.response_values.rows[0].min_value
+    max_val = slider_rows_item_create.response_values.rows[0].max_value
+    slider_rows_item_create.response_values.rows[0].scores = [i for i in range(max_val - min_val + 1)]
+    slider_rows_item_create.config.add_scores = True
+    item = ActivityItemCreate(**slider_rows_item_create.dict())
+    item.config = cast(SliderRowsConfig, item.config)
+    item.response_values = cast(SliderRowsValues, item.response_values)
+    assert item.config.add_scores
+    assert item.response_values.rows[0].scores == slider_rows_item_create.response_values.rows[0].scores
+
+
+@pytest.mark.parametrize("fixture_name", ("single_select_row_item_create", "multi_select_row_item_create"))
+def test_create_single_multi_select_row_item_add_alerts(request, fixture_name):
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["config"]["set_alerts"] = True
+    item = ActivityItemCreate(**data)
+    assert item.config.set_alerts
+
+
+def test_slider_item_with_alert(
+    base_item_data: BaseItemData, slider_value_alert, slider_response_values, slider_config
+):
+    slider_config.set_alerts = True
+    slider_response_values.alerts = [slider_value_alert]
+    item = ActivityItemCreate(
+        **base_item_data.dict(),
+        config=slider_config,
+        response_values=slider_response_values,
+        response_type=ResponseType.SLIDER,
+    )
+    item.config = cast(SliderConfig, item.config)
+    item.response_values = cast(SliderValues, item.response_values)
+    assert item.config.set_alerts
+    assert isinstance(item.response_values.alerts, list)
+    assert len(item.response_values.alerts) == 1
+    assert item.response_values.alerts[0] == slider_value_alert
+
+
+def test_slider_item__continuous_slider_with_alert(
+    base_item_data: BaseItemData, slider_value_alert, slider_response_values, slider_config
+):
+    slider_config.set_alerts = True
+    slider_config.continuous_slider = True
+    slider_value_alert.min_value = slider_response_values.min_value
+    slider_value_alert.max_value = slider_response_values.max_value
+    slider_response_values.alerts = [slider_value_alert]
+    item = ActivityItemCreate(
+        **base_item_data.dict(),
+        config=slider_config,
+        response_values=slider_response_values,
+        response_type=ResponseType.SLIDER,
+    )
+    item.config = cast(SliderConfig, item.config)
+    item.response_values = cast(SliderValues, item.response_values)
+    assert item.config.set_alerts
+    assert isinstance(item.response_values.alerts, list)
+    assert len(item.response_values.alerts) == 1
+    assert item.response_values.alerts[0] == slider_value_alert
+
+
+def test_slider_rows_item_with_alert(
+    base_item_data: BaseItemData, slider_rows_response_values, slider_rows_config, slider_value_alert
+):
+    slider_rows_config.set_alerts = True
+    slider_rows_response_values.rows[0].alerts = [slider_value_alert]
+    item = ActivityItemCreate(
+        **base_item_data.dict(),
+        config=slider_rows_config,
+        response_values=slider_rows_response_values,
+        response_type=ResponseType.SLIDERROWS,
+    )
+    item.config = cast(SliderRowsConfig, item.config)
+    item.response_values = cast(SliderRowsValues, item.response_values)
+    assert item.config.set_alerts
+    assert isinstance(item.response_values.rows[0].alerts, list)
+    assert item.response_values.rows[0].alerts[0] == slider_value_alert
+
+
+@pytest.mark.parametrize("fixture_name", ("single_select_row_item_create", "multi_select_row_item_create"))
+def test_single_multi_select_item_withou_datamatrix(request, fixture_name: str):
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["response_values"].pop("data_matrix", None)
+    item = ActivityItemCreate(**data)
+    assert item.response_values.data_matrix is None  # type: ignore[union-attr]

--- a/src/apps/activities/tests/unit/domain/test_custom_validation.py
+++ b/src/apps/activities/tests/unit/domain/test_custom_validation.py
@@ -412,7 +412,7 @@ class TestValidateSubscales:
     ):
         items0_config: SingleSelectionConfig = items[0].config  # type: ignore[assignment]
         items0_config.add_scores = True
-        subscale_item.name = "test subscale name"
+        subscale_item.name = subscale.name
         subscale_item.type = SubscaleItemType.SUBSCALE
         subscale.items = [subscale_item]
         subscale_setting.subscales = [subscale]

--- a/src/apps/activity_flows/domain/flow_update.py
+++ b/src/apps/activity_flows/domain/flow_update.py
@@ -4,21 +4,21 @@ from gettext import gettext as _
 from pydantic import root_validator
 
 from apps.activity_flows.domain.base import FlowBase
-from apps.shared.domain import InternalModel, PublicModel
+from apps.shared.domain import PublicModel
 
 
-class ActivityFlowItemUpdate(InternalModel):
+class ActivityFlowItemUpdate(PublicModel):
     id: uuid.UUID | None
     activity_key: uuid.UUID
 
 
-class PreparedFlowItemUpdate(InternalModel):
+class PreparedFlowItemUpdate(PublicModel):
     id: uuid.UUID | None
     activity_flow_id: uuid.UUID
     activity_id: uuid.UUID
 
 
-class FlowUpdate(FlowBase, InternalModel):
+class FlowUpdate(FlowBase, PublicModel):
     id: uuid.UUID | None
     items: list[ActivityFlowItemUpdate]
 

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -46,17 +46,6 @@ def scores_and_reports(section: Section) -> ScoresAndReports:
 
 
 @pytest.fixture
-def applet_report_configuration_data(
-    user: User, tom: User, report_server_public_key: str
-) -> AppletReportConfigurationBase:
-    return AppletReportConfigurationBase(
-        report_server_ip="localhost",
-        report_public_key=report_server_public_key,
-        report_recipients=[tom.email_encrypted, user.email_encrypted],
-    )
-
-
-@pytest.fixture
 def applet_data(
     applet_minimal_data: AppletCreate,
     applet_report_configuration_data: AppletReportConfigurationBase,

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -45,6 +45,8 @@ from apps.workspaces.service.user_applet_access import UserAppletAccessService
 from infrastructure.database import atomic
 from infrastructure.database.deps import get_session
 from infrastructure.http import get_language
+from infrastructure.logger import logger
+from infrastructure.utility import FirebaseNotificationType
 
 __all__ = [
     "applet_create",
@@ -64,9 +66,6 @@ __all__ = [
     "applet_duplicate",
     "applet_retrieve_by_key",
 ]
-
-from infrastructure.logger import logger
-from infrastructure.utility import FirebaseNotificationType
 
 
 async def applet_list(

--- a/src/apps/applets/domain/applet_create_update.py
+++ b/src/apps/applets/domain/applet_create_update.py
@@ -30,11 +30,16 @@ class AppletCreate(AppletReportConfigurationBase, AppletBase, InternalModel):
         activity_names = set()
         activity_keys = set()
         flow_names = set()
+        assessments_count = 0
         for activity in activities:
             if activity.name in activity_names:
                 raise DuplicateActivityNameError()
             activity_names.add(activity.name)
             activity_keys.add(activity.key)
+            assessments_count += int(activity.is_reviewable)
+
+        if assessments_count > 1:
+            raise AssessmentLimitExceed()
 
         for flow in flows:
             if flow.name in flow_names:

--- a/src/apps/applets/tests/conftest.py
+++ b/src/apps/applets/tests/conftest.py
@@ -1,17 +1,21 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.activity_flows.domain.flow_update import ActivityFlowItemUpdate, FlowUpdate
 from apps.applets.crud.applets import AppletsCRUD
 from apps.applets.db.schemas import AppletSchema
+from apps.applets.domain.applet_create_update import AppletUpdate
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.domain.applet_link import CreateAccessLink
 from apps.applets.service.applet import AppletService
+from apps.shared.enums import Language
+from apps.users.domain import User
 from apps.workspaces.domain.constants import Role
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
 
 
 @pytest.fixture
-async def applet_one_no_encryption(session: AsyncSession, applet_one: AppletFull):
+async def applet_one_no_encryption(session: AsyncSession, applet_one: AppletFull) -> AppletFull:
     crud = AppletsCRUD(session)
     instance = await crud.update_by_id(applet_one.id, AppletSchema(encryption=None))
     assert instance.encryption is None
@@ -19,19 +23,21 @@ async def applet_one_no_encryption(session: AsyncSession, applet_one: AppletFull
 
 
 @pytest.fixture
-async def applet_one_lucy_manager(session: AsyncSession, applet_one: AppletFull, tom, lucy):
+async def applet_one_lucy_manager(session: AsyncSession, applet_one: AppletFull, tom: User, lucy: User) -> AppletFull:
     await UserAppletAccessService(session, tom.id, applet_one.id).add_role(lucy.id, Role.MANAGER)
     return applet_one
 
 
 @pytest.fixture
-async def applet_one_lucy_coordinator(session: AsyncSession, applet_one: AppletFull, tom, lucy):
+async def applet_one_lucy_coordinator(
+    session: AsyncSession, applet_one: AppletFull, tom: User, lucy: User
+) -> AppletFull:
     await UserAppletAccessService(session, tom.id, applet_one.id).add_role(lucy.id, Role.COORDINATOR)
     return applet_one
 
 
 @pytest.fixture
-async def applet_one_with_public_link(session: AsyncSession, applet_one: AppletFull, tom):
+async def applet_one_with_public_link(session: AsyncSession, applet_one: AppletFull, tom: User) -> AppletFull:
     srv = AppletService(session, tom.id)
     await srv.create_access_link(applet_one.id, CreateAccessLink(require_login=False))
     applet = await srv.get_full_applet(applet_one.id)
@@ -40,9 +46,27 @@ async def applet_one_with_public_link(session: AsyncSession, applet_one: AppletF
 
 
 @pytest.fixture
-async def applet_one_with_link(session: AsyncSession, applet_one: AppletFull, tom):
+async def applet_one_with_link(session: AsyncSession, applet_one: AppletFull, tom: User) -> AppletFull:
     srv = AppletService(session, tom.id)
     await srv.create_access_link(applet_one.id, CreateAccessLink(require_login=True))
     applet = await srv.get_full_applet(applet_one.id)
     assert applet.link is not None
+    return applet
+
+
+@pytest.fixture
+async def applet_one_with_flow(
+    session: AsyncSession, applet_one: AppletFull, applet_minimal_data: AppletFull, tom: User
+):
+    data = AppletUpdate(**applet_minimal_data.dict(exclude_unset=True))
+    flow = FlowUpdate(
+        name="flow",
+        items=[ActivityFlowItemUpdate(id=None, activity_key=data.activities[0].key)],
+        description={Language.ENGLISH: "description"},
+        id=None,
+    )
+    data.activity_flows = [flow]
+    srv = AppletService(session, tom.id)
+    await srv.update(applet_one.id, data)
+    applet = await srv.get_full_applet(applet_one.id)
     return applet

--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -11,7 +11,7 @@ from apps.activities.domain.response_values import SingleSelectionValues, _Singl
 from apps.applets.crud.applets import AppletsCRUD
 from apps.applets.domain.applet_create_update import AppletCreate
 from apps.applets.domain.applet_full import AppletFull
-from apps.applets.domain.base import Encryption
+from apps.applets.domain.base import AppletReportConfigurationBase, Encryption
 from apps.applets.service.applet import AppletService
 from apps.applets.tests import constants
 from apps.applets.tests.utils import teardown_applet
@@ -54,6 +54,17 @@ def encryption() -> Encryption:
 @pytest.fixture(scope="session")
 def report_server_public_key() -> str:
     return constants.REPORT_SERVER_PUBLIC_KEY
+
+
+@pytest.fixture
+def applet_report_configuration_data(
+    user: User, tom: User, report_server_public_key: str
+) -> AppletReportConfigurationBase:
+    return AppletReportConfigurationBase(
+        report_server_ip="localhost",
+        report_public_key=report_server_public_key,
+        report_recipients=[tom.email_encrypted, user.email_encrypted],
+    )
 
 
 @pytest.fixture

--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -11,7 +11,7 @@ from apps.activities.domain.response_values import SingleSelectionValues, _Singl
 from apps.applets.crud.applets import AppletsCRUD
 from apps.applets.domain.applet_create_update import AppletCreate
 from apps.applets.domain.applet_full import AppletFull
-from apps.applets.domain.base import AppletReportConfigurationBase, Encryption
+from apps.applets.domain.base import AppletBase, AppletReportConfigurationBase, Encryption
 from apps.applets.service.applet import AppletService
 from apps.applets.tests import constants
 from apps.applets.tests.utils import teardown_applet
@@ -56,7 +56,7 @@ def report_server_public_key() -> str:
     return constants.REPORT_SERVER_PUBLIC_KEY
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def applet_report_configuration_data(
     user: User, tom: User, report_server_public_key: str
 ) -> AppletReportConfigurationBase:
@@ -64,179 +64,6 @@ def applet_report_configuration_data(
         report_server_ip="localhost",
         report_public_key=report_server_public_key,
         report_recipients=[tom.email_encrypted, user.email_encrypted],
-    )
-
-
-@pytest.fixture
-def activity_flanker_data():
-    return dict(
-        name="Activity_flanker",
-        key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-        description=dict(
-            en="Description Activity flanker.",
-            fr="Description Activity flanker.",
-        ),
-        items=[
-            dict(
-                name="Flanker_VSR_instructionsn",
-                # Nobody knows for what we need so big description
-                question=dict(
-                    en="## General Instructions\n\n\n You will "
-                    "see arrows presented at the center of the "
-                    "screen that point either to the left ‘<’ "
-                    "or right ‘>’.\n Press the left button "
-                    "if the arrow is pointing to the left ‘<’ "
-                    "or press the right button if the arrow is "
-                    "pointing to the right ‘>’.\n These arrows "
-                    "will appear in the center of a line of "
-                    "will be arrows pointing in the same "
-                    "direction, e.g.. ‘> > > > >’, or in the "
-                    "opposite direction, e.g. ‘< < > < <’.\n "
-                    "Your job is to respond to the central "
-                    "arrow, no matter what direction the other "
-                    "arrows are pointing.\n For example, you "
-                    "would press the left button for both "
-                    "‘< < < < <’, and ‘> > < > >’ because the "
-                    "middle arrow points to the left.\n "
-                    "Finally, in some trials dashes ‘ - ’ "
-                    "will appear beside the central arrow.\n "
-                    "Again, respond only to the direction "
-                    "of the central arrow. Please respond "
-                    "as quickly and accurately as possible.",
-                    fr="Flanker General instruction text.",
-                ),
-                response_type="message",
-                response_values=None,
-                config=dict(
-                    remove_back_button=False,
-                    timer=None,
-                ),
-            ),
-            dict(
-                name="Flanker_Practice_instructions_1",
-                question=dict(
-                    en="## Instructions\n\nNow you will have a "
-                    "chance to practice the task before moving "
-                    "on to the test phase.\nRemember to "
-                    "respond only to the central arrow\n",
-                    fr="Flanker Сalibration/Practice " "instruction 1 text.",
-                ),
-                response_type="message",
-                response_values=None,
-                config=dict(
-                    remove_back_button=False,
-                    timer=None,
-                ),
-            ),
-            dict(
-                name="Flanker_Practise_1",
-                question=dict(
-                    en="Flanker_Practise_1",
-                    fr="Flanker_Practise_1",
-                ),
-                response_type=ResponseType.FLANKER,
-                response_values=None,
-                config=dict(
-                    stimulusTrials=[
-                        {
-                            "id": "1",
-                            "image": "https://600.jpg",
-                            "text": "left-con",
-                            "value": 0,
-                            "weight": 10,
-                        },
-                        {
-                            "id": "2",
-                            "image": "https://600.jpg",
-                            "text": "right-inc",
-                            "value": 1,
-                            "weight": 10,
-                        },
-                        {
-                            "id": "3",
-                            "image": "https://600.jpg",
-                            "text": "left-inc",
-                            "value": 0,
-                            "weight": 10,
-                        },
-                        {
-                            "id": "4",
-                            "image": "https://600.jpg",
-                            "text": "right-con",
-                            "value": 1,
-                            "weight": 10,
-                        },
-                        {
-                            "id": "5",
-                            "image": "https://600.jpg",
-                            "text": "left-neut",
-                            "value": 0,
-                            "weight": 10,
-                        },
-                        {
-                            "id": "6",
-                            "image": "https://600.jpg",
-                            "text": "right-neut",
-                            "value": 1,
-                            "weight": 10,
-                        },
-                    ],
-                    blocks=[
-                        {
-                            "name": "Block 1",
-                            "order": [
-                                "left-con",
-                                "right-con",
-                                "left-inc",
-                                "right-inc",
-                                "left-neut",
-                                "right-neut",
-                            ],
-                        },
-                        {
-                            "name": "Block 2",
-                            "order": [
-                                "left-con",
-                                "right-con",
-                                "left-inc",
-                                "right-inc",
-                                "left-neut",
-                                "right-neut",
-                            ],
-                        },
-                    ],
-                    buttons=[
-                        {
-                            "text": "Button_1_name_<",
-                            "image": "https://1.jpg",
-                            "value": 0,
-                        },
-                        {
-                            "text": "Button_2_name_>",
-                            "image": "https://2.jpg",
-                            "value": 1,
-                        },
-                    ],
-                    nextButton="OK",
-                    fixationDuration=500,
-                    fixationScreen={
-                        "value": "FixationScreen_value",
-                        "image": "https://fixation-screen.jpg",
-                    },
-                    minimumAccuracy=75,
-                    sampleSize=1,
-                    samplingMethod="randomize-order",
-                    showFeedback=True,
-                    showFixation=True,
-                    showResults=False,
-                    trialDuration=3000,
-                    isLastPractice=False,
-                    isFirstPractice=True,
-                    isLastTest=False,
-                    blockType="practice",
-                ),
-            ),
-        ],
     )
 
 
@@ -295,12 +122,9 @@ def activity_create_session(item_create: ActivityItemCreate) -> ActivityCreate:
 
 
 @pytest.fixture(scope="session")
-def applet_minimal_data(encryption: Encryption, activity_create_session: ActivityCreate) -> AppletCreate:
-    return AppletCreate(
-        display_name="Minimal Data",
-        encryption=encryption,
-        activities=[activity_create_session],
-        activity_flows=[],
+def applet_base_data(encryption: Encryption) -> AppletBase:
+    return AppletBase(
+        display_name="Base Data",
         link=None,
         require_login=False,
         pinned_at=None,
@@ -309,7 +133,14 @@ def applet_minimal_data(encryption: Encryption, activity_create_session: Activit
         stream_enabled=False,
         stream_ip_address=None,
         stream_port=None,
+        encryption=encryption,
     )
+
+
+@pytest.fixture(scope="session")
+def applet_minimal_data(applet_base_data: AppletBase, activity_create_session: ActivityCreate) -> AppletCreate:
+    # TODO: possible need to add activity_flows
+    return AppletCreate(**applet_base_data.dict(), activities=[activity_create_session], activity_flows=[])
 
 
 @pytest.fixture(scope="session")

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -1,12 +1,64 @@
 import copy
+import http
 import uuid
+from typing import cast
 
 import pytest
+from pydantic.color import Color
+from pytest import FixtureRequest
 
 from apps.activities import errors as activity_errors
-from apps.activities.domain.response_type_config import ResponseType, SingleSelectionConfig
-from apps.activities.domain.response_values import SingleSelectionValues
-from apps.applets.domain.applet_create_update import AppletUpdate
+from apps.activities.domain.activity_create import ActivityCreate, ActivityItemCreate
+from apps.activities.domain.conditional_logic import ConditionalLogic, Match
+from apps.activities.domain.conditions import EqualToOptionCondition, OptionPayload, SingleSelectConditionType
+from apps.activities.domain.response_type_config import PerformanceTaskType, ResponseType, SingleSelectionConfig
+from apps.activities.domain.response_values import SingleSelectionValues, SliderValues
+from apps.activities.domain.scores_reports import (
+    ScoreConditionalLogic,
+    ScoresAndReports,
+    SectionConditionalLogic,
+    Subscale,
+    SubScaleLookupTable,
+    SubscaleSetting,
+    TotalScoreTable,
+)
+from apps.applets.domain.applet_create_update import AppletCreate, AppletUpdate
+from apps.applets.domain.applet_full import AppletFull
+from apps.shared.test.client import TestClient
+from apps.users.domain import User
+
+
+@pytest.fixture
+def activity_create_with_conditional_logic(
+    activity_create_session: ActivityCreate,
+    single_select_item_create: ActivityItemCreate,
+) -> ActivityCreate:
+    activity = activity_create_session.copy(deep=True)
+    single_select_item_create.response_values = cast(SingleSelectionValues, single_select_item_create.response_values)
+    single_select_with_cond = single_select_item_create.copy(deep=True)
+    single_select_with_cond.name = single_select_item_create.name + "_with_conditional_logic"
+    single_select_with_cond.conditional_logic = ConditionalLogic(
+        match=Match.ALL,
+        conditions=[
+            EqualToOptionCondition(
+                item_name=single_select_item_create.name,
+                type=SingleSelectConditionType.EQUAL_TO_OPTION,
+                payload=OptionPayload(option_value=str(single_select_item_create.response_values.options[0].value)),
+            ),
+        ],
+    )
+    activity.items = [single_select_item_create, single_select_with_cond]
+    return activity
+
+
+@pytest.fixture
+def single_select_item_create_with_score(single_select_item_create: ActivityItemCreate) -> ActivityItemCreate:
+    item_create = single_select_item_create.copy(deep=True)
+    item_create.config = cast(SingleSelectionConfig, item_create.config)
+    item_create.response_values = cast(SingleSelectionValues, item_create.response_values)
+    item_create.response_values.options[0].score = 1
+    item_create.config.add_scores = True
+    return item_create
 
 
 class TestActivityItems:
@@ -17,2258 +69,196 @@ class TestActivityItems:
     activity_detail_url = "activities/{activity_id}"
     applet_workspace_detail_url = "workspaces/{owner_id}/applets/{pk}"
 
-    async def test_creating_applet_with_activity_items(self, client, tom):
+    @pytest.mark.parametrize(
+        "item_fixture",
+        (
+            "single_select_item_create",
+            "multi_select_item_create",
+            "slider_item_create",
+            "date_item_create",
+            "number_selection_item_create",
+            "time_item_create",
+            "time_range_item_create",
+            "single_select_row_item_create",
+            "multi_select_row_item_create",
+            "slider_rows_item_create",
+            "text_item_create",
+            "drawing_item_create",
+            "photo_item_create",
+            "video_item_create",
+            "geolocation_item_create",
+            "audio_item_create",
+            "message_item_create",
+            "audio_player_item_create",
+        ),
+    )
+    async def test_create_applet_with_each_activity_item(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        item_fixture: str,
+        request: FixtureRequest,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="User daily behave",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            about=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            activities=[
-                dict(
-                    name="Morning activity",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Understand morning feelings.",
-                        fr="Understand morning feelings.",
-                    ),
-                    items=[
-                        dict(
-                            name="activity_item_text",
-                            question=dict(
-                                en="How had you slept?",
-                                fr="How had you slept?",
-                            ),
-                            response_type="text",
-                            response_values=None,
-                            config=dict(
-                                max_response_length=200,
-                                correct_answer_required=False,
-                                correct_answer=None,
-                                numerical_response_required=False,
-                                response_data_identifier=False,
-                                response_required=False,
-                                remove_back_button=False,
-                                skippable_item=True,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_message",
-                            question={"en": "What is your name?"},
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_number_selection",
-                            question={"en": "What is your name?"},
-                            response_type="numberSelect",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                            ),
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_time_range",
-                            question={"en": "What is your name?"},
-                            response_type="timeRange",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_time_range_2",
-                            question={"en": "What is your name?"},
-                            response_type="time",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_geolocation",
-                            question={"en": "What is your name?"},
-                            response_type="geolocation",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_photo",
-                            question={"en": "What is your name?"},
-                            response_type="photo",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_video",
-                            question={"en": "What is your name?"},
-                            response_type="video",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_date",
-                            question={"en": "What is your name?"},
-                            response_type="date",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_drawing",
-                            question={"en": "What is your name?"},
-                            response_type="drawing",
-                            response_values=dict(
-                                drawing_background="https://www.w3schools.com/css/img_5terre_wide.jpg",  # noqa E501
-                                drawing_example="https://www.w3schools.com/css/img_5terre_wide.jpg",  # noqa E501
-                            ),
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                                remove_undo_button=False,
-                                navigation_to_top=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_audio",
-                            question={"en": "What is your name?"},
-                            response_type="audio",
-                            response_values=dict(max_duration=200),
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_audioplayer",
-                            question={"en": "What is your name?"},
-                            response_type="audioPlayer",
-                            response_values=dict(
-                                file="https://www.w3schools.com/html/horse.mp3",  # noqa E501
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                play_once=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_sliderrows",
-                            question={"en": "What is your name?"},
-                            response_type="sliderRows",
-                            response_values=dict(
-                                rows=[
-                                    {
-                                        "label": "label1",
-                                        "min_label": "min_label1",
-                                        "max_label": "max_label1",
-                                        "min_value": 0,
-                                        "max_value": 10,
-                                        "min_image": None,
-                                        "max_image": None,
-                                        "score": None,
-                                        "alerts": [
-                                            dict(
-                                                min_value=1,
-                                                max_value=4,
-                                                alert="alert1",
-                                            ),
-                                        ],
-                                    }
-                                ]
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_multiselectionrows",
-                            question={"en": "What is your name?"},
-                            response_type="multiSelectRows",
-                            response_values=dict(
-                                rows=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "row_name": "row1",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "row_name": "row2",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                options=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "text": "option1",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                        "text": "option2",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                data_matrix=[
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 1,
-                                                "alert": None,
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 2,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 3,
-                                                "alert": None,
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 4,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_singleselectionrows",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelectRows",
-                            response_values=dict(
-                                rows=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "row_name": "row1",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "row_name": "row2",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                options=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "text": "option1",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                        "text": "option2",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                data_matrix=[
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 1,
-                                                "alert": "alert1",
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 2,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 3,
-                                                "alert": None,
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 4,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                add_tooltip=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_singleselect",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "value": 1,
-                                        "alert": "alert1",
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "value": 2,
-                                        "alert": "alert2",
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_multiselect",
-                            question={"en": "What is your name?"},
-                            response_type="multiSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {"text": "option1", "value": 0},
-                                    {"text": "option2", "value": 1},
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_slideritem",
-                            question={"en": "What is your name?"},
-                            response_type="slider",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                                min_label="min_label",
-                                max_label="max_label",
-                                min_image=None,
-                                max_image=None,
-                                scores=None,
-                                alerts=[
-                                    dict(
-                                        min_value=1,
-                                        max_value=4,
-                                        alert="alert1",
-                                    ),
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                show_tick_labels=False,
-                                show_tick_marks=False,
-                                continuous_slider=True,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_slideritem_another",
-                            question={"en": "What is your name?"},
-                            response_type="slider",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                                min_label="min_label",
-                                max_label="max_label",
-                                min_image=None,
-                                max_image=None,
-                                scores=None,
-                                alerts=[
-                                    dict(
-                                        value="1",
-                                        alert="alert1",
-                                    ),
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                show_tick_labels=False,
-                                show_tick_marks=False,
-                                continuous_slider=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="Morning questionnaire",
-                    description=dict(
-                        en="Understand how was the morning",
-                        fr="Understand how was the morning",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
+        item_create = request.getfixturevalue(item_fixture)
+        data = applet_minimal_data.copy(deep=True)
+        data.activities[0].items = [item_create]
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        resp = await client.get(
+            self.applet_workspace_detail_url.format(owner_id=tom.id, pk=resp.json()["result"]["id"])
         )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
+        assert resp.status_code == http.HTTPStatus.OK
+        result = resp.json()["result"]
+        items = result["activities"][0]["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["responseType"] == item_create.response_type
+        assert item["name"] == item_create.name
+        assert item["question"] == item_create.question
+        assert item["isHidden"] == item_create.is_hidden
+        assert not item["allowEdit"]
+        if item_create.response_type in ResponseType.get_non_response_types():
+            assert item["responseValues"] is None
+        else:
+            assert item["responseValues"] == item_create.response_values.dict(by_alias=True)
 
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-
-    async def test_creating_applet_with_ab_trails_mobile_activity_items(self, client, tom):
+    @pytest.mark.parametrize(
+        "fixture_name, performance_task_type",
+        (
+            ("activity_ab_trails_ipad_create", PerformanceTaskType.ABTRAILS),
+            ("activity_ab_trails_mobile_create", PerformanceTaskType.ABTRAILS),
+            ("activity_flanker_create", PerformanceTaskType.FLANKER),
+            ("actvitiy_cst_gyroscope_create", PerformanceTaskType.GYROSCOPE),
+            ("actvitiy_cst_touch_create", PerformanceTaskType.TOUCH),
+        ),
+    )
+    async def test_create_applet_with_performance_task(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        request: FixtureRequest,
+        fixture_name: str,
+        performance_task_type: PerformanceTaskType,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="mobile_activity_applet",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Performance Tasks AB Trails Mobile Applet",
-                fr="Performance Tasks AB Trails Mobile Applet",
-            ),
-            about=dict(
-                en="Applet AB Trails Mobile Task Builder Activity",
-                fr="Applet AB Trails Mobile Task Builder Activity",
-            ),
-            activities=[
-                dict(
-                    name="Activity_ABTrailsMobile",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Description Activity ABTrailsMobile.",
-                        fr="Description Activity ABTrailsMobile.",
-                    ),
-                    items=[
-                        dict(
-                            name="AB_Trails_Mobile_1",
-                            question=dict(
-                                en="ab_trails_mobile 1 question",
-                                fr="ab_trails_mobile 1 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="mobile",
-                                order_name="first",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Mobile_2",
-                            question=dict(
-                                en="ab_trails_mobile 2 question",
-                                fr="ab_trails_mobile 2 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="mobile",
-                                order_name="second",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Mobile_3",
-                            question=dict(
-                                en="ab_trails_mobile 3 question",
-                                fr="ab_trails_mobile 3 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="mobile",
-                                order_name="third",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Mobile_4",
-                            question=dict(
-                                en="ab_trails_mobile 4 question",
-                                fr="ab_trails_mobile 4 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="mobile",
-                                order_name="fourth",
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="name_activityFlow",
-                    description=dict(
-                        en="description activityFlow",
-                        fr="description activityFlow",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
+        data = applet_minimal_data.copy(deep=True)
+        activity = request.getfixturevalue(fixture_name)
+        data.activities = [activity]
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        activities = resp.json()["result"]["activities"]
+        assert len(activities) == 1
+        assert activities[0]["isPerformanceTask"]
+        assert activities[0]["performanceTaskType"] == performance_task_type
+        # Check that the 'get' after creating new applet returns correct performance task type
+        resp = await client.get(
+            self.applet_workspace_detail_url.format(
+                owner_id=tom.id,
+                pk=resp.json()["result"]["id"],
+            )
         )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
+        assert resp.status_code == http.HTTPStatus.OK
+        assert resp.json()["result"]["activities"][0]["isPerformanceTask"]
+        assert resp.json()["result"]["activities"][0]["performanceTaskType"] == performance_task_type
 
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-
-    async def test_creating_applet_with_ab_trails_tablet_activity_items(self, client, tom):
+    async def test_creating_applet_with_activity_items_condition(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        activity_create_with_conditional_logic: ActivityCreate,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="tablet_activity_applet",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Performance Tasks AB Trails Tablet Applet",
-                fr="Performance Tasks AB Trails Tablet Applet",
-            ),
-            about=dict(
-                en="Applet AB Trails Tablet Task Builder Activity",
-                fr="Applet AB Trails Tablet Task Builder Activity",
-            ),
-            activities=[
-                dict(
-                    name="Activity_ABTrailsTablet",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Description Activity ABTrailsTablet.",
-                        fr="Description Activity ABTrailsTablet.",
-                    ),
-                    items=[
-                        dict(
-                            name="AB_Trails_Tablet_1",
-                            question=dict(
-                                en="ab_trails_tablet 1 question",
-                                fr="ab_trails_tablet 1 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="tablet",
-                                order_name="first",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Tablet_2",
-                            question=dict(
-                                en="ab_trails_tablet 2 question",
-                                fr="ab_trails_tablet 2 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="tablet",
-                                order_name="second",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Tablet_3",
-                            question=dict(
-                                en="ab_trails_tablet 3 question",
-                                fr="ab_trails_tablet 3 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="tablet",
-                                order_name="third",
-                            ),
-                        ),
-                        dict(
-                            name="AB_Trails_Tablet_4",
-                            question=dict(
-                                en="ab_trails_tablet 4 question",
-                                fr="ab_trails_tablet 4 question",
-                            ),
-                            response_type="ABTrails",
-                            response_values=None,
-                            config=dict(
-                                device_type="tablet",
-                                order_name="fourth",
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="name_activityFlow",
-                    description=dict(
-                        en="description activityFlow",
-                        fr="description activityFlow",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
-        )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
-
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-
-    async def test_creating_applet_with_gyroscope_activity_items(self, client, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="gyroscope_activity_applet",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Performance Tasks CST Gyroscope Applet",
-                fr="Performance Tasks CST Gyroscope Applet",
-            ),
-            about=dict(
-                en="Applet CST Gyroscope Task Builder Activity",
-                fr="Applet CST Gyroscope Task Builder Activity",
-            ),
-            activities=[
-                dict(
-                    name="Activity_gyroscope",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Description Activity gyroscope.",
-                        fr="Description Activity gyroscope.",
-                    ),
-                    items=[
-                        dict(
-                            name="Gyroscope_General_instruction",
-                            question=dict(
-                                en="Gyroscope General instruction text.",
-                                fr="Gyroscope General instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Gyroscope_Сalibration_Practice_instruction",
-                            question=dict(
-                                en="Gyroscope Сalibration/Practice " "instruction text.",
-                                fr="Gyroscope Сalibration/Practice " "instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Gyroscope_Сalibration_Practice",
-                            question=dict(
-                                en="Gyroscope Сalibration/Practice.",
-                                fr="Gyroscope Сalibration/Practice.",
-                            ),
-                            response_type="stabilityTracker",
-                            response_values=None,
-                            config=dict(
-                                user_input_type="gyroscope",
-                                phase="practice",
-                                trials_number=3,
-                                duration_minutes=5,
-                                lambda_slope=0.2,
-                                max_off_target_time=10,
-                                num_test_trials=10,
-                                task_mode="pseudo_stair",
-                                tracking_dims=2,
-                                show_score=True,
-                                basis_func="zeros_1d",
-                                noise_level=0,
-                                task_loop_rate=0.0167,
-                                cycles_per_min=2,
-                                oob_duration=0.2,
-                                initial_lambda=0.075,
-                                show_preview=True,
-                                num_preview_stim=0,
-                                preview_step_gap=100,
-                                dimension_count=1,
-                                max_rad=0.26167,
-                            ),
-                        ),
-                        dict(
-                            name="Gyroscope_Test_instruction",
-                            question=dict(
-                                en="Gyroscope Test instruction text.",
-                                fr="Gyroscope Test instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Gyroscope_Test",
-                            question=dict(
-                                en="Gyroscope Test.",
-                                fr="Gyroscope Test.",
-                            ),
-                            response_type="stabilityTracker",
-                            response_values=None,
-                            config=dict(
-                                user_input_type="gyroscope",
-                                phase="test",
-                                trials_number=5,
-                                duration_minutes=7,
-                                lambda_slope=0.2,
-                                max_off_target_time=10,
-                                num_test_trials=10,
-                                task_mode="pseudo_stair",
-                                tracking_dims=2,
-                                show_score=True,
-                                basis_func="zeros_1d",
-                                noise_level=0,
-                                task_loop_rate=0.0167,
-                                cycles_per_min=2,
-                                oob_duration=0.2,
-                                initial_lambda=0.075,
-                                show_preview=True,
-                                num_preview_stim=0,
-                                preview_step_gap=100,
-                                dimension_count=1,
-                                max_rad=0.26167,
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="name_activityFlow",
-                    description=dict(
-                        en="description activityFlow",
-                        fr="description activityFlow",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
-        )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
-
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-
-    async def test_creating_applet_with_touch_activity_items(self, client, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="touch_activity_applet",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Performance Tasks CST Touch Applet",
-                fr="Performance Tasks CST Touch Applet",
-            ),
-            about=dict(
-                en="Applet CST Touch Task Builder Activity",
-                fr="Applet CST Touch Task Builder Activity",
-            ),
-            activities=[
-                dict(
-                    name="Activity_touch",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Description Activity touch.",
-                        fr="Description Activity touch.",
-                    ),
-                    items=[
-                        dict(
-                            name="Touch_General_instruction",
-                            question=dict(
-                                en="Touch General instruction text.",
-                                fr="Touch General instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Touch_Сalibration_Practice_instruction",
-                            question=dict(
-                                en="Touch Сalibration/Practice " "instruction text.",
-                                fr="Touch Сalibration/Practice " "instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Touch_Сalibration_Practice",
-                            question=dict(
-                                en="Touch Сalibration/Practise.",
-                                fr="Touch Сalibration/Practise.",
-                            ),
-                            response_type="stabilityTracker",
-                            response_values=None,
-                            config=dict(
-                                user_input_type="touch",
-                                phase="practice",
-                                trials_number=3,
-                                duration_minutes=5,
-                                lambda_slope=0.2,
-                                max_off_target_time=10,
-                                num_test_trials=10,
-                                task_mode="pseudo_stair",
-                                tracking_dims=2,
-                                show_score=True,
-                                basis_func="zeros_1d",
-                                noise_level=0,
-                                task_loop_rate=0.0167,
-                                cycles_per_min=2,
-                                oob_duration=0.2,
-                                initial_lambda=0.075,
-                                show_preview=True,
-                                num_preview_stim=0,
-                                preview_step_gap=100,
-                                dimension_count=1,
-                                max_rad=0.26167,
-                            ),
-                        ),
-                        dict(
-                            name="Touch_Test_instruction",
-                            question=dict(
-                                en="Touch Test instruction text.",
-                                fr="Touch Test instruction text.",
-                            ),
-                            response_type="message",
-                            response_values=None,
-                            config=dict(
-                                remove_back_button=False,
-                                timer=None,
-                            ),
-                        ),
-                        dict(
-                            name="Touch_Test",
-                            question=dict(
-                                en="Touch Test.",
-                                fr="Touch Test.",
-                            ),
-                            response_type="stabilityTracker",
-                            response_values=None,
-                            config=dict(
-                                user_input_type="touch",
-                                phase="test",
-                                trials_number=5,
-                                duration_minutes=7,
-                                lambda_slope=0.2,
-                                max_off_target_time=10,
-                                num_test_trials=10,
-                                task_mode="pseudo_stair",
-                                tracking_dims=2,
-                                show_score=True,
-                                basis_func="zeros_1d",
-                                noise_level=0,
-                                task_loop_rate=0.0167,
-                                cycles_per_min=2,
-                                oob_duration=0.2,
-                                initial_lambda=0.075,
-                                show_preview=True,
-                                num_preview_stim=0,
-                                preview_step_gap=100,
-                                dimension_count=1,
-                                max_rad=0.26167,
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="name_activityFlow",
-                    description=dict(
-                        en="description activityFlow",
-                        fr="description activityFlow",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
-        )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
-
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-
-    async def test_creating_applet_with_activity_items_condition(self, client, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="User daily behave",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            about=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            activities=[
-                # Activity with conditional logic
-                dict(
-                    name="Morning activity with conditional logic",
-                    key="577dbbdd-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Understand morning feelings.",
-                        fr="Understand morning feelings.",
-                    ),
-                    subscale_setting=dict(
-                        calculate_total_score="sum",
-                        total_scores_table_data=[
-                            dict(
-                                raw_score="1",
-                                optional_text="optional_text",
-                            ),
-                            dict(
-                                raw_score="2",
-                                optional_text="optional_text2",
-                            ),
-                        ],
-                        subscales=[
-                            dict(
-                                name="subscale1",
-                                scoring="sum",
-                                items=[
-                                    dict(
-                                        name="activity_item_singleselect",
-                                        type="item",
-                                    ),
-                                ],
-                                subscale_table_data=[
-                                    dict(
-                                        score="1.2342~1231",
-                                        raw_score="1",
-                                        age=15,
-                                        sex="F",
-                                        optional_text="optional_text",
-                                    ),
-                                    dict(
-                                        score="1.2342~1231.12333",
-                                        raw_score="1~6",
-                                        age=10,
-                                        sex="M",
-                                        optional_text="optional_text12",
-                                    ),
-                                    dict(
-                                        score=1,
-                                        raw_score=1,
-                                        age=15,
-                                        sex="M",
-                                        optional_text="optional_text13",
-                                    ),
-                                ],
-                            ),
-                            dict(
-                                name="subscale12",
-                                scoring="sum",
-                                items=[
-                                    dict(
-                                        name="activity_item_singleselect",
-                                        type="item",
-                                    ),
-                                    dict(
-                                        name="subscale1",
-                                        type="subscale",
-                                    ),
-                                ],
-                                subscale_table_data=[
-                                    dict(
-                                        score="1.2342~1231",
-                                        raw_score="1",
-                                        age=15,
-                                        sex="F",
-                                        optional_text="optional_text",
-                                    ),
-                                    dict(
-                                        score="1.2342~1231.12333",
-                                        raw_score="1~6",
-                                        age=10,
-                                        sex="M",
-                                        optional_text="optional_text12",
-                                    ),
-                                    dict(
-                                        score=1,
-                                        raw_score=1,
-                                        age=15,
-                                        sex="M",
-                                        optional_text="optional_text13",
-                                    ),
-                                ],
-                            ),
-                        ],
-                    ),
-                    scores_and_reports=dict(
-                        generateReport=True,
-                        showScoreSummary=True,
-                        reports=[
-                            dict(
-                                name="activity_item_singleselect_score",
-                                type="score",
-                                id="activity_item_singleselect_score",
-                                calculationType="sum",
-                                minScore=0,
-                                maxScore=3,
-                                itemsScore=["activity_item_singleselect"],
-                                message="Hello",
-                                itemsPrint=[
-                                    "activity_item_singleselect",
-                                    "activity_item_multiselect",
-                                    "activity_item_slideritem",
-                                    "activity_item_text",
-                                ],
-                                conditionalLogic=[
-                                    dict(
-                                        name="score1_condition1",
-                                        id="activity_item_singleselect_score",
-                                        flagScore=True,
-                                        message="Hello2",
-                                        match="any",
-                                        conditions=[
-                                            dict(
-                                                item_name=("activity_item_" "singleselect_score"),
-                                                type="GREATER_THAN",
-                                                payload=dict(
-                                                    value=1,
-                                                ),
-                                            ),
-                                            dict(
-                                                item_name=("activity_item_" "singleselect_score"),
-                                                type="GREATER_THAN",
-                                                payload=dict(
-                                                    value=1,
-                                                ),
-                                            ),
-                                        ],
-                                    ),
-                                ],
-                            ),
-                            dict(
-                                name="section1",
-                                type="section",
-                                messages="Hello from the other side",
-                                itemsPrint=[
-                                    "activity_item_singleselect",
-                                    "activity_item_multiselect",
-                                    "activity_item_slideritem",
-                                    "activity_item_text",
-                                ],
-                                conditionalLogic=dict(
-                                    match="all",
-                                    conditions=[
-                                        dict(
-                                            item_name=(
-                                                "activity_item_singleselect_score"  # noqa E501
-                                            ),
-                                            type="GREATER_THAN",
-                                            payload=dict(
-                                                value=1,
-                                            ),
-                                        ),
-                                        dict(
-                                            item_name=(
-                                                "activity_item_singleselect_score"  # noqa E501
-                                            ),
-                                            type="EQUAL_TO_OPTION",
-                                            payload=dict(
-                                                option_value="1",  # noqa E501
-                                            ),
-                                        ),
-                                        dict(
-                                            item_name=(
-                                                "activity_item_singleselect_score"  # noqa E501
-                                            ),
-                                            type="NOT_EQUAL_TO_OPTION",
-                                            payload=dict(
-                                                option_value="2",  # noqa E501
-                                            ),
-                                        ),
-                                        dict(
-                                            item_name=(
-                                                "activity_item_multiselect"  # noqa E501
-                                            ),
-                                            type="NOT_INCLUDES_OPTION",
-                                            payload=dict(
-                                                option_value="1",  # noqa E501
-                                            ),
-                                        ),
-                                    ],
-                                ),
-                            ),
-                        ],
-                    ),
-                    items=[
-                        dict(
-                            name="activity_item_singleselect",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "score": 1,
-                                        "id": "25e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "value": "1",
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "score": 2,
-                                        "id": "26e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "value": "2",
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=True,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_text",
-                            question=dict(
-                                en="How had you slept?",
-                                fr="How had you slept?",
-                            ),
-                            response_type="text",
-                            response_values=None,
-                            config=dict(
-                                max_response_length=200,
-                                correct_answer_required=False,
-                                correct_answer=None,
-                                numerical_response_required=False,
-                                response_data_identifier=False,
-                                response_required=False,
-                                remove_back_button=False,
-                                skippable_item=True,
-                            ),
-                            conditional_logic=dict(
-                                match="any",
-                                conditions=[
-                                    dict(
-                                        item_name="activity_item_singleselect",
-                                        type="EQUAL_TO_OPTION",
-                                        payload=dict(
-                                            option_value="1"  # noqa E501
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_singleselect_2",
-                                        type="NOT_EQUAL_TO_OPTION",
-                                        payload=dict(
-                                            option_value="2"  # noqa E501
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_multiselect",
-                                        type="INCLUDES_OPTION",
-                                        payload=dict(
-                                            option_value="1"  # noqa E501
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_multiselect_2",
-                                        type="NOT_INCLUDES_OPTION",
-                                        payload=dict(
-                                            option_value="2"  # noqa E501
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_slideritem",
-                                        type="GREATER_THAN",
-                                        payload=dict(
-                                            value=5,
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_slideritem_2",
-                                        type="OUTSIDE_OF",
-                                        payload=dict(
-                                            min_value=5,
-                                            max_value=10,
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_singleselect_2",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "score": 1,
-                                        "id": "25e69155-22cd-4484-8a49-364779fa9de1",  # noqa E501
-                                        "value": "1",
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "score": 2,
-                                        "id": "26e69155-22cd-4484-8a49-364779fa9de1",  # noqa E501
-                                        "value": "2",
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=True,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_multiselect",
-                            question={"en": "What is your name?"},
-                            response_type="multiSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "id": "27e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "value": "1",
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "id": "28e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "value": "2",
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_multiselect_2",
-                            question={"en": "Option 2?"},
-                            response_type="multiSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "id": "27e69155-22cd-4484-8a49-364779eb9de1",  # noqa E501
-                                        "value": "1",
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "id": "28e69155-22cd-4484-8a49-364779eb9de1",  # noqa E501
-                                        "value": "2",
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_slideritem",
-                            question={"en": "What is your name?"},
-                            response_type="slider",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                                min_label="min_label",
-                                max_label="max_label",
-                                min_image=None,
-                                max_image=None,
-                                scores=None,
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                show_tick_labels=False,
-                                show_tick_marks=False,
-                                continuous_slider=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_slideritem_2",
-                            question={"en": "What is your name?"},
-                            response_type="slider",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                                min_label="min_label",
-                                max_label="max_label",
-                                min_image=None,
-                                max_image=None,
-                                scores=None,
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=False,
-                                timer=1,
-                                show_tick_labels=False,
-                                show_tick_marks=False,
-                                continuous_slider=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_time_range",
-                            question={"en": "What is your name?"},
-                            response_type="timeRange",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                            conditional_logic=dict(
-                                match="all",
-                                conditions=[
-                                    dict(
-                                        item_name="activity_item_singleselect",
-                                        type="EQUAL_TO_OPTION",
-                                        payload=dict(
-                                            option_value="1"  # noqa E501
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_time_range_2",
-                            question={"en": "What is your name?"},
-                            response_type="time",
-                            response_values=None,
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                            conditional_logic=dict(
-                                match="all",
-                                conditions=[
-                                    dict(
-                                        item_name="activity_item_singleselect",
-                                        type="EQUAL_TO_OPTION",
-                                        payload=dict(
-                                            option_value="1"  # noqa E501
-                                        ),
-                                    ),
-                                    dict(
-                                        item_name="activity_item_multiselect",
-                                        type="INCLUDES_OPTION",
-                                        payload=dict(
-                                            option_value="1"  # noqa E501
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_audio",
-                            question={"en": "What is your name?"},
-                            response_type="audio",
-                            response_values=dict(max_duration=200),
-                            config=dict(
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                                remove_back_button=False,
-                                skippable_item=False,
-                                timer=1,
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="Morning questionnaire",
-                    description=dict(
-                        en="Understand how was the morning",
-                        fr="Understand how was the morning",
-                    ),
-                    items=[
-                        dict(
-                            activity_key="577dbbdd-3afc-4962-842b-8d8d11588bfe"  # noqa E501
-                        )
-                    ],
-                )
-            ],
-        )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 400
-        assert response.json()["result"][0]["message"] == activity_errors.IncorrectConditionItemIndexError.message
-
-        text_item = create_data["activities"][0]["items"][1]
-        slider_item_2 = create_data["activities"][0]["items"][6]
-        create_data["activities"][0]["items"][1] = slider_item_2
-        create_data["activities"][0]["items"][6] = text_item
-
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
-        assert isinstance(
-            response.json()["result"]["activities"][0]["items"][6]["conditionalLogic"],
-            dict,
-        )
-        assert isinstance(
-            response.json()["result"]["activities"][0]["scoresAndReports"],
-            dict,
-        )
-        assert isinstance(response.json()["result"]["activities"][0]["subscaleSetting"], dict)
-
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
+        data = applet_minimal_data.copy(deep=True)
+        data.activities = [activity_create_with_conditional_logic]
+        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
 
         activity_id = response.json()["result"]["activities"][0]["id"]
         response = await client.get(self.activity_detail_url.format(activity_id=activity_id))
-        assert response.status_code == 200
-        assert isinstance(response.json()["result"]["items"][6]["conditionalLogic"], dict)
+        assert response.status_code == http.HTTPStatus.OK
+        assert isinstance(response.json()["result"]["items"][1]["conditionalLogic"], dict)
 
-    async def test_creating_activity_items_without_option_value(self, client, tom):
+    async def test_creating_applet_with_activity_items_condition_not_valid_order_in_conditional_logic(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        activity_create_with_conditional_logic: ActivityCreate,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        create_data = dict(
-            display_name="User daily behave",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            about=dict(
-                en="Understand users behave",
-                fr="Comprendre le comportement des utilisateurs",
-            ),
-            activities=[
-                dict(
-                    name="Morning activity",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Understand morning feelings.",
-                        fr="Understand morning feelings.",
-                    ),
-                    items=[
-                        dict(
-                            name="activity_item_sliderrows",
-                            question={"en": "What is your name?"},
-                            response_type="sliderRows",
-                            response_values=dict(
-                                rows=[
-                                    {
-                                        "label": "label1",
-                                        "min_label": "min_label1",
-                                        "max_label": "max_label1",
-                                        "min_value": 0,
-                                        "max_value": 10,
-                                        "min_image": None,
-                                        "max_image": None,
-                                        "score": None,
-                                        "alerts": [
-                                            dict(
-                                                min_value=1,
-                                                max_value=4,
-                                                alert="alert1",
-                                            ),
-                                        ],
-                                    }
-                                ]
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_singleselectionrows",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelectRows",
-                            response_values=dict(
-                                rows=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "row_name": "row1",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "row_name": "row2",
-                                        "row_image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                options=[
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                        "text": "option1",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                    {
-                                        "id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                        "text": "option2",
-                                        "image": None,
-                                        "tooltip": None,
-                                    },
-                                ],
-                                data_matrix=[
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df1",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 1,
-                                                "alert": "alert1",
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 2,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                    {
-                                        "row_id": "17e69155-22cd-4484-8a49-364779ea9df2",  # noqa E501
-                                        "options": [
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de1",  # noqa E501
-                                                "score": 3,
-                                                "alert": None,
-                                            },
-                                            {
-                                                "option_id": "17e69155-22cd-4484-8a49-364779ea9de2",  # noqa E501
-                                                "score": 4,
-                                                "alert": None,
-                                            },
-                                        ],
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                add_tooltip=False,
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_slideritem",
-                            question={"en": "What is your name?"},
-                            response_type="slider",
-                            response_values=dict(
-                                min_value=0,
-                                max_value=10,
-                                min_label="min_label",
-                                max_label="max_label",
-                                min_image=None,
-                                max_image=None,
-                                scores=None,
-                                alerts=[
-                                    dict(
-                                        min_value=1,
-                                        max_value=4,
-                                        alert="alert1",
-                                    ),
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                show_tick_labels=False,
-                                show_tick_marks=False,
-                                continuous_slider=True,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                        dict(
-                            name="activity_item_singleselect",
-                            question={"en": "What is your name?"},
-                            response_type="singleSelect",
-                            response_values=dict(
-                                palette_name="palette1",
-                                options=[
-                                    {
-                                        "text": "option1",
-                                        "alert": "alert1",
-                                        "value": 0,
-                                    },
-                                    {
-                                        "text": "option2",
-                                        "alert": "alert2",
-                                        "value": 1,
-                                    },
-                                ],
-                            ),
-                            config=dict(
-                                remove_back_button=False,
-                                skippable_item=False,
-                                add_scores=False,
-                                set_alerts=True,
-                                timer=1,
-                                add_tooltip=False,
-                                set_palette=False,
-                                randomize_options=False,
-                                additional_response_option={
-                                    "text_input_option": False,
-                                    "text_input_required": False,
-                                },
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            activity_flows=[
-                dict(
-                    name="Morning questionnaire",
-                    description=dict(
-                        en="Understand how was the morning",
-                        fr="Understand how was the morning",
-                    ),
-                    items=[dict(activity_key="577dbbda-3afc-" "4962-842b-8d8d11588bfe")],
-                )
-            ],
-        )
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
+        data = applet_minimal_data.copy(deep=True)
+        data.activities = [activity_create_with_conditional_logic]
+        item_for_condition = activity_create_with_conditional_logic.items[0]
+        item_with_condition = activity_create_with_conditional_logic.items[1]
+        # Make wrong order. Item with condition must be after item which value is included in conditional logic
+        request_data = data.dict()
+        request_data["activities"][0]["items"] = [item_with_condition.dict(), item_for_condition.dict()]
+        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=request_data)
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        result = response.json()["result"]
+        assert len(result) == 1
+        assert result[0]["message"] == activity_errors.IncorrectConditionItemIndexError.message
 
-        response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
-        assert response.status_code == 200
-        applet_id = response.json()["result"]["id"]
-
-        response = await client.get(
-            self.activity_detail_url.format(activity_id=response.json()["result"]["activities"][0]["id"])
-        )
-        slider_rows_id = response.json()["result"]["items"][0]["id"]
-
-        assert response.status_code == 200
-        assert response.json()["result"]["items"][3]["responseValues"]["options"][0]["value"] == 0
-
-        create_data["activities"][0]["items"][0] = dict(
-            id=slider_rows_id,
-            name="activity_item_sliderrows",
-            question={"en": "What is your name?"},
-            response_type="sliderRows",
-            response_values=dict(
-                rows=[
-                    {
-                        "label": "label1",
-                        "min_label": "min_label1",
-                        "max_label": "max_label1",
-                        "min_value": 1,
-                        "max_value": 5,
-                        "min_image": None,
-                        "max_image": None,
-                        "scores": [1, 2, 3, 4, 5],
-                    }
-                ]
-            ),
-            config=dict(
-                remove_back_button=False,
-                skippable_item=False,
-                add_scores=True,
-                set_alerts=True,
-                timer=1,
-            ),
-        )
-
-        response = await client.put(
-            self.applet_detail_url.format(pk=applet_id),
-            data=create_data,
-        )
-        assert response.status_code == 200
-
-    async def test_create_applet_with_flanker_preformance_task(self, client, activity_flanker_data, tom):
+    async def test_create_applet__activity_with_conditional_logic(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        activity_create_with_conditional_logic: ActivityCreate,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-
-        create_data = dict(
-            display_name="Flanker",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(en="Flanker", fr="Flanker"),
-            about=dict(en="Flanker", fr="Flanker"),
-            activities=[activity_flanker_data],
-            # Empty, but required
-            activity_flows=[],
+        data = applet_minimal_data.copy(deep=True)
+        data.activities = [activity_create_with_conditional_logic]
+        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+        result = response.json()["result"]
+        item_create_with_logic = activity_create_with_conditional_logic.items[1]
+        assert item_create_with_logic.conditional_logic is not None
+        assert result["activities"][0]["items"][1]["conditionalLogic"] == item_create_with_logic.conditional_logic.dict(
+            by_alias=True
         )
-
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201, response.json()
-
-        assert response.json()["result"]["activities"][0]["isPerformanceTask"]
-        assert response.json()["result"]["activities"][0]["performanceTaskType"] == "flanker"
-
-        # Check that the 'get' after creating new applet returns correct data
-        response = await client.get(
-            self.applet_workspace_detail_url.format(
-                owner_id=tom.id,
-                pk=response.json()["result"]["id"],
-            )
-        )
-        assert response.status_code == 200
-        assert response.json()["result"]["activities"][0]["isPerformanceTask"]
-        assert response.json()["result"]["activities"][0]["performanceTaskType"] == "flanker"
-
-    async def test_applet_add_performance_task_to_the_applet(self, client, activity_flanker_data, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-
-        create_data = dict(
-            display_name="Add flanker to existing applet",
-            encryption=dict(
-                public_key=uuid.uuid4().hex,
-                prime=uuid.uuid4().hex,
-                base=uuid.uuid4().hex,
-                account_id=str(uuid.uuid4()),
-            ),
-            description=dict(en="Add flanker to existing applet"),
-            about=dict(en="Add flanker to existing applet"),
-            activities=[
-                dict(
-                    name="Morning activity",
-                    key="577dbbda-3afc-4962-842b-8d8d11588bfe",
-                    description=dict(
-                        en="Understand morning feelings.",
-                    ),
-                    items=[
-                        dict(
-                            name="activity_item_text",
-                            question=dict(
-                                en="How had you slept?",
-                            ),
-                            response_type="text",
-                            response_values=None,
-                            config=dict(
-                                max_response_length=200,
-                                correct_answer_required=False,
-                                correct_answer=None,
-                                numerical_response_required=False,
-                                response_data_identifier=False,
-                                response_required=False,
-                                remove_back_button=False,
-                                skippable_item=True,
-                            ),
-                        ),
-                    ],
-                ),
-            ],
-            # Empty, but required
-            activity_flows=[],
-        )
-
-        response = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=create_data,
-        )
-        assert response.status_code == 201
-        activity = response.json()["result"]["activities"][0]
-        assert not activity["isPerformanceTask"]
-        assert not activity["performanceTaskType"]
-        # Test that get after creating new applet returns correct data
-        # Generaly we don't need to test, tested data, but for now let leave
-        # it here
-        response = await client.get(
-            self.applet_workspace_detail_url.format(
-                owner_id=tom.id,
-                pk=response.json()["result"]["id"],
-            )
-        )
-        assert response.status_code == 200
-        activity = response.json()["result"]["activities"][0]
-        assert not activity["isPerformanceTask"]
-        assert not activity["performanceTaskType"]
-
-        # Add flanker performance task
-        create_data["activities"].append(activity_flanker_data)
-
-        response = await client.put(
-            self.applet_detail_url.format(pk=response.json()["result"]["id"]),
-            data=create_data,
-        )
-        assert response.status_code == 200
-        flanker = response.json()["result"]["activities"][1]
-        assert flanker["isPerformanceTask"]
-        assert flanker["performanceTaskType"] == "flanker"
-
-        # Check the 'get' method
-        response = await client.get(
-            self.applet_workspace_detail_url.format(
-                owner_id=tom.id,
-                pk=response.json()["result"]["id"],
-            )
-        )
-        assert response.status_code == 200
-        flanker = response.json()["result"]["activities"][1]
-        assert flanker["isPerformanceTask"]
-        assert flanker["performanceTaskType"] == "flanker"
-
-    # TODO: move all validation test to the activity domain test
-    async def test_create_applet_item_name_is_not_valid(self, client, applet_minimal_data, tom) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        data["activities"][0]["items"][0]["name"] = "%name"
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.IncorrectNameCharactersError.message
-
-    async def test_create_applet_item_config_not_valid(self, client, applet_minimal_data, tom) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        del data["activities"][0]["items"][0]["config"]["add_scores"]
-        del data["activities"][0]["items"][0]["config"]["set_alerts"]
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.IncorrectConfigError.message.format(type=SingleSelectionConfig)
-
-    async def test_create_applet_not_valid_response_type(self, client, applet_minimal_data, tom) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        data["activities"][0]["items"][0]["response_type"] = "NotValid"
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.IncorrectResponseValueError.message.format(type=ResponseType)
 
     @pytest.mark.parametrize(
-        "value,error_msg",
+        "item_fixture_name",
         (
-            (
-                {},
-                activity_errors.IncorrectResponseValueError.message.format(type=SingleSelectionValues),
-            ),
-            (
-                None,
-                activity_errors.IncorrectResponseValueError.message.format(type=SingleSelectionValues),
-            ),
+            "single_select_item_create",
+            "multi_select_item_create",
+            "single_select_row_item_create",
+            "multi_select_row_item_create",
         ),
     )
-    async def test_create_applet_not_valid_response_values(
-        self, client, applet_minimal_data, tom, value, error_msg
-    ) -> None:
+    async def test_creating_activity_items_without_option_value(
+        self,
+        client: TestClient,
+        tom: User,
+        item_fixture_name: str,
+        request: FixtureRequest,
+        applet_minimal_data: AppletCreate,
+    ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        data["activities"][0]["items"][0]["response_values"] = value
-        data["activities"][0]["items"][0]["response_type"] = ResponseType.SINGLESELECT
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == error_msg
-
-    async def test_create_applet_without_item_response_type(self, client, applet_minimal_data, tom) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        del data["activities"][0]["items"][0]["response_type"]
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == "field required"
-
-    async def test_create_applet_single_select_add_scores_not_scores_in_response_values(
-        self, client, applet_minimal_data, tom
-    ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        data["activities"][0]["items"][0]["config"]["add_scores"] = True
-        data["activities"][0]["items"][0]["response_type"] = ResponseType.SINGLESELECT
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.ScoreRequiredForResponseValueError.message
-
-    async def test_create_applet_slider_response_values_add_scores_not_scores_in_response_values(
-        self, client, applet_minimal_data, slider_response_values, slider_config, tom
-    ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        slider_config.add_scores = True
-        data["activities"][0]["items"][0]["config"] = slider_config.dict()
-        data["activities"][0]["items"][0]["response_type"] = ResponseType.SLIDER
-        data["activities"][0]["items"][0]["response_values"] = slider_response_values.dict()
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.NullScoreError.message
-
-    async def test_create_applet_slider_response_values_add_scores_scores_not_for_all_values(
-        self, client, applet_minimal_data, slider_response_values, slider_config, tom
-    ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        slider_config.add_scores = True
-        min_val = slider_response_values.min_value
-        max_val = slider_response_values.max_value
-        scores = [i for i in range(max_val - min_val)]
-        slider_response_values_data = slider_response_values.dict()
-        slider_response_values_data["scores"] = scores
-        data["activities"][0]["items"][0]["config"] = slider_config.dict()
-        data["activities"][0]["items"][0]["response_type"] = ResponseType.SLIDER
-        data["activities"][0]["items"][0]["response_values"] = slider_response_values_data
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.InvalidScoreLengthError.message
-
-    async def test_create_applet_slider_rows_response_values_add_scores_true_no_scores(
-        self, client, applet_minimal_data, slider_rows_response_values, slider_rows_config, tom
-    ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        slider_rows_config_data = slider_rows_config.dict()
-        slider_rows_response_values_data = slider_rows_response_values.dict()
-        slider_rows_config_data["add_scores"] = True
-        slider_rows_response_values_data["rows"][0]["scores"] = None
-        item = data["activities"][0]["items"][0]
-        item["config"] = slider_rows_config_data
-        item["response_type"] = ResponseType.SLIDERROWS
-        item["response_values"] = slider_rows_response_values_data
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.NullScoreError.message
-
-    async def test_create_applet_slider_rows_response_values_add_scores_true_scores_not_for_all_values(
-        self, client, applet_minimal_data, slider_rows_response_values, slider_rows_config, tom
-    ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        slider_rows_response_values_data = slider_rows_response_values.dict()
-        slider_rows_config_data = slider_rows_config.dict()
-        slider_rows_config_data["add_scores"] = True
-        min_val = slider_rows_response_values_data["rows"][0]["min_value"]
-        max_val = slider_rows_response_values_data["rows"][0]["max_value"]
-        slider_rows_response_values_data["rows"][0]["scores"] = [i for i in range(max_val - min_val)]
-        item = data["activities"][0]["items"][0]
-        item["config"] = slider_rows_config_data
-        item["response_type"] = ResponseType.SLIDERROWS
-        item["response_values"] = slider_rows_response_values_data
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.InvalidScoreLengthError.message
+        item = request.getfixturevalue(item_fixture_name)
+        data = applet_minimal_data.copy(deep=True)
+        # row
+        if hasattr(item.response_values, "data_matrix"):
+            item.response_values.data_matrix[0].options[0].value = None
+        else:
+            item.response_values.options[0].value = None
+        data.activities[0].items = [item]
+        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+        response_values = response.json()["result"]["activities"][0]["items"][0]["responseValues"]
+        assert response_values["options"][0]["value"] == 0
 
     @pytest.mark.parametrize("response_type", (ResponseType.SINGLESELECT, ResponseType.MULTISELECT))
     async def test_create_applet_single_multi_select_response_values_value_null_auto_set_value(
         self, client, applet_minimal_data, tom, response_type
     ) -> None:
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
+        data = applet_minimal_data.copy(deep=True).dict()
         item = data["activities"][0]["items"][0]
         option = item["response_values"]["options"][0]
         del option["value"]
@@ -2280,36 +270,16 @@ class TestActivityItems:
             self.applet_create_url.format(owner_id=tom.id),
             data=data,
         )
-        assert resp.status_code == 201
+        assert resp.status_code == http.HTTPStatus.CREATED
         item = resp.json()["result"]["activities"][0]["items"][0]
         # We can use enumerate because we have 2 options and values should be
         # 0 and 1
         for i, o in enumerate(item["responseValues"]["options"]):
             assert o["value"] == i
 
-    async def test_create_applet_single_select_rows_response_values_add_alerts_no_datamatrix(
-        self, client, applet_minimal_data, single_select_row_response_values, single_select_row_config, tom
+    async def test_create_applet_flow_wrong_activity_key(
+        self, client: TestClient, applet_minimal_data: AppletCreate, tom: User
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
-        data = applet_minimal_data.dict()
-        single_select_row_config_data = single_select_row_config.dict()
-        single_select_row_response_values_data = single_select_row_response_values.dict()
-        single_select_row_config_data["set_alerts"] = True
-        single_select_row_response_values_data["data_matrix"] = None
-        item = data["activities"][0]["items"][0]
-        item["config"] = single_select_row_config_data
-        item["response_type"] = ResponseType.SINGLESELECTROWS
-        item["response_values"] = single_select_row_response_values_data
-        resp = await client.post(
-            self.applet_create_url.format(owner_id=tom.id),
-            data=data,
-        )
-        assert resp.status_code == 422
-        errors = resp.json()["result"]
-        assert len(errors) == 1
-        assert errors[0]["message"] == activity_errors.DataMatrixRequiredError.message
-
-    async def test_create_applet_flow_wrong_activity_key(self, client, applet_minimal_data, tom) -> None:
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
         data = applet_minimal_data.dict()
         activity_key = data["activities"][0]["key"]
@@ -2336,10 +306,10 @@ class TestActivityItems:
             self.applet_create_url.format(owner_id=tom.id),
             data=data,
         )
-        assert resp.status_code == 201
+        assert resp.status_code == http.HTTPStatus.CREATED
 
     async def test_update_applet_duplicated_activity_item_name_is_not_allowed(
-        self, client, applet_minimal_data, tom, applet_one
+        self, client: TestClient, applet_minimal_data: AppletCreate, tom: User, applet_one: AppletFull
     ):
         await client.login(self.login_url, tom.email_encrypted, "Test1234!")
         data = AppletUpdate(**applet_minimal_data.dict(exclude_unset=True)).dict()
@@ -2349,7 +319,206 @@ class TestActivityItems:
             self.applet_detail_url.format(pk=applet_one.id),
             data=data,
         )
-        assert resp.status_code == 422
+        assert resp.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == activity_errors.DuplicateActivityItemNameNameError.message
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ("single_select_item_create", "multi_select_item_create"),
+    )
+    async def test_create_applet__item_single_multi_select_with_image(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        fixture_name: str,
+        remote_image: str,
+        request: FixtureRequest,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        item_create = request.getfixturevalue(fixture_name)
+        item_create.response_values.options[0].image = remote_image
+        data.activities[0].items = [item_create]
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        assert (
+            resp.json()["result"]["activities"][0]["items"][0]["responseValues"]["options"][0]["image"] == remote_image
+        )
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ("single_select_item_create", "multi_select_item_create"),
+    )
+    async def test_create_applet__item_single_multi_select_with_color(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        fixture_name: str,
+        request: FixtureRequest,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        item_create = request.getfixturevalue(fixture_name)
+        color = Color("#ffffff")
+        item_create.response_values.options[0].color = color
+        data.activities[0].items = [item_create]
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        assert (
+            resp.json()["result"]["activities"][0]["items"][0]["responseValues"]["options"][0]["color"]
+            == color.as_hex()
+        )
+
+    async def test_create_applet__item_slider_with_color(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        remote_image: str,
+        slider_item_create: ActivityItemCreate,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        slider_item_create.response_values = cast(SliderValues, slider_item_create.response_values)
+        slider_item_create.response_values.min_image = remote_image
+        slider_item_create.response_values.max_image = remote_image
+        data.activities[0].items = [slider_item_create]
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        assert resp.json()["result"]["activities"][0]["items"][0]["responseValues"]["minImage"] == remote_image
+        assert resp.json()["result"]["activities"][0]["items"][0]["responseValues"]["maxImage"] == remote_image
+
+    async def test_create_applet__activity_with_subscale_settings__subscale_type_item(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        subscale_setting: SubscaleSetting,
+        single_select_item_create_with_score: ActivityItemCreate,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        sub_setting = subscale_setting.copy(deep=True)
+        # subscale item must have name from activity. So for test just update name in copied subscale item
+        sub_setting.subscales[0].items[0].name = single_select_item_create_with_score.name  # type: ignore[index]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].subscale_setting = sub_setting
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
+
+    async def test_create_applet__activity_with_subscale_settings__subscale_type_subscale(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        single_select_item_create_with_score: ActivityItemCreate,
+        tom: User,
+        subscale_setting: SubscaleSetting,
+        subscale_with_item_type_subscale: Subscale,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        sub_settin = subscale_setting.copy(deep=True)
+        # subscale item must have name from activity. So for test just update name in copied subscale item
+        sub_settin.subscales[0].items[0].name = single_select_item_create_with_score.name  # type: ignore[index]
+        # Add subscale type subscale which has subscale item pointing to the subscale above
+        sub_settin.subscales.append(subscale_with_item_type_subscale)  # type: ignore[union-attr]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].subscale_setting = sub_settin
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["subscaleSetting"] == sub_settin.dict(by_alias=True)
+
+    async def test_create_applet__activity_with_subscale_settings_with_total_score_table(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        single_select_item_create_with_score: ActivityItemCreate,
+        tom: User,
+        subscale_setting: SubscaleSetting,
+        subscale_total_score_table: list[TotalScoreTable],
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        sub_setting = subscale_setting.copy(deep=True)
+        # subscale item must have name from activity. So for test just update name in copied subscale item
+        sub_setting.subscales[0].items[0].name = single_select_item_create_with_score.name  # type: ignore[index]
+        sub_setting.total_scores_table_data = subscale_total_score_table
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].subscale_setting = sub_setting
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
+
+    async def test_create_applet__activity_with_subscale_settings_with_subscale_lookup_table(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        single_select_item_create_with_score: ActivityItemCreate,
+        tom: User,
+        subscale_setting: SubscaleSetting,
+        subscale_lookup_table: list[SubScaleLookupTable],
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        sub_setting = subscale_setting.copy(deep=True)
+        # subscale item must have name from activity. So for test just update name in copied subscale item
+        sub_setting.subscales[0].items[0].name = single_select_item_create_with_score.name  # type: ignore[index]
+        sub_setting.subscales[0].subscale_table_data = subscale_lookup_table  # type: ignore[index]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].subscale_setting = sub_setting
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
+
+    async def test_create_applet__activity_with_score_and_reports__score_and_section(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        scores_and_reports: ScoresAndReports,
+        single_select_item_create_with_score: ActivityItemCreate,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        reports_data = scores_and_reports.copy(deep=True)
+        reports_data.reports[0].items_print = [single_select_item_create_with_score.name]  # type: ignore[index]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].scores_and_reports = reports_data
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["scoresAndReports"] == reports_data.dict(by_alias=True)
+
+    async def test_create_applet__activity_with_score_and_reports__score_and_section_with_conditional_logic(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        tom: User,
+        scores_and_reports: ScoresAndReports,
+        score_conditional_logic: ScoreConditionalLogic,
+        section_conditional_logic: SectionConditionalLogic,
+        single_select_item_create_with_score: ActivityItemCreate,
+    ):
+        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        data = applet_minimal_data.copy(deep=True)
+        reports_data = scores_and_reports.copy(deep=True)
+        reports_data.reports[0].items_print = [single_select_item_create_with_score.name]  # type: ignore[index]
+        reports_data.reports[1].items_print = [single_select_item_create_with_score.name]  # type: ignore[index]
+        score_conditional_logic.items_print = [single_select_item_create_with_score.name]
+        reports_data.reports[0].conditional_logic = [score_conditional_logic]  # type: ignore[index]
+        reports_data.reports[1].conditional_logic = section_conditional_logic  # type: ignore[index]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].scores_and_reports = reports_data
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.CREATED
+        result = resp.json()["result"]
+        assert result["activities"][0]["scoresAndReports"] == reports_data.dict(by_alias=True)

--- a/src/apps/applets/tests/test_applet_link.py
+++ b/src/apps/applets/tests/test_applet_link.py
@@ -1,4 +1,6 @@
+from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
 from config import settings
 
 
@@ -6,7 +8,7 @@ class TestLink(BaseTest):
     login_url = "/auth/login"
     access_link_url = "applets/{applet_id}/access_link"
 
-    async def test_applet_access_link_create_by_admin(self, client, applet_one):
+    async def test_applet_access_link_create_by_admin(self, client: TestClient, applet_one: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         data = {"require_login": True}
@@ -30,7 +32,7 @@ class TestLink(BaseTest):
         )
         assert response.status_code == 400
 
-    async def test_applet_access_link_create_by_manager(self, client, applet_one_lucy_manager):
+    async def test_applet_access_link_create_by_manager(self, client: TestClient, applet_one_lucy_manager: AppletFull):
         await client.login(self.login_url, "lucy@gmail.com", "Test123")
 
         data = {"require_login": True}
@@ -42,7 +44,9 @@ class TestLink(BaseTest):
         assert response.status_code == 201
         assert isinstance(response.json()["result"]["link"], str)
 
-    async def test_applet_access_link_create_by_coordinator(self, client, applet_one_lucy_coordinator):
+    async def test_applet_access_link_create_by_coordinator(
+        self, client: TestClient, applet_one_lucy_coordinator: AppletFull
+    ):
         await client.login(self.login_url, "lucy@gmail.com", "Test123")
 
         data = {"require_login": True}
@@ -54,7 +58,7 @@ class TestLink(BaseTest):
         assert response.status_code == 201
         assert isinstance(response.json()["result"]["link"], str)
 
-    async def test_applet_access_link_get(self, client, applet_one_with_link):
+    async def test_applet_access_link_get(self, client: TestClient, applet_one_with_link: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         response = await client.get(self.access_link_url.format(applet_id=applet_one_with_link.id))
@@ -63,13 +67,13 @@ class TestLink(BaseTest):
         url_path = settings.service.urls.frontend.private_link
         assert response.json()["result"]["link"] == f"https://{domain}/{url_path}/{applet_one_with_link.link}"
 
-    async def test_wrong_applet_access_link_get(self, client):
+    async def test_wrong_applet_access_link_get(self, client: TestClient):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         response = await client.get(self.access_link_url.format(applet_id="00000000-0000-0000-0000-000000000000"))
         assert response.status_code == 404
 
-    async def test_applet_access_link_delete(self, client, applet_one_with_link):
+    async def test_applet_access_link_delete(self, client: TestClient, applet_one_with_link: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         response = await client.delete(self.access_link_url.format(applet_id=applet_one_with_link.id))
@@ -78,7 +82,7 @@ class TestLink(BaseTest):
         response = await client.get(self.access_link_url.format(applet_id=applet_one_with_link.id))
         assert response.status_code == 404
 
-    async def test_applet_access_link_create_for_anonym(self, client, applet_one):
+    async def test_applet_access_link_create_for_anonym(self, client: TestClient, applet_one: AppletFull):
         resp = await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
         applet_id = applet_one.id
         data = {"require_login": False}

--- a/src/apps/applets/tests/test_applet_settings.py
+++ b/src/apps/applets/tests/test_applet_settings.py
@@ -1,6 +1,8 @@
 import http
 
+from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
 
 
 class TestSettings(BaseTest):
@@ -8,7 +10,7 @@ class TestSettings(BaseTest):
     applet_url = "applets/{applet_id}"
     data_retention = applet_url + "/retentions"
 
-    async def test_applet_set_data_retention(self, client, applet_one):
+    async def test_applet_set_data_retention(self, client: TestClient, applet_one: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         retention_data = dict(
@@ -27,7 +29,7 @@ class TestSettings(BaseTest):
         assert response.json()["result"]["retentionPeriod"] == retention_data["period"]
         assert response.json()["result"]["retentionType"] == retention_data["retention"]
 
-    async def test_applet_set_data_retention_for_indefinite(self, client, applet_one):
+    async def test_applet_set_data_retention_for_indefinite(self, client: TestClient, applet_one: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         retention_data = dict(
@@ -45,7 +47,7 @@ class TestSettings(BaseTest):
         assert response.json()["result"]["retentionPeriod"] is None
         assert response.json()["result"]["retentionType"] == retention_data["retention"]
 
-    async def test_applet_set_data_retention_for_indefinite_fail(self, client, applet_one):
+    async def test_applet_set_data_retention_for_indefinite_fail(self, client: TestClient, applet_one: AppletFull):
         await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
 
         retention_data = dict(

--- a/src/apps/shared/test/client.py
+++ b/src/apps/shared/test/client.py
@@ -1,21 +1,19 @@
 import json
 import urllib.parse
 from io import BytesIO
-from typing import Any, Mapping, Type, TypeVar
+from typing import Any, Mapping
 
 from httpx import AsyncClient, Response
 from pydantic import BaseModel
 
-T = TypeVar("T", bound=BaseModel)
-
 
 class TestClient:
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.client = AsyncClient(app=app, base_url="http://test.com")
-        self.headers = {}
+        self.headers: dict[str, Any] = {}
 
     @staticmethod
-    def _prepare_url(url, query):
+    def _prepare_url(url, query) -> str:
         return f"{url}?{urllib.parse.urlencode(query)}"
 
     def _get_updated_headers(self, headers: dict | None = None) -> dict:
@@ -25,7 +23,7 @@ class TestClient:
         return headers_
 
     @staticmethod
-    def _get_body(data: dict[str, Any] | Type[T] | None = None):
+    def _get_body(data: dict[str, Any] | BaseModel | None = None) -> str | None:
         if data:
             if isinstance(data, BaseModel):
                 request_data = data.dict()
@@ -37,7 +35,7 @@ class TestClient:
     async def post(
         self,
         url: str,
-        data: dict[str, Any] | Type[T] | None = None,
+        data: dict[str, Any] | BaseModel | None = None,
         query: dict | None = None,
         headers: dict | None = None,
         files: Mapping[str, BytesIO] | None = None,
@@ -55,7 +53,7 @@ class TestClient:
     async def put(
         self,
         url: str,
-        data: dict | None = None,
+        data: dict | BaseModel | None = None,
         query: dict | None = None,
         headers: dict | None = None,
     ) -> Response:
@@ -96,7 +94,7 @@ class TestClient:
         )
         return response
 
-    async def login(self, url: str, email: str | None, password: str, device_id: str | None = None):
+    async def login(self, url: str, email: str | None, password: str, device_id: str | None = None) -> Response:
         # Just make password option to shut up mypy error when User.email_encrypted passed as arument
         assert password is not None
         response = await self.post(
@@ -113,5 +111,5 @@ class TestClient:
         self.headers["Authorization"] = f"{token_type} {access_token}"
         return response
 
-    async def logout(self):
+    async def logout(self) -> None:
         self.headers = {}


### PR DESCRIPTION
resolves: [M2-5207](https://mindlogger.atlassian.net/browse/M2-5207)

### Objective

- Add missing tests for applets API.
- Split existing big tests on several small tests to check only one thing.

### Notes

- Added fixtures (create) for all activity_items.
- Added request fixtures for Performance tasks.
- Added fixture for FCM client for notifications to use in tests.
- Move domain (activity_item_create/base)  validation tests  to the activities/tests/unit

[M2-5207]: https://mindlogger.atlassian.net/browse/M2-5207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ