### PR TITLE
M2-5631: Add hasScore and hasSubmitted filters to applet activities endpoint

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -5,11 +5,15 @@ from fastapi import Depends
 
 from apps.activities.crud import ActivitiesCRUD
 from apps.activities.domain.activity import ActivitySingleLanguageWithItemsDetailPublic
-from apps.activities.services.activity import ActivityService
+from apps.activities.filters import AppletActivityFilter
+from apps.activities.services.activity import ActivityItemService, ActivityService
+from apps.answers.deps.preprocess_arbitrary import get_answer_session
+from apps.answers.service import AnswerService
 from apps.applets.domain.applet import AppletActivitiesDetailsPublic, AppletSingleLanguageDetailMobilePublic
 from apps.applets.service import AppletService
 from apps.authentication.deps import get_current_user
 from apps.shared.domain import Response
+from apps.shared.query_params import QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
 from apps.users import User
 from apps.workspaces.service.check_access import CheckAccessService
@@ -48,19 +52,24 @@ async def public_activity_retrieve(
 async def applet_activities(
     applet_id: uuid.UUID,
     user: User = Depends(get_current_user),
+    query_params: QueryParams = Depends(parse_query_params(AppletActivityFilter)),
     language: str = Depends(get_language),
     session=Depends(get_session),
+    answer_session=Depends(get_answer_session),
 ) -> Response[AppletActivitiesDetailsPublic]:
     async with atomic(session):
         service = AppletService(session, user.id)
         await service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
 
+        filters = AppletActivityFilter(**query_params.filters)
+
         applet_future = service.get_single_language_by_id(applet_id, language)
         subject_future = SubjectsService(session, user.id).get_by_user_and_applet(user.id, applet_id)
         activities_future = ActivityService(session, user.id).get_single_language_with_items_by_applet_id(
             applet_id, language
         )
+
         applet, subject, activities = await asyncio.gather(
             applet_future,
             subject_future,
@@ -68,6 +77,42 @@ async def applet_activities(
         )
         applet_detail = AppletSingleLanguageDetailMobilePublic.from_orm(applet)
         respondent_meta = {"nickname": subject.nickname if subject else None}
+
+        for activity in activities:
+            # Filter by `hasSubmitted` (if the activity has submitted answers)
+            if filters.has_submitted is not None:
+                latest_answer = await AnswerService(session, user.id, answer_session).get_latest_answer_by_activity_id(
+                    applet_id, activity.id
+                )
+                if filters.has_submitted:
+                    if latest_answer is None:
+                        activities.remove(activity)
+                else:
+                    if latest_answer is not None:
+                        activities.remove(activity)
+
+            # Filter by `hasScore` (if the activity has score set to activity items)
+            if filters.has_score is not None:
+                activity_items = await ActivityItemService(session).get_single_language_by_activity_id(
+                    activity.id, language
+                )
+
+                found_score = False
+                for activity_item in activity_items:
+                    if found_score:
+                        break
+
+                    options = getattr(activity_item.response_values, "options", [])
+                    for option in options:
+                        if option.score > 0:
+                            found_score = True
+
+                if filters.has_score:
+                    if not found_score:
+                        activities.remove(activity)
+                else:
+                    if found_score:
+                        activities.remove(activity)
 
     result = AppletActivitiesDetailsPublic(
         activities_details=activities,

--- a/src/apps/activities/crud/activity.py
+++ b/src/apps/activities/crud/activity.py
@@ -40,7 +40,11 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
         result = await self._execute(query)
         return result.scalars().all()
 
-    async def get_mobile_with_items_by_applet_id(self, applet_id: uuid.UUID, is_reviewable=None) -> list:
+    async def get_mobile_with_items_by_applet_id(
+        self,
+        applet_id: uuid.UUID,
+        is_reviewable=None,
+    ) -> list:
         query: Query = select(
             ActivitySchema.id,
             ActivitySchema.name,
@@ -55,9 +59,11 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
             ActivitySchema.order,
             ActivitySchema.scores_and_reports,
         )
+
         query = query.where(ActivitySchema.applet_id == applet_id)
         if isinstance(is_reviewable, bool):
             query = query.where(ActivitySchema.is_reviewable == is_reviewable)
+
         query = query.order_by(ActivitySchema.order.asc())
         result = await self._execute(query)
 

--- a/src/apps/activities/filters.py
+++ b/src/apps/activities/filters.py
@@ -1,0 +1,6 @@
+from apps.shared.query_params import BaseQueryParams
+
+
+class AppletActivityFilter(BaseQueryParams):
+    has_submitted: bool | None
+    has_score: bool | None

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -289,6 +289,16 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(AnswerSchema.applet_id == applet_id)
         query = query.where(AnswerSchema.activity_history_id.in_(activity_id))
         query = query.where(AnswerSchema.target_subject_id == subject_id)
+
+        db_result = await self._execute(query)
+        return db_result.scalars().first()
+
+    async def get_latest_answer_by_activity_id(
+        self, applet_id: uuid.UUID, activity_id: uuid.UUID
+    ) -> AnswerSchema | None:
+        query: Query = select(AnswerSchema)
+        query = query.where(AnswerSchema.applet_id == applet_id)
+        query = query.where(func.split_part(AnswerSchema.activity_history_id, "_", 1) == str(activity_id))
         query = query.order_by(AnswerSchema.created_at.desc())
         query = query.limit(1)
 

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1081,6 +1081,12 @@ class AnswerService:
     async def delete_by_subject(self, subject_id: uuid.UUID):
         await AnswersCRUD(self.answer_session).delete_by_subject(subject_id)
 
+    async def get_latest_answer_by_activity_id(
+        self, applet_id: uuid.UUID, activity_id: uuid.UUID
+    ) -> AnswerSchema | None:
+        result = await AnswersCRUD(self.answer_session).get_latest_answer_by_activity_id(applet_id, activity_id)
+        return result
+
 
 class ReportServerService:
     def __init__(self, session, arbitrary_session=None):


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5631](https://mindlogger.atlassian.net/browse/M2-5631)

Allows `/activities/applet/{applet_id}` to be filtered by `hasSubmitted` and `hasScore`.

`hasSubmitted` - Filter activities based on whether they have submitted any activities (Yes or No)
`hasScore` - Filter activities based on the availability of score (Yes or No)

### 🪤 Peer Testing

#### Testing `hasSubmitted`

1. Create a new applet with activity 
2. Call `/activities/applet/{applet_id}` endpoint with `hasSubmitted` it should return no results.
3. Add answers to this activity and run the same query again now it should return the activity that contains answers.

#### Testing `hasScore`

1. Create a new applet with activity but make sure to add a score to activity items.
2. Call `/activities/applet/{applet_id}` endpoint with `hasScore` it should return this new activity with the score definied.

### ✏️ Notes

Both `hasSubmitted` and `hasScore` can be set to true/false.