### PR TITLE
M2-5808: fix saving stream ip address and port on new applet

### DIFF
--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -158,6 +158,9 @@ class AppletService:
                 encryption=create_data.encryption.dict() if create_data.encryption else None,
                 extra_fields=create_data.extra_fields,
                 creator_id=creator_id,
+                stream_enabled=create_data.stream_enabled,
+                stream_ip_address=create_data.stream_ip_address,
+                stream_port=create_data.stream_port,
             )
         )
         return AppletFull.from_orm(schema)

--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -130,9 +130,9 @@ def applet_base_data(encryption: Encryption) -> AppletBase:
         pinned_at=None,
         retention_period=None,
         retention_type=None,
-        stream_enabled=False,
-        stream_ip_address=None,
-        stream_port=None,
+        stream_enabled=True,
+        stream_ip_address="127.0.0.1",
+        stream_port=2323,
         encryption=encryption,
     )
 

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -53,6 +53,7 @@ class TestApplet:
     public_applet_detail_url = "/public/applets/{key}"
     public_applet_base_info_url = f"{public_applet_detail_url}/base_info"
 
+    @pytest.mark.run
     async def test_create_applet_with_minimal_data(
         self, client: TestClient, tom: User, applet_minimal_data: AppletCreate
     ):
@@ -68,6 +69,9 @@ class TestApplet:
 
         response = await client.get(self.applet_detail_url.format(pk=response.json()["result"]["id"]))
         assert response.status_code == http.HTTPStatus.OK
+        result = response.json()["result"]
+        assert result["streamIpAddress"] == str(applet_minimal_data.stream_ip_address)
+        assert result["streamPort"] == applet_minimal_data.stream_port
 
     async def test_creating_applet_failed_by_duplicate_activity_name(
         self, client: TestClient, tom: User, applet_minimal_data: AppletCreate

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -53,7 +53,6 @@ class TestApplet:
     public_applet_detail_url = "/public/applets/{key}"
     public_applet_base_info_url = f"{public_applet_detail_url}/base_info"
 
-    @pytest.mark.run
     async def test_create_applet_with_minimal_data(
         self, client: TestClient, tom: User, applet_minimal_data: AppletCreate
     ):
@@ -72,6 +71,16 @@ class TestApplet:
         result = response.json()["result"]
         assert result["streamIpAddress"] == str(applet_minimal_data.stream_ip_address)
         assert result["streamPort"] == applet_minimal_data.stream_port
+        assert result["displayName"] == applet_minimal_data.display_name
+        assert result["image"] == applet_minimal_data.image
+        assert result["watermark"] == applet_minimal_data.watermark
+        assert result["link"] == applet_minimal_data.link
+        assert result["pinnedAt"] == applet_minimal_data.pinned_at
+        assert result["retentionPeriod"] == applet_minimal_data.retention_period
+        assert result["retentionType"] == applet_minimal_data.retention_type
+        assert result["reportServerIp"] == applet_minimal_data.report_server_ip
+        assert result["reportPublicKey"] == applet_minimal_data.report_public_key
+        assert result["reportRecipients"] == applet_minimal_data.report_recipients
 
     async def test_creating_applet_failed_by_duplicate_activity_name(
         self, client: TestClient, tom: User, applet_minimal_data: AppletCreate


### PR DESCRIPTION

- [x] Tests for the changes have been added
(https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-5808](https://mindlogger.atlassian.net/browse/M2-5808)

Changes include:

- Save stream ip address, port, stream_enabled flag on applet creation
- Cover with test the case



