### PR TITLE
M2-5922: Create Update Jira Tickets GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -119,7 +119,7 @@ jobs:
             fi
           
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" --connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -44,15 +44,11 @@ jobs:
         id: ping-jenkins
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
-          echo "Repo name: ${repoName}"
           currentTag=${{ steps.get-tag.outputs.tag }}
-          echo "Current tag: ${currentTag}"
-          git fetch --tags
+          git fetch -q --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
-          echo "Release candidate tags: ${rcTags}"
           started=false
           jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
-          echo "Jenkins URL: ${jenkinsUrl}"
           
           for tagName in $rcTags
           do
@@ -66,6 +62,7 @@ jobs:
 
             echo "Checking for successful Jenkins build for GitHub tag ${tagName}"
             response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${jenkinsUrl}/api/json")
+            echo "Response: ${response}" 
             if [ "$response" == "200" ]; then
               echo "Found successful Jenkins build for GitHub tag ${tagName}: ${jenkinsUrl}"
               echo "tagName=${tagName}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -98,6 +98,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag=${{ steps.get-tag.outputs.tag }}
-          "Waiting for current build to finish.."
+          echo "Waiting for current build to finish.."
           while true; do
             echo -n "."
             result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -22,8 +22,6 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
             currentTag=${GITHUB_REF#refs/tags/}
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            currentTag=v1.3.21-rc1
           else
             currentTag=${{ github.event.inputs.tagName }}
           fi

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -9,11 +9,31 @@ on:
       tagName:
         description: 'Tag Name'
         required: true
+      jenkinsUser:
+          description: Jenkins user ID
+          required: true
+      jenkinsToken:
+          description: Jenkins API token for the user
+          required: true
+      jenkinsHost:
+          description: "Host name of the Jenkins server (starting with https://)"
+          required: true
+      jiraWebhookUrl:
+          description: URL of the Jira webhook
+          required: true
 
 jobs:
   process-release:
+    env:
+      JENKINS_USER: ${{ secrets.JENKINS_USER || github.event.inputs.jenkinsUser }}
+      JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN || github.event.inputs.jenkinsToken }}
+      JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL || github.event.inputs.jiraWebhookUrl }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set temporary env vars
+        run: |
+          echo "JENKINS_HOST=${{ env.JENKINS_HOST || github.event.inputs.jenkinsHost }}" >> $GITHUB_ENV
+
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -55,9 +75,9 @@ jobs:
             fi
 
             echo "Checking for successful Jenkins build for GitHub tag ${tagName}"
-            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
+            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
             if [ "$response" == "200" ]; then
-              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
               echo "tagName=${tagName}" >> $GITHUB_OUTPUT
               break
             fi
@@ -91,12 +111,12 @@ jobs:
           "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets=${{ steps.jira-tickets.outputs.tickets }}
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              curl -X POST -H 'Content-Type: application/json' --url "${{ secrets.JIRA_WEBHOOK_URL }}" --data "$json"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               # TODO: Determine what the possible states of `result` are

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -54,7 +54,7 @@ jobs:
             fi
 
             echo "Checking for successful Jenkins build for GitHub tag ${$tagName}"
