### PR TITLE
M2-6273: Fix "has_answer" flag

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -783,9 +783,11 @@ class AnswerService:
         activity_ids_with_date = await AnswersCRUD(self.answer_session).get_submitted_activity_with_last_date(
             activity_ver_ids, respondent_id
         )
-        submitted_activities = dict()
+        submitted_activities: dict[str, datetime.datetime] = {}
         for activity_history_id, submit_date in activity_ids_with_date:
-            submitted_activities[activity_history_id] = submit_date
+            activity_id = activity_history_id.split("_")[0]
+            date = submitted_activities.get(activity_id)
+            submitted_activities[activity_id] = max(submit_date, date) if date else submit_date
 
         results = []
         for activity in activities:
@@ -794,8 +796,8 @@ class AnswerService:
                     id=activity.id,
                     name=activity.name,
                     is_performance_task=activity.is_performance_task,
-                    has_answer=str(activity.id_version) in submitted_activities,
-                    last_answer_date=submitted_activities.get(str(activity.id_version)),
+                    has_answer=str(activity.id) in submitted_activities,
+                    last_answer_date=submitted_activities.get(str(activity.id)),
                 )
             )
         return results


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6273](https://mindlogger.atlassian.net/browse/M2-6273)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 🪤 Peer Testing
Go to the ‘Summary' tab and open 'ActivityST’ → responses are not displayed

1. Pass an Activity on web/mobile 
2. Go to the ‘Summary' tab and open 'ActivityST’ → responses becomes available
3. Add new Activity with SS and Text items
4. Save changes
5. Go to the ‘Summary' tab and open 'ActivityST’ 

𝐄𝐱𝐩𝐞𝐜𝐭𝐞𝐝 𝐫𝐞𝐬𝐮𝐥𝐭:
Responses should be displayed
