### PR TITLE
M2-5331: Replace login post request with generating token

### DIFF
--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -29,9 +29,9 @@ class TestActivities:
     activities_applet = "/activities/applet/{applet_id}"
     public_activity_detail = "public/activities/{pk}"
 
-    async def test_activity_detail(self, client, applet_one: AppletFull):
+    async def test_activity_detail(self, client, applet_one: AppletFull, tom: User):
         activity = applet_one.activities[0]
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         response = await client.get(self.activity_detail.format(pk=activity.id))
 
         assert response.status_code == http.HTTPStatus.OK
@@ -43,7 +43,7 @@ class TestActivities:
         assert result["items"][0]["question"] == activity.items[0].question[Language.ENGLISH]
 
     async def test_activities_applet(self, client, applet_one: AppletFull, default_theme: Theme, tom: User):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         response = await client.get(self.activities_applet.format(applet_id=applet_one.id))
 
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/activities/tests/test_reusable_items.py
+++ b/src/apps/activities/tests/test_reusable_items.py
@@ -2,14 +2,13 @@ import uuid
 
 
 class TestReusableItem:
-    login_url = "/auth/login"
     create_url = "activities/item_choices"
     update_url = "activities/item_choices"
     delete_url = "activities/item_choices/{id}"
     retrieve_url = "activities/item_choices"
 