-            response=$(curl -o /dev/null -s -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
+            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
             if [ "$response" == "200" ]; then
               echo "Found successful Jenkins build for GitHub tag ${$tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
               echo "::set-output name=tagName::$tagName"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -33,6 +33,14 @@ jobs:
           echo "Tag: ${currentTag}"
           echo "tag=${currentTag}" >> $GITHUB_OUTPUT
 
+      - name: Validate tag
+        run: |
+          git fetch -q --tags
+          if ! git tag --list | grep -qx "${{ steps.get-tag.outputs.tag }}"; then
+            echo "Not a valid tag, ending workflow"
+            exit 1
+          fi
+
       - name: Check if tag is a release candidate
         run: |
           if [[ ${{ steps.get-tag.outputs.tag }} != *"-rc"* ]]; then

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -67,7 +67,11 @@ jobs:
         run: |
           currentTag=${{ steps.get-tag.outputs.tag }}
           previousTag=${{ steps.ping-jenkins.outputs.tagName }}
-          commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
+          if [ "$previousTag" == "" ]; then
+            commitMessages=$(git log --pretty=%B $currentTag)
+          else
+            commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
+          fi
           echo "Commit messages since the last release: ${commitMessages}"
           echo "::set-output name=messages::$commitMessages"
 

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -128,7 +128,7 @@ jobs:
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"
-              break
+              exit 1
             fi
             sleep 60
           done

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -55,10 +55,10 @@ jobs:
               continue;
             fi
 
-            echo "Checking for successful Jenkins build for GitHub tag ${$tagName}"
+            echo "Checking for successful Jenkins build for GitHub tag ${tagName}"
             response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
             if [ "$response" == "200" ]; then
-              echo "Found successful Jenkins build for GitHub tag ${$tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
               echo "::set-output name=tagName::$tagName"
               break
             fi

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -96,7 +96,7 @@ jobs:
             result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
-              tickets=${{ steps.jira-tickets.outputs.tickets }}
+              tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
               curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/5000/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "httpstat.us/500" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Get current tag
         id: get-tag
@@ -40,7 +42,6 @@ jobs:
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag=${{ steps.get-tag.outputs.tag }}
-          git fetch --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
           for tagName in $rcTags

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -16,7 +16,7 @@ jobs:
       JENKINS_USER: ${{ secrets.JENKINS_USER }}
       JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
       JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
-      JENKINS_HOST: ${{ env.JENKINS_HOST }}
+      JENKINS_HOST: ${{ vars.JENKINS_HOST }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "http://10.255.255.1" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -28,7 +28,7 @@ jobs:
           if [ "${{ github.event_name }}" == "release" ]; then
             currentTag=${GITHUB_REF#refs/tags/}
           else
-            currentTag=${{ github.event.inputs.tagName }}
+            currentTag="${{ github.event.inputs.tagName }}"
           fi
           echo "Tag: ${currentTag}"
           echo "tag=${currentTag}" >> $GITHUB_OUTPUT
@@ -44,7 +44,7 @@ jobs:
         id: ping-jenkins
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
-          currentTag=${{ steps.get-tag.outputs.tag }}
+          currentTag="${{ steps.get-tag.outputs.tag }}"
           git fetch -q --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
@@ -74,8 +74,8 @@ jobs:
       - name: Determine Jira tickets from commit messages
         id: jira-tickets
         run: |
-          currentTag=${{ steps.get-tag.outputs.tag }}
-          previousTag=${{ steps.ping-jenkins.outputs.tagName }}
+          currentTag="${{ steps.get-tag.outputs.tag }}"
+          previousTag="${{ steps.ping-jenkins.outputs.tagName }}"
           if [ "$previousTag" == "" ]; then
             commitMessages=$(git log --pretty=%B $currentTag)
           else
@@ -89,7 +89,7 @@ jobs:
       - name: Periodically ping Jenkins for current tag build status
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
-          currentTag=${{ steps.get-tag.outputs.tag }}
+          currentTag="${{ steps.get-tag.outputs.tag }}"
           echo "Waiting for current build to finish.."
           while true; do
             echo -n "."

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -101,7 +101,6 @@ jobs:
               curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
-              # TODO: Determine what the possible states of `result` are
               echo "Build failed, ending workflow"
               break
             fi

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [[ ${{ steps.get-tag.outputs.tag }} != *"-rc"* ]]; then
             echo "Not a release candidate, ending workflow."
-            exit 0
+            exit 1
           fi
 
       - name: Ping Jenkins for previous successful tag
@@ -98,7 +98,6 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -56,6 +56,7 @@ jobs:
           git fetch -q --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
+          previousTag=""
 
           for tagName in $rcTags
           do
@@ -74,21 +75,24 @@ jobs:
             echo "Response: ${response}" 
             if [ "$response" == "200" ]; then
               echo "Found successful Jenkins build for GitHub tag ${tagName}: ${jenkinsUrl}"
-              echo "tagName=${tagName}" >> $GITHUB_OUTPUT
+              previousTag="${tagName}"
               break
             fi
           done
+          
+          if [ "${previousTag}" == "" ]; then
+            echo "No successful Jenkins builds found for any previous tags. Ending workflow"
+            exit 1
+          else
+            echo "tagName=${previousTag}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Determine Jira tickets from commit messages
         id: jira-tickets
         run: |
           currentTag="${{ steps.get-tag.outputs.tag }}"
           previousTag="${{ steps.ping-jenkins.outputs.tagName }}"
-          if [ "$previousTag" == "" ]; then
-            commitMessages=$(git log --pretty=%B $currentTag)
-          else
-            commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
-          fi
+          commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
           echo "Commit messages since the last release: ${commitMessages}"
           jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
           echo "Jira tickets since the last release: ${jiraTickets}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -90,7 +90,7 @@ jobs:
           "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets=${{ steps.jira-tickets.outputs.tickets }}

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -110,6 +110,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -82,7 +82,7 @@ jobs:
             commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
           fi
           echo "Commit messages since the last release: ${commitMessages}"
-          echo "messages=${$commitMessages}" >> $GITHUB_OUTPUT
+          echo "messages=${commitMessages}" >> $GITHUB_OUTPUT
 
       - name: Determine Jira tickets from commit messages
         id: jira-tickets
@@ -90,7 +90,7 @@ jobs:
           commitMessages=${{ steps.get-commits.outputs.messages }}
           jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
           echo "Jira tickets since the last release: ${jiraTickets}"
-          echo "tickets=${$jiraTickets}" >> $GITHUB_OUTPUT
+          echo "tickets=${jiraTickets}" >> $GITHUB_OUTPUT
 
       - name: Periodically ping Jenkins for current tag build status
         run: |

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -98,7 +98,6 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "httpstat.us/500" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "http://10.255.255.1" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -1,0 +1,90 @@
+name: Update Jira Tickets
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  process-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get current tag
+        id: get-tag
+        run: |
+          currentTag=${GITHUB_REF#refs/tags/}
+          echo "Tag: ${currentTag}"
+          echo "::set-output name=tag::${currentTag}"
+
+      - name: Check if tag is a release candidate
+        run: |
+          if [[ ${{ steps.get-tag.outputs.tag }} != *"-rc"* ]]; then
+            echo "Not a release candidate, ending workflow."
+            exit 0
+          fi
+
+      - name: Get previous tags
+        id: get-prev-tag
+        run: |
+          currentTag=${{ steps.get-tag.outputs.tag }}
+          git fetch --tags
+          previousTag=$(git tag --sort=-creatordate | grep -v $currentTag | grep rc | head -1)
+          echo "Previous release tag is ${previousTag}"
+          echo "::set-output name=prevTag::$previousTag"
+
+      - name: Ping Jenkins for previous successful tag
+        id: ping-jenkins
+        run: |
+          repoName=${GITHUB_REPOSITORY##*/}
+          tagName=${{ steps.get-prev-tag.outputs.prevTag }}
+          while [ -z "$tagName" ]; do
+            echo "Checking for successful Jenkins build for GitHub tag ${$tagName}"
+            response=$(curl --silent "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
+            if [ "$response" != "" ]; then
+              echo "Found successful Jenkins build for GitHub tag ${$tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+              echo "::set-output name=tagName::$tagName"
+              break
+            fi
+            tagName=$(git tag --sort=-creatordate | grep -v $tagName | grep rc | head -1)
+          done
+
+      - name: Get commit messages between tags
+        id: get-commits
+        run: |
+          currentTag=${{ steps.get-tag.outputs.tag }}
+          previousTag=${{ steps.ping-jenkins.outputs.tagName }}
+          commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
+          echo "Commit messages since the last release: ${commitMessages}"
+          echo "::set-output name=messages::$commitMessages"
+
+      - name: Determine Jira tickets from commit messages
+        id: jira-tickets
+        run: |
+          commitMessages=${{ steps.get-commits.outputs.messages }}
+          jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
+          echo "Jira tickets since the last release: ${jiraTickets}"
+          echo "::set-output name=tickets::$jiraTickets"
+
+      - name: Periodically ping Jenkins for current tag build status
+        run: |
+          repoName=${GITHUB_REPOSITORY##*/}
+          currentTag=${{ steps.get-tag.outputs.tag }}
+          "Waiting for current build to finish.."
+          while true; do
+            echo -n "."
+            result=$(curl --silent "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            if [[ "$result" == "SUCCESS" ]]; then
+              echo "Build successful! Submitting ticket numbers to Jira"
+              tickets=${{ steps.jira-tickets.outputs.tickets }}
+              json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
+              curl -X POST -H 'Content-Type: application/json' --url "${{ secrets.JIRA_WEBHOOK_URL }}" --data "$json"
+              break
+            elif [[ "$result" != "null" ]]; then
+              # TODO: Determine what the possible states of `result` are
+              echo "Build failed, ending workflow"
+              break
+            fi
+            sleep 60
+          done

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -10,6 +10,10 @@ on:
         description: 'Tag Name'
         required: true
 
+  # Temporarily allow workflow to get registered
+  # TODO: Remove this
+  push:
+
 jobs:
   process-release:
     runs-on: ubuntu-latest
@@ -22,6 +26,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
             currentTag=${GITHUB_REF#refs/tags/}
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            currentTag=v1.3.21-rc1
           else
             currentTag=${{ github.event.inputs.tagName }}
           fi

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -28,7 +28,7 @@ jobs:
             currentTag=${{ github.event.inputs.tagName }}
           fi
           echo "Tag: ${currentTag}"
-          echo "::set-output name=tag::${currentTag}"
+          echo "tag=${currentTag}" >> $GITHUB_OUTPUT
 
       - name: Check if tag is a release candidate
         run: |
@@ -59,7 +59,7 @@ jobs:
             response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
             if [ "$response" == "200" ]; then
               echo "Found successful Jenkins build for GitHub tag ${tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
-              echo "::set-output name=tagName::$tagName"
+              echo "tagName=${tagName}" >> $GITHUB_OUTPUT
               break
             fi
           done
@@ -75,7 +75,7 @@ jobs:
             commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
           fi
           echo "Commit messages since the last release: ${commitMessages}"
-          echo "::set-output name=messages::$commitMessages"
+          echo "messages=${$commitMessages}" >> $GITHUB_OUTPUT
 
       - name: Determine Jira tickets from commit messages
         id: jira-tickets
@@ -83,7 +83,7 @@ jobs:
           commitMessages=${{ steps.get-commits.outputs.messages }}
           jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
           echo "Jira tickets since the last release: ${jiraTickets}"
-          echo "::set-output name=tickets::$jiraTickets"
+          echo "tickets=${$jiraTickets}" >> $GITHUB_OUTPUT
 
       - name: Periodically ping Jenkins for current tag build status
         run: |

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -49,6 +49,13 @@ jobs:
           currentTag=${{ steps.get-tag.outputs.tag }}
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
+          jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+          
+          echo "Repo name: ${repoName}"
+          echo "Current tag: ${currentTag}"
+          echo "Release candidate tags: ${rcTags}"
+          echo "Jenkins URL: ${jenkinsUrl}"
+          
           for tagName in $rcTags
           do
             # Skip tags more recent than the current one
@@ -60,9 +67,9 @@ jobs:
             fi
 
             echo "Checking for successful Jenkins build for GitHub tag ${tagName}"
-            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
+            response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${jenkinsUrl}/api/json")
             if [ "$response" == "200" ]; then
-              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+              echo "Found successful Jenkins build for GitHub tag ${tagName}: ${jenkinsUrl}"
               echo "tagName=${tagName}" >> $GITHUB_OUTPUT
               break
             fi

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -9,31 +9,16 @@ on:
       tagName:
         description: 'Tag Name'
         required: true
-      jenkinsUser:
-          description: Jenkins user ID
-          required: true
-      jenkinsToken:
-          description: Jenkins API token for the user
-          required: true
-      jenkinsHost:
-          description: "Host name of the Jenkins server (starting with https://)"
-          required: true
-      jiraWebhookUrl:
-          description: URL of the Jira webhook
-          required: true
 
 jobs:
   process-release:
     env:
-      JENKINS_USER: ${{ secrets.JENKINS_USER || github.event.inputs.jenkinsUser }}
-      JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN || github.event.inputs.jenkinsToken }}
-      JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL || github.event.inputs.jiraWebhookUrl }}
+      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+      JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+      JENKINS_HOST: ${{ env.JENKINS_HOST }}
     runs-on: ubuntu-latest
     steps:
-      - name: Set temporary env vars
-        run: |
-          echo "JENKINS_HOST=${{ env.JENKINS_HOST || github.event.inputs.jenkinsHost }}" >> $GITHUB_ENV
-
       - name: Check out code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -3,6 +3,12 @@ name: Update Jira Tickets
 on:
   release:
     types: [created]
+  # Allows running manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      tagName:
+        description: 'Tag Name'
+        required: true
 
 jobs:
   process-release:
@@ -14,7 +20,11 @@ jobs:
       - name: Get current tag
         id: get-tag
         run: |
-          currentTag=${GITHUB_REF#refs/tags/}
+          if [ "${{ github.event_name }}" == "release" ]; then
+            currentTag=${GITHUB_REF#refs/tags/}
+          else
+            currentTag=${{ github.event.inputs.tagName }}
+          fi
           echo "Tag: ${currentTag}"
           echo "::set-output name=tag::${currentTag}"
 

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tagName:
-        description: 'Tag Name'
+        description: "Tag Name"
         required: true
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
           git fetch -q --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
-          
+
           for tagName in $rcTags
           do
             # Skip tags more recent than the current one

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -48,7 +48,6 @@ jobs:
           git fetch -q --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           started=false
-          jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
           
           for tagName in $rcTags
           do
@@ -60,7 +59,9 @@ jobs:
               continue;
             fi
 
-            echo "Checking for successful Jenkins build for GitHub tag ${tagName}"
+            jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
+            echo "Checking for successful Jenkins build for GitHub tag ${tagName} at ${jenkinsUrl}"
+            
             response=$(curl -o /dev/null --silent -w "%{http_code}\n" -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${jenkinsUrl}/api/json")
             echo "Response: ${response}" 
             if [ "$response" == "200" ]; then

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -54,7 +54,7 @@ jobs:
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag="${{ steps.get-tag.outputs.tag }}"
           git fetch -q --tags
-          rcTags=$(git tag --sort=-creatordate | grep rc)
+          rcTags=$(git tag --sort=-creatordate | grep -- -rc)
           started=false
           previousTag=""
 

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -10,10 +10,6 @@ on:
         description: 'Tag Name'
         required: true
 
-  # Temporarily allow workflow to get registered
-  # TODO: Remove this
-  push:
-
 jobs:
   process-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -105,12 +105,12 @@ jobs:
           echo "Waiting for current build to finish.."
           while true; do
             echo -n "."
-            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
+            result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/5000/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              # curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -35,29 +35,31 @@ jobs:
             exit 0
           fi
 
-      - name: Get previous tags
-        id: get-prev-tag
-        run: |
-          currentTag=${{ steps.get-tag.outputs.tag }}
-          git fetch --tags
-          previousTag=$(git tag --sort=-creatordate | grep -v $currentTag | grep rc | head -1)
-          echo "Previous release tag is ${previousTag}"
-          echo "::set-output name=prevTag::$previousTag"
-
       - name: Ping Jenkins for previous successful tag
         id: ping-jenkins
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
-          tagName=${{ steps.get-prev-tag.outputs.prevTag }}
-          while [ -z "$tagName" ]; do
+          currentTag=${{ steps.get-tag.outputs.tag }}
+          git fetch --tags
+          rcTags=$(git tag --sort=-creatordate | grep rc)
+          started=false
+          for tagName in $rcTags
+          do
+            # Skip tags more recent than the current one
+            if [ "$tagName" != "$currentTag" ] && [ "$started" = false ]; then
+              continue;
+            elif [ "$tagName" == "$currentTag" ]; then
+              started=true;
+              continue;
+            fi
+
             echo "Checking for successful Jenkins build for GitHub tag ${$tagName}"
-            response=$(curl --silent "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
-            if [ "$response" != "" ]; then
+            response=$(curl -o /dev/null -s -w "%{http_code}\n" -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}" "${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild/api/json")
+            if [ "$response" == "200" ]; then
               echo "Found successful Jenkins build for GitHub tag ${$tagName}: ${{ env.JENKINS_HOST }}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
               echo "::set-output name=tagName::$tagName"
               break
             fi
-            tagName=$(git tag --sort=-creatordate | grep -v $tagName | grep rc | head -1)
           done
 
       - name: Get commit messages between tags

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -71,8 +71,8 @@ jobs:
             fi
           done
 
-      - name: Get commit messages between tags
-        id: get-commits
+      - name: Determine Jira tickets from commit messages
+        id: jira-tickets
         run: |
           currentTag=${{ steps.get-tag.outputs.tag }}
           previousTag=${{ steps.ping-jenkins.outputs.tagName }}
@@ -82,12 +82,6 @@ jobs:
             commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
           fi
           echo "Commit messages since the last release: ${commitMessages}"
-          echo "messages=${commitMessages}" >> $GITHUB_OUTPUT
-
-      - name: Determine Jira tickets from commit messages
-        id: jira-tickets
-        run: |
-          commitMessages=${{ steps.get-commits.outputs.messages }}
           jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')
           echo "Jira tickets since the last release: ${jiraTickets}"
           echo "tickets=${jiraTickets}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Get current tag
         id: get-tag
@@ -49,6 +47,7 @@ jobs:
           echo "Repo name: ${repoName}"
           currentTag=${{ steps.get-tag.outputs.tag }}
           echo "Current tag: ${currentTag}"
+          git fetch --tags
           rcTags=$(git tag --sort=-creatordate | grep rc)
           echo "Release candidate tags: ${rcTags}"
           started=false

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -17,6 +17,9 @@ jobs:
       JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
       JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
       JENKINS_HOST: ${{ vars.JENKINS_HOST }}
+
+      # The max amount of time (in minutes) we should wait for the current Jenkins build to finish. Defaults to 6 hours
+      JENKINS_BUILD_MAX_WAIT_MINS: ${{ vars.JENKINS_BUILD_MAX_WAIT_MINS || 360 }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -103,7 +106,18 @@ jobs:
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag="${{ steps.get-tag.outputs.tag }}"
           echo "Waiting for current build to finish.."
+          
+          start_time=$(date +%s)
           while true; do
+            current_time=$(date +%s)
+            elapsed_time_mins=$(( (current_time - start_time) / 60 ))
+          
+            # Break out of the loop if we've been waiting longer than 6 hours
+            if [ $elapsed_time_mins -ge $JENKINS_BUILD_MAX_WAIT_MINS ]; then
+                echo "Timed out waiting for build to finish"
+                exit 1
+            fi
+          
             echo -n "."
             result=$(curl --silent -u "${JENKINS_USER}:${JENKINS_TOKEN}" -connect-timeout 10 -m 10 "${JENKINS_HOST}/job/${repoName}/view/tags/job/${currentTag}/lastBuild/api/json" | jq -r .result)
             if [[ "$result" == "SUCCESS" ]]; then

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -46,14 +46,13 @@ jobs:
         id: ping-jenkins
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
+          echo "Repo name: ${repoName}"
           currentTag=${{ steps.get-tag.outputs.tag }}
+          echo "Current tag: ${currentTag}"
           rcTags=$(git tag --sort=-creatordate | grep rc)
+          echo "Release candidate tags: ${rcTags}"
           started=false
           jenkinsUrl="${JENKINS_HOST}/job/${repoName}/view/tags/job/${tagName}/lastSuccessfulBuild"
-          
-          echo "Repo name: ${repoName}"
-          echo "Current tag: ${currentTag}"
-          echo "Release candidate tags: ${rcTags}"
           echo "Jenkins URL: ${jenkinsUrl}"
           
           for tagName in $rcTags

--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -110,7 +110,7 @@ jobs:
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
               json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
-              # curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
+              curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then
               echo "Build failed, ending workflow"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-5922](https://mindlogger.atlassian.net/browse/M2-5922)

This PR introduces a GitHub Actions workflow that submits a list of ticket numbers to a Jira webhook based on a number of factors.

The workflow is triggered by a GitHub release, and it collates the list of Jira ticket numbers that were worked on since the last GitHub release that had a successful Jenkins build. It then waits for the outcome of the current build (trigged by the release) and submits that list of Jira tickets if the build is successful.

My original approach to this ticket was to modify the Jenkins scripts, but I changed that because it's much simpler to have this logic in one workflow (instead of being split across multiple CodeCommit repos), and we eventually intent to move CI/CD to GitHub Actions anyway so this is a step in that direction

### 🪤 Peer Testing

Outside of creating a new GitHub release, you may refer to the following workflow runs for each of these scenarios:

- Success: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8525198096/job/23351552592
- Not a release candidate: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8526166676/job/23354815860
- Invalid tag name: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8526161440/job/23354797374
- No successful Jenkins build found: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8526428307/job/23355653176
- No Jenkins build triggered for tag/release: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8527604345/job/23359396372
- Jenkins responds with 500 error code: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8527648072/job/23359525445
- Jenkins doesn't respond: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/8527733576/job/23359784347

These were manually triggered using the GitHub CLI, which is another way you may test the workflow

```shell
gh workflow run "Update Jira Tickets" --ref "M2-5922/automate-jira-tickets" -f "tagName=v1.3.21-rc1"
```

You can pass it different tag names to explore the various scenarios. The only scenario I wasn't able to test is the one where the current build is not successful, as we would need a new release and a new Jenkins build to test that

### ✏️ Notes

This workflow is currently using Jenkins API credentials that I created from my Jenkins user. Before this is merged, we need to replace those credentials with a dedicated API user

- [ ] Replace my Jenkins API credentials with API user