### PR TITLE
M2-5706 Change secret user id export format for admin respondent

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -381,7 +381,7 @@ async def applet_answers_export(
     total_answers = data.total_answers
     for answer in data.answers:
         if answer.is_manager:
-            answer.respondent_secret_id = f"[admin account] ({answer.respondent_email})"
+            answer.respondent_secret_id = f"[admin account] ({answer.respondent_secret_id})"
 
     if activities_last_version:
         applet = await AppletService(session, user.id).get(applet_id)

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import re
 import uuid
 
 import pytest
@@ -1042,8 +1043,12 @@ class TestAnswerActivityItems(BaseTest):
             "endDatetime", "legacyProfileId", "migratedDate", "client",
             "tzOffset", "scheduledEventId",
         }
-        assert int(answer['startDatetime'] * 1000) == 1690188679657
-        assert answer['tzOffset'] == tz_offset
+        assert int(answer["startDatetime"] * 1000) == 1690188679657
+        assert answer["tzOffset"] == tz_offset
+        assert re.match(
+            r"\[admin account\] \([0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12}\)",
+            answer["respondentSecretId"]
+        )
         # fmt: on
 
         assert set(assessment.keys()) == expected_keys


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-5706](https://mindlogger.atlassian.net/browse/M2-5706)

Change format of admin secret id in data export from `[admin account] (<email>)` to `[admin account] (<secret id>)`