### PR TITLE
M2-5595: Error message appears when trying to reset password

### DIFF
--- a/src/apps/users/tests/test_password.py
+++ b/src/apps/users/tests/test_password.py
@@ -163,6 +163,39 @@ class TestPassword:
         assert len(TestMail.mails) == 6
         assert TestMail.mails[0].recipients[0] == password_recovery_request.email
 
+    async def test_password_recovery_invalid(self, client: TestClient, user_create: UserCreate):
+        # Password recovery
+        password_recovery_request: PasswordRecoveryRequest = PasswordRecoveryRequest(email=user_create.dict()["email"])
+
+        response = await client.post(
+            url=self.password_recovery_url,
+            data=password_recovery_request.dict(),
+            headers={"MindLogger-Content-Source": "invalid-content-source"},
+        )
+
+        cache = RedisCache()
+
+        assert response.status_code == status.HTTP_201_CREATED
+        keys = await cache.keys(key=f"PasswordRecoveryCache:{user_create.email}*")
+        assert len(keys) == 1
+        assert password_recovery_request.email in keys[0]
+        assert len(TestMail.mails) == 7
+        assert TestMail.mails[0].recipients[0] == password_recovery_request.email
+        assert TestMail.mails[0].subject == "MindLogger"
+
+        response = await client.post(
+            url=self.password_recovery_url,
+            data=password_recovery_request.dict(),
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        new_keys = await cache.keys(key=f"PasswordRecoveryCache:{user_create.email}*")
+        assert len(keys) == 1
+        assert keys[0] != new_keys[0]
+        assert len(TestMail.mails) == 8
+        assert TestMail.mails[0].recipients[0] == password_recovery_request.email
+
     async def test_password_recovery_approve(self, client: TestClient, user_create: UserCreate):
         cache = RedisCache()
 

--- a/src/infrastructure/http/deps.py
+++ b/src/infrastructure/http/deps.py
@@ -8,10 +8,14 @@ async def get_mindlogger_content_source(
 ) -> MindloggerContentSource:
     """Fetch the Mindlogger-Content-Source HTTP header."""
 
-    return getattr(
-        MindloggerContentSource,
-        request.headers.get("mindlogger-content-source", MindloggerContentSource.web.name),
-    )
+    # Try catch for invalid header value
+    try:
+        return getattr(
+            MindloggerContentSource,
+            request.headers.get("mindlogger-content-source", MindloggerContentSource.web.name),
+        )
+    except AttributeError:
+        return MindloggerContentSource.web
 
 
 def get_language(request: Request) -> str:

--- a/src/infrastructure/http/deps.py
+++ b/src/infrastructure/http/deps.py
@@ -8,7 +8,6 @@ async def get_mindlogger_content_source(
 ) -> MindloggerContentSource:
     """Fetch the Mindlogger-Content-Source HTTP header."""
 
-    # Try catch for invalid header value
     try:
         return getattr(
             MindloggerContentSource,

--- a/src/infrastructure/http/domain.py
+++ b/src/infrastructure/http/domain.py
@@ -6,3 +6,4 @@ class MindloggerContentSource(str, Enum):
 
     web = "web"
     admin = "admin"
+    mobile = "mobile"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5595](https://mindlogger.atlassian.net/browse/M2-5595)

This PR adds support for the mobile value of the `MindLogger-Content-Source` HTTP header. #1100 started making use of this HTTP header, but didn't account for the mobile value so this fixes that. I've also added a test case for it

### 🪤 Peer Testing

Start up the API and the mobile app, and submit the forgot password form. You should be able to see the email at localhost:8085 pointing to the respondent web app password reset form (since the mobile app doesn't have this yet)

### ✏️ Notes

Make sure you have a `.env.dev` file in the mobile app folder, and not a `.env`
