### PR TITLE
M2-6075: Add new `/activity/flows/applet/{applet_id}` endpoint that returns combined activity and activity flows

### DIFF
--- a/src/apps/activities/router.py
+++ b/src/apps/activities/router.py
@@ -1,11 +1,16 @@
 from fastapi.routing import APIRouter
 from starlette import status
 
-from apps.activities.api.activities import activity_retrieve, applet_activities, public_activity_retrieve
+from apps.activities.api.activities import (
+    activity_retrieve,
+    applet_activities,
+    applet_activities_and_flows,
+    public_activity_retrieve,
+)
 from apps.activities.api.reusable_item_choices import item_choice_create, item_choice_delete, item_choice_retrieve
 from apps.activities.domain.activity import ActivitySingleLanguageWithItemsDetailPublic
 from apps.activities.domain.reusable_item_choices import PublicReusableItemChoice
-from apps.applets.domain.applet import AppletActivitiesDetailsPublic
+from apps.applets.domain.applet import AppletActivitiesAndFlowsDetailsPublic, AppletActivitiesDetailsPublic
 from apps.shared.domain import Response, ResponseMulti
 from apps.shared.domain.response import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE
 
@@ -72,3 +77,13 @@ router.get(
         **DEFAULT_OPENAPI_RESPONSE,
     },
 )(applet_activities)
+
+router.get(
+    "/flows/applet/{applet_id}",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {"model": Response[AppletActivitiesAndFlowsDetailsPublic]},
+        **AUTHENTICATION_ERROR_RESPONSES,
+        **DEFAULT_OPENAPI_RESPONSE,
+    },
+)(applet_activities_and_flows)

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -29,6 +29,7 @@ class TestActivities:
     login_url = "/auth/login"
     activity_detail = "/activities/{pk}"
     activities_applet = "/activities/applet/{applet_id}"
+    activities_flows_applet = "/activities/flows/applet/{applet_id}"
     public_activity_detail = "public/activities/{pk}"
     answer_url = "/answers"
     applet_update_url = "applets/{applet_id}"
@@ -144,6 +145,94 @@ class TestActivities:
         assert result["appletDetail"]["activityFlows"] == []
 
         assert result["respondentMeta"] == {"nickname": f"{tom.first_name} {tom.last_name}"}