-    async def test_create_item_choice(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_create_item_choice(self, client, tom):
+        client.login(tom)
         create_data = dict(
             token_name="Average age",
             token_value="21",
@@ -21,8 +20,8 @@ class TestReusableItem:
         assert response.status_code == 201, response.json()
         assert response.json()["result"]["id"]
 
-    async def test_recreate_item_choice(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_recreate_item_choice(self, client, tom):
+        client.login(tom)
         create_data = dict(
             token_name="Average age 2",
             token_value="21",
@@ -49,8 +48,8 @@ class TestReusableItem:
         assert response.status_code == 400, res_data
         assert res_data["result"][0]["message"] == "Reusable item choice already exist."
 
-    async def test_delete_item_choice(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_delete_item_choice(self, client, tom):
+        client.login(tom)
         create_data = dict(
             token_name="Average age 3",
             token_value="21",
@@ -66,15 +65,15 @@ class TestReusableItem:
 
         assert response.status_code == 204, response.json()
 
-    async def test_delete_item_choice_does_not_exist(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_delete_item_choice_does_not_exist(self, client, tom):
+        client.login(tom)
 
         response = await client.delete(self.delete_url.format(id=str(uuid.uuid4())))
 
         assert response.status_code == 404, response.json()
 
-    async def test_create_item_choice_with_long_int_value(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_create_item_choice_with_long_int_value(self, client, tom):
+        client.login(tom)
         create_data = dict(
             token_name="Average age",
             token_value=12321312312312323,
@@ -86,8 +85,8 @@ class TestReusableItem:
         res_data = response.json()
         assert response.status_code == 422, res_data
 
-    async def test_retrieve_item_choice(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_retrieve_item_choice(self, client, tom):
+        client.login(tom)
         create_data = dict(
             token_name="Average age 3",
             token_value="21",

--- a/src/apps/alerts/test_alerts.py
+++ b/src/apps/alerts/test_alerts.py
@@ -13,15 +13,15 @@ class TestAlert(BaseTest):
     alert_list_url = "/alerts"
     watch_alert_url = "/alerts/{alert_id}/is_watched"
 
-    async def test_all_alerts(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_all_alerts(self, client, tom):
+        client.login(tom)
 
         response = await client.get(self.alert_list_url)
         assert response.status_code == http.HTTPStatus.OK
         assert response.json()["count"] == 2
 
-    async def test_watch_alert(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_watch_alert(self, client, tom):
+        client.login(tom)
 
         response = await client.post(self.watch_alert_url.format(alert_id="6f794861-0ff6-4c39-a3ed-602fd4e22c58"))
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/answers/tests/test_answer_for_cases.py
+++ b/src/apps/answers/tests/test_answer_for_cases.py
@@ -48,8 +48,10 @@ class TestAnswerCases:
     login_url = "/auth/login"
     answer_url = "/answers"
 
-    async def test_answer_activity_items_create_for_respondent(self, client: TestClient, applet_with_flow: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_answer_activity_items_create_for_respondent(
+        self, client: TestClient, applet_with_flow: AppletFull, tom: User
+    ):
+        client.login(tom)
 
         submit_id = str(uuid.uuid4())
         answer_value_id = str(uuid.uuid4())

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -85,7 +85,7 @@ class TestAnswerActivityItems(BaseTest):
     assessment_delete_url = "/answers/applet/{applet_id}/answers/{answer_id}/assessment/{assessment_id}"
 
     async def test_answer_activity_items_create_for_respondent(self, mock_kiq_report, client, tom, applet: AppletFull):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         create_data = dict(
             submit_id=str(uuid.uuid4()),
             applet_id=str(applet.id),
@@ -140,7 +140,7 @@ class TestAnswerActivityItems(BaseTest):
         RedisCacheTest._storage = {}
 
     async def test_get_latest_summary(self, mock_report_server_response, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -219,7 +219,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 201, response.json()
 
     async def test_answer_skippable_activity_items_create_for_respondent(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -255,7 +255,7 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_list_submit_dates(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -299,7 +299,7 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_answer_flow_items_create_for_respondent(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -335,7 +335,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 201, response.json()
 
     async def test_answer_with_skipping_all(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -361,7 +361,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 201, response.json()
 
     async def test_answered_applet_activities(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -429,7 +429,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["result"]["events"] == '{"events": ["event1", "event2"]}'
 
     async def test_fail_answered_applet_not_existed_activities(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -486,7 +486,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 404, response.json()
 
     async def test_applet_activity_answers(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -530,7 +530,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["count"] == 1
 
     async def test_applet_assessment_retrieve(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -585,7 +585,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 200, response.json()
 
     async def test_applet_assessment_create(self, mock_kiq_report, client, tom, applet_with_reviewable_activity):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -704,7 +704,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["result"][0]["reviewer"]["lastName"] == "Isaak"
 
     async def test_applet_activities(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(
             self.review_activities_url.format(applet_id=str(applet.id)),
@@ -719,7 +719,7 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"][0]["answerDates"]) == 0
 
     async def test_add_note(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -783,7 +783,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["count"] == 1
 
     async def test_edit_note(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -871,7 +871,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["result"][0]["note"] == "Some note 2"
 
     async def test_delete_note(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -957,8 +957,8 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["count"] == 0
 
     @pytest.mark.usefixtures("mock_kiq_report", "user")
-    async def test_answer_activity_items_create_for_not_respondent(self, client, applet):
-        await client.login(self.login_url, "user@example.com", "Test1234!")
+    async def test_answer_activity_items_create_for_not_respondent(self, client, applet, user):
+        client.login(user)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -990,7 +990,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 403, response.json()
 
     async def test_answers_export(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         # create answer
         create_data = dict(
@@ -1108,7 +1108,7 @@ class TestAnswerActivityItems(BaseTest):
         assert not data["answers"]
 
     async def test_get_identifiers(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(
             self.identifiers_url.format(
@@ -1164,7 +1164,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["result"][0]["userPublicKey"] == "user key"
 
     async def test_get_versions(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(
             self.versions_url.format(
@@ -1179,7 +1179,7 @@ class TestAnswerActivityItems(BaseTest):
         assert response.json()["result"][0]["createdAt"]
 
     async def test_get_summary_activities(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(
             self.summary_activities_url.format(
@@ -1194,7 +1194,7 @@ class TestAnswerActivityItems(BaseTest):
         assert not response.json()["result"][0]["hasAnswer"]
 
     async def test_get_summary_activities_after_submitted_answer(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -1242,7 +1242,7 @@ class TestAnswerActivityItems(BaseTest):
         app_width = 819
         app_height = 1080
 
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         create_data = dict(
             submit_id=str(uuid.uuid4()),
             applet_id=str(applet.id),
@@ -1279,7 +1279,7 @@ class TestAnswerActivityItems(BaseTest):
         assert app_height == res.client["height"]
 
     async def test_activity_answers_by_identifier(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -1326,7 +1326,7 @@ class TestAnswerActivityItems(BaseTest):
         assert result["count"] == 1
 
     async def test_applet_completions(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         # create answer
         create_data = dict(
@@ -1404,7 +1404,7 @@ class TestAnswerActivityItems(BaseTest):
         assert activity_answer_data["localEndTime"] == "12:35:00"
 
     async def test_applets_completions(self, mock_kiq_report, client, tom, applet):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         # create answer
         create_data = dict(
@@ -1487,9 +1487,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @pytest.mark.usefixtures("user_reviewer_applet_one")
     async def test_summary_restricted_for_reviewer_if_external_respondent(
-        self, mock_kiq_report, client, tom, applet_one
+        self, mock_kiq_report, client, tom, applet_one, user
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             submit_id=str(uuid.uuid4()),
@@ -1521,8 +1521,8 @@ class TestAnswerActivityItems(BaseTest):
         response = await client.post(self.answer_url, data=create_data)
         assert response.status_code == 201
 
-        await client.logout()
-        await client.login(self.login_url, "user@example.com", "Test1234!")
+        client.logout()
+        client.login(user)
 
         response = await client.get(
             self.summary_activities_url.format(
@@ -1568,13 +1568,14 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 201
 
     @pytest.mark.parametrize(
-        "email,password,expected_code",
+        "user_fixture,expected_code",
         (
-            ("tom@mindlogger.com", "Test1234!", 204),  # owner
-            ("lucy@gmail.com", "Test123", 403),  # not in applet
-            ("bob@gmail.com", "Test1234!", 403),  # reviewer
+            ("tom", 204),  # owner
+            ("lucy", 403),  # not in applet
+            ("bob", 403),  # reviewer
         ),
     )
+    @pytest.mark.usefixtures("bob_reviewer_in_applet_with_reviewable_activity")
     async def test_review_delete(
         self,
         tom_answer_create_data,
@@ -1584,12 +1585,12 @@ class TestAnswerActivityItems(BaseTest):
         tom,
         applet_with_reviewable_activity,
         session,
-        bob_reviewer_in_applet_with_reviewable_activity,
-        email,
-        password,
+        user_fixture,
         expected_code,
+        request,
     ):
-        await client.login(self.login_url, email, password)
+        login_user = request.getfixturevalue(user_fixture)
+        client.login(login_user)
         answer_service = AnswerService(session, tom.id)
         answer = await answer_service.create_answer(tom_answer_create_data)
         await answer_service.create_assessment_answer(
@@ -1619,7 +1620,7 @@ class TestAnswerActivityItems(BaseTest):
         applet_with_reviewable_activity,
         session,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         applet_id = applet_with_reviewable_activity.id
         answer_service = AnswerService(session, tom.id)
         submit_dates = []
@@ -1648,7 +1649,7 @@ class TestAnswerActivityItems(BaseTest):
         applet_with_reviewable_activity,
         session,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         applet_id = applet_with_reviewable_activity.id
         response = await client.get(
             self.summary_activities_url.format(

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -88,7 +88,7 @@ class TestAnswerActivityItems:
         self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet
     ):
         submit_id = "270d86e0-2158-4d18-befd-86b3ce0122a1"
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
         create_data = dict(
             submit_id=submit_id,
             applet_id=str(applet.id),
@@ -140,7 +140,7 @@ class TestAnswerActivityItems:
     async def test_get_latest_summary(
         self, mock_report_server_response, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a0",
@@ -231,7 +231,7 @@ class TestAnswerActivityItems:
     async def test_answer_skippable_activity_items_create_for_respondent(
         self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a4",
@@ -274,7 +274,7 @@ class TestAnswerActivityItems:
         await assert_answer_exist_on_arbitrary("270d86e0-2158-4d18-befd-86b3ce0122a4", arbitrary_session)
 
     async def test_list_submit_dates(self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a5",
@@ -324,7 +324,7 @@ class TestAnswerActivityItems:
     async def test_answer_flow_items_create_for_respondent(
         self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a6",
@@ -361,7 +361,7 @@ class TestAnswerActivityItems:
         assert response.status_code == 201, response.json()
 
     async def test_answer_with_skipping_all(self, mock_kiq_report, arbitrary_client, arbitrary_session, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a7",
@@ -393,7 +393,7 @@ class TestAnswerActivityItems:
         await assert_answer_exist_on_arbitrary("270d86e0-2158-4d18-befd-86b3ce0122a7", arbitrary_session)
 
     async def test_answered_applet_activities(self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a8",
@@ -466,7 +466,7 @@ class TestAnswerActivityItems:
     async def test_fail_answered_applet_not_existed_activities(
         self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122a9",
@@ -523,7 +523,7 @@ class TestAnswerActivityItems:
         assert response.status_code == 404, response.json()
 
     async def test_applet_activity_answers(self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce012210",
@@ -566,7 +566,7 @@ class TestAnswerActivityItems:
         assert response.json()["count"] == 1
 
     async def test_applet_assessment_retrieve(self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce012211",
@@ -623,7 +623,7 @@ class TestAnswerActivityItems:
     async def test_applet_assessment_create(
         self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet_with_reviewable_activity
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         submit_id = str(uuid.uuid4())
         create_data = dict(
@@ -744,7 +744,7 @@ class TestAnswerActivityItems:
         ]
 
     async def test_applet_activities(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         response = await arbitrary_client.get(
             self.review_activities_url.format(applet_id=str(applet.id)),
@@ -760,9 +760,9 @@ class TestAnswerActivityItems:
 
     @pytest.mark.usefixtures("mock_kiq_report", "user")
     async def test_answer_activity_items_create_for_not_respondent(
-        self, arbitrary_session, arbitrary_client, public_applet
+        self, arbitrary_session, arbitrary_client, public_applet, user
     ):
-        await arbitrary_client.login(self.login_url, "user@example.com", "Test1234!")
+        arbitrary_client.login(user)
 
         submit_id = str(uuid.uuid4())
         create_data = dict(
@@ -795,7 +795,7 @@ class TestAnswerActivityItems:
         assert response.status_code == 403, response.json()
 
     async def test_answers_export(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         # create answer
         create_data = dict(
@@ -900,7 +900,7 @@ class TestAnswerActivityItems:
         assert not data["answers"]
 
     async def test_get_identifiers(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         response = await arbitrary_client.get(
             self.identifiers_url.format(
@@ -956,7 +956,7 @@ class TestAnswerActivityItems:
         assert response.json()["result"][0]["userPublicKey"] == "user key"
 
     async def test_get_versions(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         response = await arbitrary_client.get(
             self.versions_url.format(
@@ -971,7 +971,7 @@ class TestAnswerActivityItems:
         assert response.json()["result"][0]["createdAt"]
 
     async def test_get_summary_activities(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         response = await arbitrary_client.get(
             self.summary_activities_url.format(
@@ -986,7 +986,7 @@ class TestAnswerActivityItems:
         assert response.json()["result"][0]["hasAnswer"] is False
 
     async def test_get_summary_activities_after_submitted_answer(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122ae",
@@ -1035,7 +1035,7 @@ class TestAnswerActivityItems:
         app_width = 819
         app_height = 1080
 
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122ae",
             applet_id=str(applet.id),
@@ -1075,7 +1075,7 @@ class TestAnswerActivityItems:
         assert app_height == res.client["height"]
 
     async def test_activity_answers_by_identifier(self, mock_kiq_report, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         create_data = dict(
             submit_id="270d86e0-2158-4d18-befd-86b3ce0122ae",
@@ -1119,7 +1119,7 @@ class TestAnswerActivityItems:
         assert result["count"] == 1
 
     async def test_answers_arbitrary_export(self, mock_kiq_report, arbitrary_session, arbitrary_client, tom, applet):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
 
         # create answer
         create_data = dict(
@@ -1234,7 +1234,7 @@ class TestAnswerActivityItems:
         applet_with_reviewable_activity,
         arbitrary_session,
     ):
-        await arbitrary_client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        arbitrary_client.login(tom)
         answer_service = AnswerService(session, tom.id, arbitrary_session)
         answer = await answer_service.create_answer(tom_answer_create_data)
         await answer_service.create_assessment_answer(

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -100,7 +100,7 @@ class TestActivityItems:
         item_fixture: str,
         request: FixtureRequest,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         item_create = request.getfixturevalue(item_fixture)
         data = applet_minimal_data.copy(deep=True)
         data.activities[0].items = [item_create]
@@ -143,7 +143,7 @@ class TestActivityItems:
         fixture_name: str,
         performance_task_type: PerformanceTaskType,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         activity = request.getfixturevalue(fixture_name)
         data.activities = [activity]
@@ -171,7 +171,7 @@ class TestActivityItems:
         applet_minimal_data: AppletCreate,
         activity_create_with_conditional_logic: ActivityCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         data.activities = [activity_create_with_conditional_logic]
         response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
@@ -189,7 +189,7 @@ class TestActivityItems:
         applet_minimal_data: AppletCreate,
         activity_create_with_conditional_logic: ActivityCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         data.activities = [activity_create_with_conditional_logic]
         item_for_condition = activity_create_with_conditional_logic.items[0]
@@ -210,7 +210,7 @@ class TestActivityItems:
         applet_minimal_data: AppletCreate,
         activity_create_with_conditional_logic: ActivityCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         data.activities = [activity_create_with_conditional_logic]
         response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
@@ -239,7 +239,7 @@ class TestActivityItems:
         request: FixtureRequest,
         applet_minimal_data: AppletCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         item = request.getfixturevalue(item_fixture_name)
         data = applet_minimal_data.copy(deep=True)
         # row
@@ -257,7 +257,7 @@ class TestActivityItems:
     async def test_create_applet_single_multi_select_response_values_value_null_auto_set_value(
         self, client, applet_minimal_data, tom, response_type
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True).dict()
         item = data["activities"][0]["items"][0]
         option = item["response_values"]["options"][0]
@@ -280,7 +280,7 @@ class TestActivityItems:
     async def test_create_applet_flow_wrong_activity_key(
         self, client: TestClient, applet_minimal_data: AppletCreate, tom: User
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.dict()
         activity_key = data["activities"][0]["key"]
         activity_wrong_key = uuid.uuid4()
@@ -311,7 +311,7 @@ class TestActivityItems:
     async def test_update_applet_duplicated_activity_item_name_is_not_allowed(
         self, client: TestClient, applet_minimal_data: AppletCreate, tom: User, applet_one: AppletFull
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = AppletUpdate(**applet_minimal_data.dict(exclude_unset=True)).dict()
         item = copy.deepcopy(data["activities"][0]["items"][0])
         data["activities"][0]["items"].append(item)
@@ -337,7 +337,7 @@ class TestActivityItems:
         remote_image: str,
         request: FixtureRequest,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         item_create = request.getfixturevalue(fixture_name)
         item_create.response_values.options[0].image = remote_image
@@ -360,7 +360,7 @@ class TestActivityItems:
         fixture_name: str,
         request: FixtureRequest,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         item_create = request.getfixturevalue(fixture_name)
         color = Color("#ffffff")
@@ -381,7 +381,7 @@ class TestActivityItems:
         remote_image: str,
         slider_item_create: ActivityItemCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         slider_item_create.response_values = cast(SliderValues, slider_item_create.response_values)
         slider_item_create.response_values.min_image = remote_image
@@ -400,7 +400,7 @@ class TestActivityItems:
         subscale_setting: SubscaleSetting,
         single_select_item_create_with_score: ActivityItemCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         sub_setting = subscale_setting.copy(deep=True)
         # subscale item must have name from activity. So for test just update name in copied subscale item
@@ -421,7 +421,7 @@ class TestActivityItems:
         subscale_setting: SubscaleSetting,
         subscale_with_item_type_subscale: Subscale,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         sub_settin = subscale_setting.copy(deep=True)
         # subscale item must have name from activity. So for test just update name in copied subscale item
@@ -444,7 +444,7 @@ class TestActivityItems:
         subscale_setting: SubscaleSetting,
         subscale_total_score_table: list[TotalScoreTable],
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         sub_setting = subscale_setting.copy(deep=True)
         # subscale item must have name from activity. So for test just update name in copied subscale item
@@ -466,7 +466,7 @@ class TestActivityItems:
         subscale_setting: SubscaleSetting,
         subscale_lookup_table: list[SubScaleLookupTable],
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         sub_setting = subscale_setting.copy(deep=True)
         # subscale item must have name from activity. So for test just update name in copied subscale item
@@ -487,7 +487,7 @@ class TestActivityItems:
         scores_and_reports: ScoresAndReports,
         single_select_item_create_with_score: ActivityItemCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         reports_data = scores_and_reports.copy(deep=True)
         reports_data.reports[0].items_print = [single_select_item_create_with_score.name]  # type: ignore[index]
@@ -508,7 +508,7 @@ class TestActivityItems:
         section_conditional_logic: SectionConditionalLogic,
         single_select_item_create_with_score: ActivityItemCreate,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = applet_minimal_data.copy(deep=True)
         reports_data = scores_and_reports.copy(deep=True)
         reports_data.reports[0].items_print = [single_select_item_create_with_score.name]  # type: ignore[index]

--- a/src/apps/applets/tests/test_applet_folder.py
+++ b/src/apps/applets/tests/test_applet_folder.py
@@ -20,7 +20,7 @@ class TestAppletMoveToFolder(BaseTest):
     folders_applet_url = "applets/folders/{id}"
 
     async def test_move_to_folder(self, session: AsyncSession, client: TestClient, tom: User, applet_one: AppletFull):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(
             applet_id=str(applet_one.id),
             folder_id="ecf66358-a717-41a7-8027-807374307731",
@@ -37,7 +37,7 @@ class TestAppletMoveToFolder(BaseTest):
         assert str(folders_ids[0]) == "ecf66358-a717-41a7-8027-807374307731"
 
     async def test_invalid_applet_move_to_folder(self, client: TestClient, tom: User, uuid_zero: uuid.UUID):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(
             applet_id=str(uuid_zero),
             folder_id="ecf66358-a717-41a7-8027-807374307731",
@@ -47,7 +47,7 @@ class TestAppletMoveToFolder(BaseTest):
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
     async def test_move_to_not_accessible_folder(self, client: TestClient, tom: User, applet_one: AppletFull):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(
             applet_id=str(applet_one.id),
             folder_id="ecf66358-a717-41a7-8027-807374307733",
@@ -58,7 +58,7 @@ class TestAppletMoveToFolder(BaseTest):
         assert response.json()["result"][0]["message"] == "Access denied to folder."
 
     async def test_move_not_accessible_applet_to_folder(self, client: TestClient, user: User, applet_one: AppletFull):
-        await client.login(self.login_url, user.email_encrypted, "Test1234!")
+        client.login(user)
         data = dict(
             applet_id=str(applet_one.id),
             folder_id="ecf66358-a717-41a7-8027-807374307732",
@@ -71,7 +71,7 @@ class TestAppletMoveToFolder(BaseTest):
     async def test_remove_from_folder(
         self, session: AsyncSession, client: TestClient, tom: User, applet_one: AppletFull
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(applet_id=str(applet_one.id), folder_id=None)
 
         response = await client.post(self.set_folder_url, data)
@@ -83,7 +83,7 @@ class TestAppletMoveToFolder(BaseTest):
     async def test_move_to_folder__folder_does_not_exists(
         self, client: TestClient, tom: User, applet_one: AppletFull, uuid_zero: uuid.UUID
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(
             applet_id=str(applet_one.id),
             folder_id=str(uuid_zero),
@@ -96,7 +96,7 @@ class TestAppletMoveToFolder(BaseTest):
     async def test_move_to_folder_applet_already_moved(
         self, session: AsyncSession, client: TestClient, tom: User, applet_one: AppletFull
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = dict(
             applet_id=str(applet_one.id),
             folder_id="ecf66358-a717-41a7-8027-807374307731",

--- a/src/apps/applets/tests/test_applet_link.py
+++ b/src/apps/applets/tests/test_applet_link.py
@@ -1,6 +1,7 @@
 from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.users.domain import User
 from config import settings
 
 
@@ -8,8 +9,8 @@ class TestLink(BaseTest):
     login_url = "/auth/login"
     access_link_url = "applets/{applet_id}/access_link"
 
-    async def test_applet_access_link_create_by_admin(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_access_link_create_by_admin(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = {"require_login": True}
         response = await client.post(
@@ -32,8 +33,10 @@ class TestLink(BaseTest):
         )
         assert response.status_code == 400
 
-    async def test_applet_access_link_create_by_manager(self, client: TestClient, applet_one_lucy_manager: AppletFull):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_applet_access_link_create_by_manager(
+        self, client: TestClient, applet_one_lucy_manager: AppletFull, lucy: User
+    ):
+        client.login(lucy)
 
         data = {"require_login": True}
         response = await client.post(
@@ -45,9 +48,9 @@ class TestLink(BaseTest):
         assert isinstance(response.json()["result"]["link"], str)
 
     async def test_applet_access_link_create_by_coordinator(
-        self, client: TestClient, applet_one_lucy_coordinator: AppletFull
+        self, client: TestClient, applet_one_lucy_coordinator: AppletFull, lucy: User
     ):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
 
         data = {"require_login": True}
         response = await client.post(
@@ -58,8 +61,8 @@ class TestLink(BaseTest):
         assert response.status_code == 201
         assert isinstance(response.json()["result"]["link"], str)
 
-    async def test_applet_access_link_get(self, client: TestClient, applet_one_with_link: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_access_link_get(self, client: TestClient, applet_one_with_link: AppletFull, tom: User):
+        client.login(tom)
 
         response = await client.get(self.access_link_url.format(applet_id=applet_one_with_link.id))
         assert response.status_code == 200
@@ -67,14 +70,14 @@ class TestLink(BaseTest):
         url_path = settings.service.urls.frontend.private_link
         assert response.json()["result"]["link"] == f"https://{domain}/{url_path}/{applet_one_with_link.link}"
 
-    async def test_wrong_applet_access_link_get(self, client: TestClient):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_wrong_applet_access_link_get(self, client: TestClient, tom: User):
+        client.login(tom)
 
         response = await client.get(self.access_link_url.format(applet_id="00000000-0000-0000-0000-000000000000"))
         assert response.status_code == 404
 
-    async def test_applet_access_link_delete(self, client: TestClient, applet_one_with_link: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_access_link_delete(self, client: TestClient, applet_one_with_link: AppletFull, tom: User):
+        client.login(tom)
 
         response = await client.delete(self.access_link_url.format(applet_id=applet_one_with_link.id))
         assert response.status_code == 204
@@ -82,8 +85,8 @@ class TestLink(BaseTest):
         response = await client.get(self.access_link_url.format(applet_id=applet_one_with_link.id))
         assert response.status_code == 404
 
-    async def test_applet_access_link_create_for_anonym(self, client: TestClient, applet_one: AppletFull):
-        resp = await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_access_link_create_for_anonym(self, client: TestClient, applet_one: AppletFull, tom: User):
+        resp = client.login(tom)
         applet_id = applet_one.id
         data = {"require_login": False}
         resp = await client.post(

--- a/src/apps/applets/tests/test_applet_settings.py
+++ b/src/apps/applets/tests/test_applet_settings.py
@@ -3,6 +3,7 @@ import http
 from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.users.domain import User
 
 
 class TestSettings(BaseTest):
@@ -10,8 +11,8 @@ class TestSettings(BaseTest):
     applet_url = "applets/{applet_id}"
     data_retention = applet_url + "/retentions"
 
-    async def test_applet_set_data_retention(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_set_data_retention(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         retention_data = dict(
             period=1,
@@ -29,8 +30,10 @@ class TestSettings(BaseTest):
         assert response.json()["result"]["retentionPeriod"] == retention_data["period"]
         assert response.json()["result"]["retentionType"] == retention_data["retention"]
 
-    async def test_applet_set_data_retention_for_indefinite(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_set_data_retention_for_indefinite(
+        self, client: TestClient, applet_one: AppletFull, tom: User
+    ):
+        client.login(tom)
 
         retention_data = dict(
             retention="indefinitely",
@@ -47,8 +50,10 @@ class TestSettings(BaseTest):
         assert response.json()["result"]["retentionPeriod"] is None
         assert response.json()["result"]["retentionType"] == retention_data["retention"]
 
-    async def test_applet_set_data_retention_for_indefinite_fail(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_set_data_retention_for_indefinite_fail(
+        self, client: TestClient, applet_one: AppletFull, tom: User
+    ):
+        client.login(tom)
 
         retention_data = dict(
             retention="days",

--- a/src/apps/file/test_file.py
+++ b/src/apps/file/test_file.py
@@ -69,9 +69,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @mock.patch("infrastructure.utility.cdn_arbitrary.ArbitraryS3CdnClient.upload")
     async def test_arbitrary_upload_to_s3_aws(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.AWS, session)
 
         content = io.BytesIO(b"File content")
@@ -88,9 +88,9 @@ class TestAnswerActivityItems(BaseTest):
         return_value=(iter(("a", "b")), "txt"),
     )
     async def test_arbitrary_download_from_s3_aws(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.AWS, session)
 
         response = await client.post(
@@ -102,9 +102,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @mock.patch("infrastructure.utility.cdn_arbitrary.ArbitraryGCPCdnClient.upload")
     async def test_arbitrary_upload_to_s3_gcp(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.GCP, session)
         content = io.BytesIO(b"File content")
         response = await client.post(
@@ -120,9 +120,9 @@ class TestAnswerActivityItems(BaseTest):
         return_value=(iter(("a", "b")), "txt"),
     )
     async def test_arbitrary_download_from_s3_gcp(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.GCP, session)
 
         response = await client.post(
@@ -141,8 +141,9 @@ class TestAnswerActivityItems(BaseTest):
         session: AsyncSession,
         client: TestClient,
         applet_one: AppletFull,
+        tom: User,
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.AZURE, session)
         content = io.BytesIO(b"File content")
         response = await client.post(
@@ -155,9 +156,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @mock.patch("infrastructure.utility.cdn_arbitrary.CDNClient.check_existence")
     async def test_default_storage_check_existence(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.existance_url.format(applet_id=applet_one.id),
             data={"files": [self.file_id]},
@@ -167,9 +168,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @mock.patch("infrastructure.utility.cdn_arbitrary.ArbitraryS3CdnClient.check_existence")
     async def test_arbitary_s3_aws_check_existence(
-        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull
+        self, mock_client: mock.MagicMock, session: AsyncSession, client: TestClient, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         await set_storage_type(StorageType.AWS, session)
         response = await client.post(
             self.existance_url.format(applet_id=applet_one.id),
@@ -180,8 +181,8 @@ class TestAnswerActivityItems(BaseTest):
 
     @pytest.mark.usefixtures("mock_presigned_post")
     @pytest.mark.parametrize("file_name,", ("test1.jpg", "test2.jpg"))
-    async def test_generate_upload_url(self, client: TestClient, file_name: str):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_generate_upload_url(self, client: TestClient, file_name: str, tom: User):
+        client.login(tom)
         bucket_name = "testbucket"
         domain_name = "testdomain"
         settings.cdn.bucket = bucket_name
@@ -195,7 +196,7 @@ class TestAnswerActivityItems(BaseTest):
     async def test_generate_presigned_url_for_post_answer__user_does_not_have_access_to_the_applet(
         self, client: TestClient, user: User, applet_one: AppletFull
     ):
-        await client.login(self.login_url, user.email_encrypted, "Test1234!")
+        client.login(user)
         resp = await client.post(self.answer_upload_url.format(applet_id=applet_one.id), data={"file_id": "test.txt"})
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
         result = resp.json()["result"]
@@ -206,7 +207,7 @@ class TestAnswerActivityItems(BaseTest):
     async def test_generate_presigned_url_for_answers(
         self, client: TestClient, tom: User, mocker: MockerFixture, applet_one: AppletFull
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         file_id = "test.txt"
         expected_key = CDNClient.generate_key(FileScopeEnum.ANSWER, f"{tom.id}/{applet_one.id}", file_id)
         bucket_name = "bucket"
@@ -239,7 +240,7 @@ class TestAnswerActivityItems(BaseTest):
         )
         cdn_client = CDNClient(config, env="env")
         mocker.patch("infrastructure.dependency.cdn.get_log_bucket", return_value=cdn_client)
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         file_name = "test.txt"
         resp = await client.post(self.log_upload_url.format(device_id=device_tom), data={"file_id": file_name})
         assert resp.status_code == http.HTTPStatus.OK
@@ -251,9 +252,9 @@ class TestAnswerActivityItems(BaseTest):
     @pytest.mark.usefixtures("mock_presigned_post")
     @pytest.mark.parametrize("file_name", ("test.webm", "test.WEBM"))
     async def test_generate_presigned_media_for_webm_file__conveted_in_url__upload_url_has_operations_bucket(
-        self, client: TestClient, file_name
+        self, client: TestClient, file_name, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         settings.cdn.bucket_operations = "bucket_operations"
         settings.cdn.bucket = "bucket_media"
@@ -270,9 +271,9 @@ class TestAnswerActivityItems(BaseTest):
     @pytest.mark.usefixtures("mock_presigned_post")
     @pytest.mark.parametrize("file_name", ("answer.heic", "answer.HEIC"))
     async def test_generate_presigned_for_answer_for_heic_format_not_arbitrary(
-        self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, file_name: str
+        self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, file_name: str, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         settings.cdn.bucket_operations = "bucket_operations"
         settings.cdn.bucket_answer = "bucket_answer"
@@ -292,9 +293,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @pytest.mark.usefixtures("mock_presigned_post")
     async def test_generate_presigned_for_answer_for_heic_format_arbitrary_workspace(
-        self, client: TestClient, applet_one: AppletFull, session: AsyncSession
+        self, client: TestClient, applet_one: AppletFull, session: AsyncSession, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         file_name = "answer.heic"
         settings.cdn.bucket_operations = "bucket_operations"
@@ -313,7 +314,7 @@ class TestAnswerActivityItems(BaseTest):
     async def test_answer_existance_for_heic_format_not_arbitrary(
         self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         file_name = "answer.heic"
         settings.cdn.bucket_operations = "bucket_operations"
@@ -340,7 +341,7 @@ class TestAnswerActivityItems(BaseTest):
     async def test_answer_existance_for_heic_format_for_arbitrary(
         self, client: TestClient, tom: User, applet_one: AppletFull, session: AsyncSession, mocker: MockerFixture
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         file_name = "answer.heic"
         settings.cdn.bucket_operations = "bucket_operations"
@@ -372,9 +373,9 @@ class TestAnswerActivityItems(BaseTest):
         ),
     )
     async def test_generate_upload_url__webm_to_mp3_mp4(
-        self, client: TestClient, file_name: str, target_extension: WebmTargetExtenstion, exp_file_name: str
+        self, client: TestClient, file_name: str, target_extension: WebmTargetExtenstion, exp_file_name: str, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         data = {"file_name": file_name, "target_extension": target_extension}
         if target_extension == "without extension":
             del data["target_extension"]
@@ -385,9 +386,9 @@ class TestAnswerActivityItems(BaseTest):
 
     @pytest.mark.parametrize("not_valid_extesion", ("mp3", "mp2"))
     async def test_generate_upload_url__webm_to_mp3_mp4_not_valid_extension(
-        self, client: TestClient, not_valid_extesion: str
+        self, client: TestClient, not_valid_extesion: str, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         data = {"file_name": "test.webm", "target_extension": not_valid_extesion}
         resp = await client.post(self.upload_media_url, data=data)
         assert resp.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -161,7 +161,7 @@ class TestInvite(BaseTest):
     invite_respondent_url = f"{invitation_list}/{{applet_id}}/respondent"
 
     async def test_invitation_list(self, client, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(self.invitation_list)
         assert response.status_code == http.HTTPStatus.OK
@@ -169,7 +169,7 @@ class TestInvite(BaseTest):
         assert len(response.json()["result"]) == 2
 
     async def test_applets_invitation_list(self, client, tom, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(
             self.invitation_list,
@@ -179,8 +179,8 @@ class TestInvite(BaseTest):
 
         assert len(response.json()["result"]) == 1
 
-    async def test_invitation_retrieve(self, client, applet_one):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_invitation_retrieve(self, client, applet_one, lucy):
+        client.login(lucy)
 
         response = await client.get(self.invitation_detail.format(key="6a3ab8e6-f2fa-49ae-b2db-197136677da6"))
         assert response.status_code == http.HTTPStatus.OK
@@ -188,8 +188,8 @@ class TestInvite(BaseTest):
         assert response.json()["result"]["appletId"] == str(applet_one.id)
         assert response.json()["result"]["role"] == Role.MANAGER
 
-    async def test_private_invitation_retrieve(self, client, applet_one_with_link):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_private_invitation_retrieve(self, client, applet_one_with_link, lucy):
+        client.login(lucy)
 
         response = await client.get(self.private_invitation_detail.format(key=applet_one_with_link.link))
         assert response.status_code == http.HTTPStatus.OK
@@ -198,7 +198,7 @@ class TestInvite(BaseTest):
         assert response.json()["result"]["role"] == Role.RESPONDENT
 
     async def test_admin_invite_manager_success(self, client, invitation_manager_data, tom, user, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
             invitation_manager_data,
@@ -210,7 +210,7 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].subject == "Applet 1 invitation"
 
     async def test_admin_invite_coordinator_success(self, client, invitation_coordinator_data, tom, user, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
             invitation_coordinator_data,
@@ -221,7 +221,7 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].recipients == [invitation_coordinator_data.email]
 
     async def test_admin_invite_editor_success(self, client, invitation_editor_data, tom, user, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
             invitation_editor_data,
@@ -232,7 +232,7 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].recipients == [invitation_editor_data.email]
 
     async def test_admin_invite_reviewer_success(self, client, invitation_revier_data, tom, user, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
             invitation_revier_data,
@@ -244,7 +244,7 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].subject == "Applet 1 invitation"
 
     async def test_admin_invite_respondent_success(self, client, invitation_respondent_data, tom, user, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one.id)),
             invitation_respondent_data,
@@ -258,7 +258,7 @@ class TestInvite(BaseTest):
     async def test_admin_invite_respondent_duplicate_pending_secret_id(
         self, client, invitation_respondent_data, tom, applet_one
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one.id)),
             invitation_respondent_data,
@@ -273,8 +273,8 @@ class TestInvite(BaseTest):
         assert response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json()["result"][0]["message"] == NonUniqueValue.message
 
-    async def test_manager_invite_manager_success(self, client, invitation_manager_data, applet_one_lucy_manager):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_manager_invite_manager_success(self, client, invitation_manager_data, applet_one_lucy_manager, lucy):
+        client.login(lucy)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one_lucy_manager.id)),
             invitation_manager_data,
@@ -286,9 +286,9 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].subject == "Applet 1 invitation"
 
     async def test_manager_invite_coordinator_success(
-        self, client, invitation_coordinator_data, applet_one_lucy_manager
+        self, client, invitation_coordinator_data, applet_one_lucy_manager, lucy
     ):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one_lucy_manager.id)),
             invitation_coordinator_data,
@@ -298,8 +298,8 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
         assert TestMail.mails[0].recipients == [invitation_coordinator_data.email]
 
-    async def test_manager_invite_editor_success(self, client, invitation_editor_data, applet_one_lucy_manager):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_manager_invite_editor_success(self, client, invitation_editor_data, applet_one_lucy_manager, lucy):
+        client.login(lucy)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one_lucy_manager.id)),
             invitation_editor_data,
@@ -309,8 +309,8 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
         assert TestMail.mails[0].recipients == [invitation_editor_data.email]
 
-    async def test_manager_invite_reviewer_success(self, client, invitation_revier_data, applet_one_lucy_manager):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_manager_invite_reviewer_success(self, client, invitation_revier_data, applet_one_lucy_manager, lucy):
+        client.login(lucy)
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one_lucy_manager.id)),
             invitation_revier_data,
@@ -320,8 +320,10 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
         assert TestMail.mails[0].recipients == [invitation_revier_data.email]
 
-    async def test_manager_invite_respondent_success(self, client, invitation_respondent_data, applet_one_lucy_manager):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_manager_invite_respondent_success(
+        self, client, invitation_respondent_data, applet_one_lucy_manager, lucy
+    ):
+        client.login(lucy)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one_lucy_manager.id)),
             invitation_respondent_data,
@@ -332,9 +334,9 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].recipients == [invitation_respondent_data.email]
 
     async def test_coordinator_invite_respondent_success(
-        self, client, invitation_respondent_data, applet_one_lucy_coordinator
+        self, client, invitation_respondent_data, applet_one_lucy_coordinator, lucy
     ):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one_lucy_coordinator.id)),
             invitation_respondent_data,
@@ -345,9 +347,9 @@ class TestInvite(BaseTest):
         assert TestMail.mails[0].recipients == [invitation_respondent_data.email]
 
     async def test_coordinator_invite_reviewer_success(
-        self, client, invitation_revier_data, applet_one_lucy_coordinator
+        self, client, invitation_revier_data, applet_one_lucy_coordinator, lucy
     ):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one_lucy_coordinator.id)),
             invitation_revier_data,
@@ -357,8 +359,10 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
         assert TestMail.mails[0].recipients == [invitation_revier_data.email]
 
-    async def test_coordinator_invite_manager_fail(self, client, invitation_manager_data, applet_one_lucy_coordinator):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_coordinator_invite_manager_fail(
+        self, client, invitation_manager_data, applet_one_lucy_coordinator, lucy
+    ):
+        client.login(lucy)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one_lucy_coordinator.id)),
             invitation_manager_data,
@@ -370,7 +374,7 @@ class TestInvite(BaseTest):
     async def test_editor_invite_respondent_fail(
         self, client, invitation_respondent_data, lucy, applet_one_lucy_editor
     ):
-        await client.login(self.login_url, lucy.email_encrypted, "Test123")
+        client.login(lucy)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one_lucy_editor.id)),
             invitation_respondent_data,
@@ -379,7 +383,7 @@ class TestInvite(BaseTest):
         assert response.json()["result"][0]["message"] == "Access denied to manipulate with invites of the applet."
 
     async def test_invitation_accept_and_absorb_roles(self, session, client, lucy, applet_one_lucy_roles, applet_one):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
 
         roles = await UserAppletAccessCRUD(session).get_user_roles_to_applet(lucy.id, applet_one.id)
         assert len(roles) == 3
@@ -395,7 +399,7 @@ class TestInvite(BaseTest):
         assert Role.RESPONDENT in roles
 
     async def test_private_invitation_accept(self, session, client, lucy, applet_one_with_link):
-        await client.login(self.login_url, lucy.email_encrypted, "Test123")
+        client.login(lucy)
 
         response = await client.post(self.accept_private_url.format(key=applet_one_with_link.link))
         assert response.status_code == http.HTTPStatus.OK
@@ -407,19 +411,19 @@ class TestInvite(BaseTest):
         assert access.role == Role.RESPONDENT
 
     async def test_invitation_accept_invitation_does_not_exists(self, client, tom, uuid_zero):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.post(self.accept_url.format(key=uuid_zero))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
     async def test_invitation_decline(self, client, lucy):
-        await client.login(self.login_url, lucy.email_encrypted, "Test123")
+        client.login(lucy)
 
         response = await client.delete(self.decline_url.format(key="6a3ab8e6-f2fa-49ae-b2db-197136677da6"))
         assert response.status_code == http.HTTPStatus.OK
 
     async def test_invitation_decline_wrong_invitation_does_not_exists(self, client, tom):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.delete(self.decline_url.format(key="6a3ab8e6-f2fa-49ae-b2db-197136677da9"))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
@@ -427,9 +431,9 @@ class TestInvite(BaseTest):
 
     @pytest.mark.parametrize("role", (Role.MANAGER, Role.COORDINATOR, Role.EDITOR))
     async def test_manager_invite_if_duplicate_email_and_role_not_accepted(
-        self, client, role, invitation_manager_data, applet_one_lucy_manager
+        self, client, role, invitation_manager_data, applet_one_lucy_manager, lucy
     ):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
         invitation_manager_data.role = role
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one_lucy_manager.id)),
@@ -447,7 +451,7 @@ class TestInvite(BaseTest):
     async def test_admin_invite_respondent_fail_if_duplicate_email(
         self, client, invitation_respondent_data, tom, applet_one_lucy_respondent, lucy
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_respondent_data.email = lucy.email_encrypted
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one_lucy_respondent.id)),
@@ -462,7 +466,7 @@ class TestInvite(BaseTest):
     async def test_fail_if_invite_manager_on_editor_role(
         self, client, invitation_editor_data, tom, applet_one_lucy_manager, lucy
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_editor_data.email = lucy.email_encrypted
         response = await client.post(
             self.invite_manager_url.format(applet_id=applet_one_lucy_manager.id),
@@ -475,7 +479,7 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 0
 
     async def test_invite_not_registered_user_manager(self, client, invitation_manager_data, tom, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_manager_data.email = f"new{invitation_manager_data.email}"
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
@@ -486,7 +490,7 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
 
     async def test_invite_not_registered_user_reviewer(self, client, invitation_revier_data, tom, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_revier_data.email = f"new{invitation_revier_data.email}"
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
@@ -497,7 +501,7 @@ class TestInvite(BaseTest):
         assert len(TestMail.mails) == 1
 
     async def test_invite_not_registered_user_respondent(self, client, invitation_respondent_data, tom, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_respondent_data.email = f"new{invitation_respondent_data.email}"
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one.id)),
@@ -517,7 +521,7 @@ class TestInvite(BaseTest):
     async def test_new_user_accept_decline_invitation(
         self, session, client, user_create_data, status, url, method, invitation_manager_data, tom, applet_one
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         new_email = f"new{invitation_manager_data.email}"
         invitation_manager_data.email = new_email
         # Send an invite
@@ -533,8 +537,8 @@ class TestInvite(BaseTest):
         # An invited user creates an account
         resp = await client.post("/users", data=user_create_data)
         assert resp.status_code == http.HTTPStatus.CREATED
-        resp = await client.login(self.login_url, new_email, user_create_data.password)
-        exp_user_id = resp.json()["result"]["user"]["id"]
+        client.login(uuid.UUID(resp.json()["result"]["id"]))
+        exp_user_id = resp.json()["result"]["id"]
         # Accept invite
         client_method = getattr(client, method)
         resp = await client_method(getattr(self, url).format(key=invitation_key))
@@ -548,7 +552,7 @@ class TestInvite(BaseTest):
     async def test_update_invitation_for_new_user_who_registered_after_first_invitation(
         self, client, user_create_data, invitation_manager_data, tom, applet_one
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         new_email = f"new{invitation_manager_data.email}"
         invitation_manager_data.email = new_email
         # Send an invite
@@ -563,11 +567,11 @@ class TestInvite(BaseTest):
         # An invited user creates an account
         resp = await client.post("/users", data=user_create_data)
         assert resp.status_code == http.HTTPStatus.CREATED
-        resp = await client.login(self.login_url, new_email, user_create_data.password)
-        exp_user_id = resp.json()["result"]["user"]["id"]
+        client.login(uuid.UUID(resp.json()["result"]["id"]))
+        exp_user_id = resp.json()["result"]["id"]
 
         # Update an invite
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
             invitation_manager_data,
@@ -578,7 +582,7 @@ class TestInvite(BaseTest):
     async def test_resend_invitation_with_updates_for_respondent_with_pending_invitation(
         self, session, client, invitation_respondent_data, tom, applet_one
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one.id)),
             invitation_respondent_data,
@@ -605,9 +609,9 @@ class TestInvite(BaseTest):
         assert inv.last_name == invitation_respondent_data.last_name
 
     async def test_resend_invitation_for_respondent_with_pending_invitation_only_last_key_valid(
-        self, client, invitation_respondent_data, tom, applet_one
+        self, client, invitation_respondent_data, tom, applet_one, user
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_respondent_url.format(applet_id=str(applet_one.id)),
             invitation_respondent_data,
@@ -621,7 +625,7 @@ class TestInvite(BaseTest):
         )
         assert response.status_code == http.HTTPStatus.OK
         new_key = response.json()["result"]["key"]
-        await client.login(self.login_url, invitation_respondent_data.email, "Test1234!")
+        client.login(user)
 
         response = await client.get(self.invitation_detail.format(key=old_key))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
@@ -642,8 +646,9 @@ class TestInvite(BaseTest):
         invitation_revier_data,
         tom,
         applet_one,
+        user,
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitations_urls = [
             (invitation_coordinator_data, self.invite_manager_url),
             (invitation_editor_data, self.invite_manager_url),
@@ -669,7 +674,7 @@ class TestInvite(BaseTest):
         # Only one invite
         assert count_invitations == 1
 
-        await client.login(self.login_url, invitation_respondent_data.email, "Test1234!")
+        client.login(user)
         # Check first and last invitations to test that only last is valid
         response = await client.get(self.invitation_detail.format(key=keys[0]))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
@@ -677,7 +682,7 @@ class TestInvite(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
 
     async def test_get_invitation_by_key_invitation_does_not_exist(self, client, tom, uuid_zero):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(self.invitation_detail.format(key=uuid_zero))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
@@ -690,7 +695,7 @@ class TestInvite(BaseTest):
     async def test_get_invitation_by_key_already_accpted_declined(
         self, client, url: Literal["decline_url", "accept_url"], method: Literal["delete", "post"], lucy
     ):
-        await client.login(self.login_url, lucy.email_encrypted, "Test123")
+        client.login(lucy)
         key = "6a3ab8e6-f2fa-49ae-b2db-197136677da6"
         client_method = getattr(client, method)
         url_ = getattr(self, url)
@@ -702,23 +707,23 @@ class TestInvite(BaseTest):
         assert response.json()["result"][0]["message"] == InvitationAlreadyProcessed.message
 
     async def test_get_private_invitation_by_link_does_not_exist(self, client, tom, uuid_zero):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.get(self.private_invitation_detail.format(key=uuid_zero))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
         assert response.json()["result"][0]["message"] == InvitationDoesNotExist.message
 
     async def test_private_invitation_accept_invitation_does_not_exist(self, client, tom, uuid_zero):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
 
         response = await client.post(self.accept_private_url.format(key=uuid_zero))
         assert response.status_code == http.HTTPStatus.NOT_FOUND
         assert response.json()["result"][0]["message"] == InvitationDoesNotExist.message
 
     async def test_send_invitation_to_reviewer_invitation_already_approved(
-        self, client, invitation_revier_data, tom, applet_one
+        self, client, invitation_revier_data, tom, applet_one, user
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         # send an invite
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
@@ -727,12 +732,12 @@ class TestInvite(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         key = response.json()["result"]["key"]
         # accept invite
-        await client.login(self.login_url, invitation_revier_data.email, "Test1234!")
+        client.login(user)
         response = await client.post(self.accept_url.format(key=key))
         assert response.status_code == http.HTTPStatus.OK
 
         # resend invite
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
             invitation_revier_data,
@@ -741,7 +746,7 @@ class TestInvite(BaseTest):
         assert response.json()["result"][0]["message"] == ManagerInvitationExist.message
 
     async def test_send_incorrect_role_to_invite_managers(self, client, invitation_manager_data, tom, applet_one):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         data = invitation_manager_data.dict()
         data["role"] = "notvalid"
         resp = await client.post(
@@ -757,7 +762,7 @@ class TestInvite(BaseTest):
     async def test_invite_reviewer_with_respondent_does_not_exist(
         self, client, invitation_revier_data, tom, applet_one, uuid_zero
     ):
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         invitation_revier_data.respondents = [uuid_zero]
         response = await client.post(
             self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
@@ -773,9 +778,9 @@ class TestInvite(BaseTest):
         (("accept_url", "post"), ("decline_url", "delete")),
     )
     async def test_accept_or_decline_already_processed_invitation(
-        self, client, url, method, invitation_manager_data, tom, applet_one
+        self, client, url, method, invitation_manager_data, tom, applet_one, user
     ) -> None:
-        await client.login(self.login_url, tom.email_encrypted, "Test1234!")
+        client.login(tom)
         # Send an invite
         response = await client.post(
             self.invite_manager_url.format(applet_id=str(applet_one.id)),
@@ -784,11 +789,7 @@ class TestInvite(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
 
         invitation_key = response.json()["result"]["key"]
-        resp = await client.login(
-            self.login_url,
-            invitation_manager_data.email,
-            "Test1234!",
-        )
+        client.login(user)
         # Accept invite
         client_method = getattr(client, method)
         resp = await client_method(getattr(self, url).format(key=invitation_key))

--- a/src/apps/library/tests.py
+++ b/src/apps/library/tests.py
@@ -14,6 +14,7 @@ from apps.library.errors import (
 )
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.users.domain import User
 
 DictStrAny = dict[str, Any]
 
@@ -51,8 +52,8 @@ class TestLibrary(BaseTest):
         "version",
     }
 
-    async def test_library_share(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_share(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -65,15 +66,15 @@ class TestLibrary(BaseTest):
         result = response.json()["result"]
         assert result["keywords"] == ["test", "test2"]
 
-    async def test_library_check_name(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_check_name(self, client, tom: User):
+        client.login(tom)
 
         data = dict(name="PHQ2")
         response = await client.post(self.library_check_name_url, data=data)
         assert response.status_code == http.HTTPStatus.OK
 
-    async def test_library_get_all_search(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_get_all_search(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -96,8 +97,8 @@ class TestLibrary(BaseTest):
         result = response.json()["result"]
         assert len(result) == 1
 
-    async def test_library_get_detail(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_get_detail(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -115,8 +116,8 @@ class TestLibrary(BaseTest):
         assert set(result.keys()) == self.applet_expected_keys
         assert result["keywords"] == ["test", "test2"]
 
-    async def test_library_get_url(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_get_url(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -131,8 +132,8 @@ class TestLibrary(BaseTest):
         result = response.json()["result"]
         assert isinstance(result["url"], str)
 
-    async def test_library_update(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_update(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -154,8 +155,8 @@ class TestLibrary(BaseTest):
         result = response.json()["result"]
         assert result["keywords"] == ["test", "test2", "test3"]
 
-    async def test_add_to_cart(self, client: TestClient, applet_two: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_add_to_cart(self, client: TestClient, applet_two: AppletFull, tom: User):
+        client.login(tom)
 
         create_data = dict(
             cart_items=[
@@ -212,10 +213,10 @@ class TestLibrary(BaseTest):
         ),
     )
     async def test_cart_search(
-        self, client, search, applet_fixture_name, page, limit, request, applet_three, applet_four
+        self, client, search, applet_fixture_name, page, limit, request, applet_three, applet_four, tom: User
     ):
         applet_fixture = request.getfixturevalue(applet_fixture_name)
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         create_data = dict(
             cart_items=[
@@ -273,10 +274,10 @@ class TestLibrary(BaseTest):
         assert len(response.json()["result"]) <= limit
 
     async def test_library_list_data_integrity(
-        self, client: TestClient, applet_one: AppletFull, applet_two: AppletFull
+        self, client: TestClient, applet_one: AppletFull, applet_two: AppletFull, tom: User
     ):
         applet_id = applet_one.id
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
 
         data = dict(
             applet_id=applet_id,
@@ -300,8 +301,10 @@ class TestLibrary(BaseTest):
         assert applet["image"] == applet_two.image
         assert len(applet["activities"]) == len(applet_two.activities)
 
-    async def test_applet_in_library_item_with_response_values(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_applet_in_library_item_with_response_values(
+        self, client: TestClient, applet_one: AppletFull, tom: User
+    ):
+        client.login(tom)
         response = await client.post(
             self.library_url,
             data=dict(
@@ -321,8 +324,10 @@ class TestLibrary(BaseTest):
         item = applet["activities"][0]["items"][0]
         assert item["responseValues"]
 
-    async def test_library_check_activity_item_config_fields(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_check_activity_item_config_fields(
+        self, client: TestClient, applet_one: AppletFull, tom: User
+    ):
+        client.login(tom)
 
         data = dict(
             applet_id=applet_one.id,
@@ -342,8 +347,8 @@ class TestLibrary(BaseTest):
                 for key_inner in value:
                     assert key_inner.find("_") == -1
 
-    async def test_library_applet_name_already_exists(self, client: TestClient, applet_two: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_applet_name_already_exists(self, client: TestClient, applet_two: AppletFull, tom: User):
+        client.login(tom)
         data = dict(name=applet_two.display_name)
         response = await client.post(self.library_check_name_url, data=data)
 
@@ -352,8 +357,8 @@ class TestLibrary(BaseTest):
         assert len(res) == 1
         assert res[0]["message"] == AppletNameExistsError.message
 
-    async def test_library_share_version_exists(self, client: TestClient, applet_two: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_share_version_exists(self, client: TestClient, applet_two: AppletFull, tom: User):
+        client.login(tom)
         data = dict(
             applet_id=applet_two.id,
             keywords=[],
@@ -366,8 +371,8 @@ class TestLibrary(BaseTest):
         assert len(res) == 1
         assert res[0]["message"] == AppletVersionExistsError.message
 
-    async def test_library_update_library_does_not_exist(self, client: TestClient, uuid_zero: uuid.UUID):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_library_update_library_does_not_exist(self, client: TestClient, uuid_zero: uuid.UUID, tom: User):
+        client.login(tom)
 
         data = dict(
             keywords=["test", "test2", "test3"],
@@ -384,16 +389,16 @@ class TestLibrary(BaseTest):
         assert res[0]["message"] == LibraryItemDoesNotExistError.message
 
     @pytest.mark.usefixtures("applet_two")
-    async def test_get_cart_no_cart_for_user(self, client: TestClient):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_get_cart_no_cart_for_user(self, client: TestClient, tom: User):
+        client.login(tom)
         resp = await client.get(self.library_cart_url)
         assert resp.status_code == http.HTTPStatus.OK
         assert not resp.json()["result"]
         assert resp.json()["count"] == 0
 
     @pytest.mark.usefixtures("applet_two")
-    async def test_add_to_cart_no_cart_items(self, client: TestClient):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_add_to_cart_no_cart_items(self, client: TestClient, tom: User):
+        client.login(tom)
         create_data: dict[str, list] = dict(cart_items=[])
         resp = await client.post(self.library_cart_url, data=create_data)
         assert resp.status_code == http.HTTPStatus.OK
@@ -402,9 +407,9 @@ class TestLibrary(BaseTest):
         assert resp.json()["result"]["cartItems"] is None
 
     async def test_get_library_by_id_with_flows(
-        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull
+        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         exp_activity_flow_name = "flow"
         applet_data["activity_flows"] = [
             dict(
@@ -432,9 +437,9 @@ class TestLibrary(BaseTest):
         assert activity_flwo["name"] == exp_activity_flow_name
 
     async def test_get_library_item_by_lib_id_library_does_not_exist(
-        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull, uuid_zero: uuid.UUID
+        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull, uuid_zero: uuid.UUID, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         # Update applet, change version
         resp = await client.put(f"/applets/{applet_two.id}", data=applet_data)
         assert resp.status_code == http.HTTPStatus.OK
@@ -445,9 +450,9 @@ class TestLibrary(BaseTest):
         assert res[0]["message"] == LibraryItemDoesNotExistError.message
 
     async def test_library_get_url_applet_version_does_not_exists(
-        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull
+        self, client: TestClient, applet_data: DictStrAny, applet_two: AppletFull, tom: User
     ) -> None:
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         # Update applet, change version
         resp = await client.put(f"/applets/{applet_two.id}", data=applet_data)
         assert resp.status_code == http.HTTPStatus.OK

--- a/src/apps/test_data/test_data.py
+++ b/src/apps/test_data/test_data.py
@@ -10,7 +10,7 @@ class TestData(BaseTest):
     applet_list_url = "applets"
 
     async def test_generate_applet(self, client, user):
-        await client.login(self.login_url, user.email_encrypted, "Test1234!")
+        client.login(user)
 
         response = await client.post(
             self.generate_applet_url,

--- a/src/apps/themes/tests.py
+++ b/src/apps/themes/tests.py
@@ -8,8 +8,8 @@ class TestThemes(BaseTest):
     list_url = "/themes"
     detail_url = "themes/{id}"
 
-    async def test_create_theme(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_create_theme(self, client, tom):
+        client.login(tom)
         create_data = dict(
             name="Test theme",
             logo="test/logo.png",
@@ -23,8 +23,8 @@ class TestThemes(BaseTest):
         assert response.status_code == 201, response.json()
         assert response.json()["result"]["id"]
 
-    async def test_delete_theme(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_delete_theme(self, client, tom):
+        client.login(tom)
         create_data = dict(
             name="Test theme",
             logo="test/logo.png",
@@ -43,8 +43,8 @@ class TestThemes(BaseTest):
 
         assert response.status_code == 204, response.json()
 
-    async def test_update_theme(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_update_theme(self, client, tom):
+        client.login(tom)
         create_data = dict(
             name="Test theme",
             logo="test/logo.png",
@@ -81,8 +81,8 @@ class TestThemes(BaseTest):
         assert response.json()["result"]["secondaryColor"] == Color(update_data["secondary_color"]).as_hex()
         assert response.json()["result"]["tertiaryColor"] == Color(update_data["tertiary_color"]).as_hex()
 
-    async def test_themes_list(self, client):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_themes_list(self, client, tom):
+        client.login(tom)
         response = await client.get(self.list_url)
 
         assert response.status_code == 200

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -59,8 +59,8 @@ class TestTransfer(BaseTest):
     workspace_applet_managers_list = "/workspaces/{owner_id}/applets/{applet_id}/managers"
     applet_encryption_url = f"{applet_details_url}/encryption"
 
-    async def test_initiate_transfer(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_initiate_transfer(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
         data = {"email": "lucy@gmail.com"}
 
         response = await client.post(
@@ -73,8 +73,8 @@ class TestTransfer(BaseTest):
         assert TestMail.mails[0].recipients == [data["email"]]
         assert TestMail.mails[0].subject == "Transfer ownership of an applet"
 
-    async def test_initiate_transfer_fail(self, client: TestClient):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_initiate_transfer_fail(self, client: TestClient, tom: User):
+        client.login(tom)
         data = {"email": "aloevdamirkhon@gmail.com"}
 
         response = await client.post(
@@ -84,9 +84,10 @@ class TestTransfer(BaseTest):
 
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
-    async def test_decline_transfer(self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull):
-        resp = await client.login(self.login_url, "lucy@gmail.com", "Test123")
-        lucy_id = resp.json()["result"]["user"]["id"]
+    async def test_decline_transfer(
+        self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, lucy: User
+    ):
+        client.login(lucy)
         mock = mocker.patch("apps.transfer_ownership.crud.TransferCRUD.decline_by_key")
         key = "6a3ab8e6-f2fa-49ae-b2db-197136677da7"
         response = await client.delete(
@@ -97,10 +98,10 @@ class TestTransfer(BaseTest):
         )
 
         assert response.status_code == http.HTTPStatus.NO_CONTENT
-        mock.assert_awaited_once_with(uuid.UUID(key), uuid.UUID(lucy_id))
+        mock.assert_awaited_once_with(uuid.UUID(key), lucy.id)
 
-    async def test_decline_wrong_transfer(self, client: TestClient):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_decline_wrong_transfer(self, client: TestClient, lucy: User):
+        client.login(lucy)
         response = await client.delete(
             self.response_url.format(
                 applet_id="00000000-0000-0000-0000-000000000000",
@@ -110,8 +111,8 @@ class TestTransfer(BaseTest):
 
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
-    async def test_re_decline_transfer(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_re_decline_transfer(self, client: TestClient, applet_one: AppletFull, lucy: User):
+        client.login(lucy)
         response = await client.delete(
             self.response_url.format(
                 applet_id=applet_one.id,
@@ -130,9 +131,8 @@ class TestTransfer(BaseTest):
 
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
-    async def test_accept_transfer(self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull):
-        resp = await client.login(self.login_url, "lucy@gmail.com", "Test123")
-        lucy_id = resp.json()["result"]["user"]["id"]
+    async def test_accept_transfer(self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, lucy: User):
+        client.login(lucy)
         mock = mocker.patch("apps.transfer_ownership.crud.TransferCRUD.approve_by_key")
         key = "6a3ab8e6-f2fa-49ae-b2db-197136677da7"
         response = await client.post(
@@ -143,10 +143,10 @@ class TestTransfer(BaseTest):
         )
 
         assert response.status_code == http.HTTPStatus.OK
-        mock.assert_awaited_once_with(uuid.UUID(key), uuid.UUID(lucy_id))
+        mock.assert_awaited_once_with(uuid.UUID(key), lucy.id)
 
-    async def test_accept_wrong_transfer(self, client: TestClient):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_accept_wrong_transfer(self, client: TestClient, lucy: User):
+        client.login(lucy)
         response = await client.post(
             self.response_url.format(
                 applet_id="00000000-0000-0000-0000-000000000000",
@@ -156,8 +156,8 @@ class TestTransfer(BaseTest):
 
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
-    async def test_re_accept_transfer(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+    async def test_re_accept_transfer(self, client: TestClient, applet_one: AppletFull, lucy: User):
+        client.login(lucy)
         response = await client.post(
             self.response_url.format(
                 applet_id=applet_one.id,
@@ -177,7 +177,7 @@ class TestTransfer(BaseTest):
         assert response.status_code == http.HTTPStatus.NOT_FOUND
 
     async def test_accept_transfer_report_settings_are_kept(
-        self, client: TestClient, applet_one_with_report_conf: AppletFull
+        self, client: TestClient, applet_one_with_report_conf: AppletFull, tom: User, lucy
     ):
         report_settings_keys = (
             "reportServerIp",
@@ -187,7 +187,7 @@ class TestTransfer(BaseTest):
             "reportIncludeUserId",
             "reportIncludeCaseId",
         )
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         resp = await client.get(self.applet_details_url.format(applet_id=applet_one_with_report_conf.id))
         assert resp.status_code == http.HTTPStatus.OK
         resp_data = resp.json()["result"]
@@ -195,7 +195,7 @@ class TestTransfer(BaseTest):
         for key in report_settings_keys:
             assert resp_data[key]
 
-        await client.login(self.login_url, "lucy@gmail.com", "Test123")
+        client.login(lucy)
         response = await client.post(
             self.response_url.format(
                 applet_id=applet_one_with_report_conf.id,
@@ -213,9 +213,9 @@ class TestTransfer(BaseTest):
 
     @pytest.mark.usefixtures("user")
     async def test_reinvite_manager_after_transfer(
-        self, client: TestClient, user: User, mike: User, applet_one: AppletFull
+        self, client: TestClient, user: User, mike: User, applet_one: AppletFull, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         request_data = dict(
             email=user.email_encrypted,
             first_name=user.first_name,
@@ -233,14 +233,14 @@ class TestTransfer(BaseTest):
         assert TestMail.mails[0].recipients == [request_data["email"]]
 
         # accept manager invite
-        await client.login(self.login_url, user.email_encrypted, "Test1234!")
+        client.login(user)
         key = response.json()["result"]["key"]
         response = await client.post(self.invite_accept_url.format(key=key))
         assert response.status_code == http.HTTPStatus.OK
 
         # transfer ownership to mike@gmail.com
         # initiate transfer
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         data = {"email": mike.email_encrypted}
 
         response = await client.post(
@@ -255,13 +255,13 @@ class TestTransfer(BaseTest):
         assert TestMail.mails[0].subject == "Transfer ownership of an applet"
         body = TestMail.mails[0].body
         regex = (
-            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"  # noqa: E501
+            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"
         )
         key = re.findall(regex, body)
         key = key[0][4:-14]
 
         # accept transfer
-        await client.login(self.login_url, mike.email_encrypted, "Test1234")
+        client.login(mike)
         response = await client.post(
             self.response_url.format(
                 applet_id=applet_one.id,
@@ -308,10 +308,9 @@ class TestTransfer(BaseTest):
 
     # TODO: move these tests to the unit tests for service and crud
     async def test_init_transfer__user_to_does_not_exist(
-        self, client: TestClient, session: AsyncSession, applet_one: AppletFull
+        self, client: TestClient, session: AsyncSession, applet_one: AppletFull, tom: User
     ):
-        resp = await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
-        from_user_id = resp.json()["result"]["user"]["id"]
+        client.login(tom)
         data = {"email": "userdoesnotexist@example.com"}
         applet_id = applet_one.id
         response = await client.post(
@@ -321,20 +320,19 @@ class TestTransfer(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         body = TestMail.mails[0].body
         regex = (
-            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"  # noqa: E501
+            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"
         )
         key = str(re.findall(regex, body)[0][4:-14])
         crud = TransferCRUD(session)
         transfer = await crud.get_by_key(uuid.UUID(key))
         assert transfer.to_user_id is None
-        assert transfer.from_user_id == uuid.UUID(from_user_id)
+        assert transfer.from_user_id == tom.id
 
     # TODO: move these tests to the unit tests for service and crud
     async def test_init_transfer__user_to_exists(
-        self, client: TestClient, session: AsyncSession, lucy: User, applet_one: AppletFull
+        self, client: TestClient, session: AsyncSession, lucy: User, applet_one: AppletFull, tom: User
     ):
-        resp = await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
-        from_user_id = resp.json()["result"]["user"]["id"]
+        client.login(tom)
         data = {"email": "lucy@gmail.com"}
         applet_id = applet_one.id
         response = await client.post(
@@ -344,16 +342,16 @@ class TestTransfer(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         body = TestMail.mails[0].body
         regex = (
-            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"  # noqa: E501
+            r"\bkey=[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}&action=accept"
         )
         key = str(re.findall(regex, body)[0][4:-14])
         crud = TransferCRUD(session)
         transfer = await crud.get_by_key(uuid.UUID(key))
         assert transfer.to_user_id == lucy.id
-        assert transfer.from_user_id == uuid.UUID(from_user_id)
+        assert transfer.from_user_id == tom.id
 
-    async def test_init_transfer_owner_invite_themself(self, client: TestClient, applet_one: AppletFull):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+    async def test_init_transfer_owner_invite_themself(self, client: TestClient, applet_one: AppletFull, tom: User):
+        client.login(tom)
         data = {"email": "tom@mindlogger.com"}
         applet_id = applet_one.id
         resp = await client.post(


### PR DESCRIPTION
resolves: [M2-5331](https://mindlogger.atlassian.net/browse/M2-5331)

### Objective
Replace the POST request for the `login` method of test client for API calls with generating access token and adding it to the client headers. It decrease API tests execution time on ~25-30%

[M2-5331]: https://mindlogger.atlassian.net/browse/M2-5331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