### PR TITLE
M2-6057 Add proportion field for drawing item

### DIFF
--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -170,9 +170,14 @@ class NumberSelectionValues(PublicModel):
         return values
 
 
+class DrawingProportion(PublicModel):
+    enabled: bool
+
+
 class DrawingValues(PublicModel):
     drawing_example: str | None
     drawing_background: str | None
+    proportion: DrawingProportion | None = None
 
     @validator("drawing_example", "drawing_background")
     def validate_image(cls, value):

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -6,6 +6,7 @@ import pytest
 from apps.activities.domain.response_values import (
     AudioPlayerValues,
     AudioValues,
+    DrawingProportion,
     DrawingValues,
     MultiSelectionRowsValues,
     MultiSelectionValues,
@@ -73,7 +74,9 @@ def number_selection_response_values() -> NumberSelectionValues:
 
 @pytest.fixture
 def drawing_response_values(remote_image: str) -> DrawingValues:
-    return DrawingValues(drawing_background=remote_image, drawing_example=remote_image)
+    return DrawingValues(
+        drawing_background=remote_image, drawing_example=remote_image, proportion=DrawingProportion(enabled=True)
+    )
 
 
 @pytest.fixture

--- a/src/apps/activities/tests/unit/domain/test_activity_item_create.py
+++ b/src/apps/activities/tests/unit/domain/test_activity_item_create.py
@@ -233,6 +233,45 @@ def test_create_item_with_drawing_response_values(
     assert item.response_values.drawing_example == remote_image
 
 
+@pytest.mark.parametrize(
+    "proportion",
+    [
+        "N/A",
+        None,
+        dict(enabled=False),
+    ],
+)
+def test_create_item_with_drawing_response_values_proportion_from_json(
+    drawing_response_values: DrawingValues,
+    drawing_config: DrawingConfig,
+    base_item_data: BaseItemData,
+    proportion: dict | str | None,
+):
+    data = ActivityItemCreate(
+        response_type=ResponseType.DRAWING,
+        config=drawing_config,
+        response_values=drawing_response_values,
+        **base_item_data.dict(),
+    ).dict()
+
+    del data["response_values"]["proportion"]
+    if proportion != "N/A":
+        data["response_values"]["proportion"] = proportion
+
+    item = ActivityItemCreate(**data)
+
+    item.response_values = cast(DrawingValues, item.response_values)
+    if proportion != "N/A":
+        assert "proportion" in data["response_values"]
+        if isinstance(proportion, dict):
+            assert item.response_values.proportion.dict() == proportion  # type: ignore[union-attr]
+        else:
+            assert item.response_values.proportion == proportion
+    else:
+        assert "proportion" not in data["response_values"]
+        assert item.response_values.proportion is None
+
+
 def test_create_item_with_drawing_response_values_images_are_none(
     drawing_config: DrawingConfig,
     base_item_data: BaseItemData,


### PR DESCRIPTION
- [x] Tests for the changes have been added
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6057](https://mindlogger.atlassian.net/browse/M2-6057)

### ✏️ Notes
Drawing Values Request Format:
```
{
    "drawingExample": "example.jpg",
    "drawingBackground": "example.jpg",
    "proportion": {
        "enabled": true
    }
}
```