+
+    async def test_activities_flows_applet(
+        self, client, applet_activity_flow: AppletFull, default_theme: Theme, tom: User
+    ):
+        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        response = await client.get(self.activities_flows_applet.format(applet_id=applet_activity_flow.id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        result = response.json()["result"]
+
+        activity = applet_activity_flow.activities[0]
+        flow = applet_activity_flow.activity_flows[0]
+        assert len(result["details"]) == 2
+
+        assert result["details"][0]["id"] == str(activity.id)
+        assert result["details"][0]["name"] == activity.name
+        assert result["details"][0]["description"] == activity.description[Language.ENGLISH]
+        assert result["details"][0]["splashScreen"] == activity.splash_screen
+        assert result["details"][0]["image"] == activity.image
+        assert result["details"][0]["showAllAtOnce"] == activity.show_all_at_once
+        assert result["details"][0]["isSkippable"] == activity.is_skippable
+        assert result["details"][0]["isReviewable"] == activity.is_reviewable
+        assert result["details"][0]["isHidden"] == activity.is_hidden
+        assert result["details"][0]["responseIsEditable"] == activity.response_is_editable
+        assert result["details"][0]["order"] == 1
+        assert result["details"][0]["type"] == "activity"
+
+        items = result["details"][0]["items"]
+        activity_item = activity.items[0]
+        assert len(items) == 1
+        assert len(items) == len(activity.items)
+        item = items[0]
+        assert item["id"] == str(activity_item.id)
+        assert item["question"] == activity_item.question[Language.ENGLISH]
+        assert item["responseType"] == activity_item.response_type
+        assert item["name"] == activity_item.name
+        assert item["isHidden"] == activity_item.is_hidden
+        assert item["conditionalLogic"] == activity_item.conditional_logic
+        assert item["allowEdit"] == activity_item.allow_edit
+        assert len(item["responseValues"]["options"]) == 1
+        option = item["responseValues"]["options"][0]
+        activity_item.response_values = cast(SingleSelectionValues, activity_item.response_values)
+        assert item["responseValues"]["paletteName"] == activity_item.response_values.palette_name
+        activity_item_option = activity_item.response_values.options[0]
+        assert option["id"] == activity_item_option.id
+        assert option["text"] == activity_item_option.text
+        assert option["image"] == activity_item_option.image
+        assert option["score"] == activity_item_option.score
+        assert option["tooltip"] == activity_item_option.tooltip
+        assert option["isHidden"] == activity_item_option.is_hidden
+        assert option["color"] == activity_item_option.color
+        assert option["alert"] == activity_item_option.alert
+        assert option["value"] == activity_item_option.value
+        config = item["config"]
+        activity_item.config = cast(SingleSelectionConfig, activity_item.config)
+        assert config["removeBackButton"] == activity_item.config.remove_back_button
+        assert config["skippableItem"] == activity_item.config.skippable_item
+        assert config["randomizeOptions"] == activity_item.config.randomize_options
+        assert config["timer"] == activity_item.config.timer
+        assert config["addScores"] == activity_item.config.add_scores
+        assert config["setAlerts"] == activity_item.config.set_alerts
+        assert config["addTooltip"] == activity_item.config.add_tooltip
+        assert config["setPalette"] == activity_item.config.set_palette
+        assert config["addTokens"] == activity_item.config.add_tokens
+        assert (
+            config["additionalResponseOption"]["textInputOption"]
+            == activity_item.config.additional_response_option.text_input_option
+        )
+        assert (
+            config["additionalResponseOption"]["textInputRequired"]
+            == activity_item.config.additional_response_option.text_input_required
+        )
+
+        assert result["details"][0]["scoresAndReports"] == activity.scores_and_reports
+
+        assert activity.id == flow.items[0].activity_id
+        assert result["details"][1]["name"] == flow.name
+        assert result["details"][1]["description"] == flow.description
+        assert result["details"][1]["type"] == "activityFlow"
+
+        items = result["details"][1]["items"]
+        flow_item = flow.items[0]
+        assert len(items) == 1
+        assert len(items) == len(flow.items)
+        item = items[0]
+        assert item["id"] == str(flow_item.id)
+        assert item["activityId"] == str(flow_item.activity_id)
+        assert item["order"] == flow_item.order
 
     async def test_public_activity_detail(self, client, applet_one_with_public_link: AppletFull):
         activity = applet_one_with_public_link.activities[0]

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -149,7 +149,7 @@ class TestActivities:
     async def test_activities_flows_applet(
         self, client, applet_activity_flow: AppletFull, default_theme: Theme, tom: User
     ):
-        await client.login(self.login_url, "tom@mindlogger.com", "Test1234!")
+        client.login(tom)
         response = await client.get(self.activities_flows_applet.format(applet_id=applet_activity_flow.id))
 
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/applets/domain/applet.py
+++ b/src/apps/applets/domain/applet.py
@@ -17,6 +17,7 @@ from apps.activity_flows.domain.flow import (
     FlowSingleLanguageDetailPublic,
     FlowSingleLanguageMobileDetailPublic,
 )
+from apps.activity_flows.domain.flow_full import PublicFlowFull
 from apps.applets.domain.base import AppletBaseInfo, AppletFetchBase, Encryption
 from apps.shared.domain import InternalModel, PublicModel, Response
 from apps.themes.domain import PublicTheme, PublicThemeMobile, Theme
@@ -134,6 +135,19 @@ class AppletActivitiesDetailsPublic(PublicModel):
     activities_details: list[ActivityLanguageWithItemsMobileDetailPublic] = Field(default_factory=list)
     applet_detail: AppletSingleLanguageDetailMobilePublic
     respondent_meta: dict | None = None
+
+
+class ActivityLanguageWithItemsMobileDetailPublicType(ActivityLanguageWithItemsMobileDetailPublic):
+    type = "activity"
+
+
+class PublicFlowFullType(PublicFlowFull):
+    type = "activityFlow"
+
+
+# Returns a combination of activity and activity flows
+class AppletActivitiesAndFlowsDetailsPublic(PublicModel):
+    details: list[ActivityLanguageWithItemsMobileDetailPublicType | PublicFlowFullType] = Field(default_factory=list)
 
 
 class AppletActivitiesBaseInfo(AppletMinimumInfo, PublicModel):


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-6075](https://mindlogger.atlassian.net/browse/M2-6075)

- Add new `/activity/flows/applet/{applet_id}` endpoint that returns combined activity and activity flows
- Add tests for `/activity/flows/applet/{applet_id}`

### 🪤 Peer Testing

Example test step:

- Call API endpoint `/activity/flows/applet/{applet_id}` with an applet ID that contains activities and activity flows and you should see a combined result of activities and activity flows

Example output: https://gist.github.com/binho/7d1e03c686b83412e3ddc22b5b211e9c

### ✏️ Notes

PR #1166 should be merged first