### PR TITLE
feature/M2 6050 update backend libraries for fastapi

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ aioredis = "~=2.0.1"
 alembic = "~=1.8.1"
 asyncpg = "~=0.27.0"
 boto3 = "==1.26.10"
-fastapi = "==0.110.0"
+fastapi = "==0.87.0"
 # The latest version of the fastapi is not taken because of the issue
 # with fastapi-mail that requires 0.21 < starlette < 0.22
 # starlette version for those deps ==0.21.0
@@ -18,7 +18,7 @@ jinja2 = "~=3.1.2"
 bcrypt = "==4.0.1"
 passlib = {version = "~=1.7.4", extras = ["bcrypt"]}
 pyOpenSSL = "~=22.1.0"
-pydantic = {extras = ["email"], version = "==1.10.15"}
+pydantic = {extras = ["email"], version = "~=1.10.2"}
 python-jose = {version = "~=3.3.0", extras = ["cryptography"]}
 python-multipart = "~=0.0.5"
 sentry-sdk = "~=1.6"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ aioredis = "~=2.0.1"
 alembic = "~=1.8.1"
 asyncpg = "~=0.27.0"
 boto3 = "==1.26.10"
-fastapi = "==0.87.0"
+fastapi = "==0.110.0"
 # The latest version of the fastapi is not taken because of the issue
 # with fastapi-mail that requires 0.21 < starlette < 0.22
 # starlette version for those deps ==0.21.0
@@ -18,7 +18,7 @@ jinja2 = "~=3.1.2"
 bcrypt = "==4.0.1"
 passlib = {version = "~=1.7.4", extras = ["bcrypt"]}
 pyOpenSSL = "~=22.1.0"
-pydantic = {extras = ["email"], version = "~=1.10.2"}
+pydantic = {extras = ["email"], version = "==1.10.15"}
 python-jose = {version = "~=3.3.0", extras = ["cryptography"]}
 python-multipart = "~=0.0.5"
 sentry-sdk = "~=1.6"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ aioredis = "~=2.0.1"
 alembic = "~=1.8.1"
 asyncpg = "~=0.27.0"
 boto3 = "==1.26.10"
-fastapi = "==0.87.0"
+fastapi = "==0.110.0"
 # The latest version of the fastapi is not taken because of the issue
 # with fastapi-mail that requires 0.21 < starlette < 0.22
 # starlette version for those deps ==0.21.0
@@ -18,7 +18,7 @@ jinja2 = "~=3.1.2"
 bcrypt = "==4.0.1"
 passlib = {version = "~=1.7.4", extras = ["bcrypt"]}
 pyOpenSSL = "~=22.1.0"
-pydantic = {extras = ["email"], version = "~=1.10.2"}
+pydantic = {extras = ["email"], version = "==1.10.15"}
 python-jose = {version = "~=3.3.0", extras = ["cryptography"]}
 python-multipart = "~=0.0.5"
 sentry-sdk = "~=1.6"
@@ -58,8 +58,8 @@ opentelemetry-sdk-extension-aws = "==2.0.1"
 
 [dev-packages]
 # Nobody knows for what its needed
-pudb = "~=2022.1"
 ipdb = "~=0.13"
+pudb = "~=2022.1"
 # Linters and Formatters
 isort = "~=5.10"
 pre-commit = "~=2.7.1"
@@ -75,7 +75,7 @@ pytest-mock = "~=3.8"
 nest-asyncio = "==1.6.0"
 gevent = "~=23.9"
 # MyPy
-mypy = "~=0.960"
+mypy = "~=1.9.0"
 types-passlib = "==1.7.7.1"
 types-python-dateutil = "~=2.8.19"
 types-python-jose = "==3.3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3cd5c3680db2dc7bc6e13020c8085cd7307d0c73512930eca9d22a6bf1cd5d0a"
+            "sha256": "29e5ca92ebf4c5f4b6750c9b860f3d503d6248c55938d5a31796051bbe6cb916"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3097,39 +3097,36 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d",
-                "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6",
-                "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf",
-                "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f",
-                "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813",
-                "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33",
-                "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad",
-                "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05",
-                "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297",
-                "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06",
-                "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd",
-                "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243",
-                "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305",
-                "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476",
-                "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711",
-                "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70",
-                "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5",
-                "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461",
-                "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab",
-                "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c",
-                "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d",
-                "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135",
-                "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93",
-                "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648",
-                "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a",
-                "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb",
-                "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3",
-                "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372",
-                "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb",
-                "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"
+                "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6",
+                "sha256:190da1ee69b427d7efa8aa0d5e5ccd67a4fb04038c380237a0d96829cb157913",
+                "sha256:2418488264eb41f69cc64a69a745fad4a8f86649af4b1041a4c64ee61fc61129",
+                "sha256:3a3c007ff3ee90f69cf0a15cbcdf0995749569b86b6d2f327af01fd1b8aee9dc",
+                "sha256:3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974",
+                "sha256:48533cdd345c3c2e5ef48ba3b0d3880b257b423e7995dada04248725c6f77374",
+                "sha256:49c87c15aed320de9b438ae7b00c1ac91cd393c1b854c2ce538e2a72d55df150",
+                "sha256:4d3dbd346cfec7cb98e6cbb6e0f3c23618af826316188d587d1c1bc34f0ede03",
+                "sha256:571741dc4194b4f82d344b15e8837e8c5fcc462d66d076748142327626a1b6e9",
+                "sha256:587ce887f75dd9700252a3abbc9c97bbe165a4a630597845c61279cf32dfbf02",
+                "sha256:5d741d3fc7c4da608764073089e5f58ef6352bedc223ff58f2f038c2c4698a89",
+                "sha256:5e6061f44f2313b94f920e91b204ec600982961e07a17e0f6cd83371cb23f5c2",
+                "sha256:61758fabd58ce4b0720ae1e2fea5cfd4431591d6d590b197775329264f86311d",
+                "sha256:653265f9a2784db65bfca694d1edd23093ce49740b2244cde583aeb134c008f3",
+                "sha256:68edad3dc7d70f2f17ae4c6c1b9471a56138ca22722487eebacfd1eb5321d612",
+                "sha256:81a10926e5473c5fc3da8abb04119a1f5811a236dc3a38d92015cb1e6ba4cb9e",
+                "sha256:85ca5fcc24f0b4aeedc1d02f93707bccc04733f21d41c88334c5482219b1ccb3",
+                "sha256:a260627a570559181a9ea5de61ac6297aa5af202f06fd7ab093ce74e7181e43e",
+                "sha256:aceb1db093b04db5cd390821464504111b8ec3e351eb85afd1433490163d60cd",
+                "sha256:b685154e22e4e9199fc95f298661deea28aaede5ae16ccc8cbb1045e716b3e04",
+                "sha256:d357423fa57a489e8c47b7c85dfb96698caba13d66e086b412298a1a0ea3b0ed",
+                "sha256:d4d5ddc13421ba3e2e082a6c2d74c2ddb3979c39b582dacd53dd5d9431237185",
+                "sha256:e49499be624dead83927e70c756970a0bc8240e9f769389cdf5714b0784ca6bf",
+                "sha256:e54396d70be04b34f31d2edf3362c1edd023246c82f1730bbf8768c28db5361b",
+                "sha256:f88566144752999351725ac623471661c9d1cd8caa0134ff98cceeea181789f4",
+                "sha256:f8a67616990062232ee4c3952f41c779afac41405806042a8126fe96e098419f",
+                "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"
             ],
             "index": "pypi",
-            "version": "==0.991"
+            "version": "==1.9.0"
         },
         "mypy-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f4df5a2f6801671e6718ba4ededf896a485e4542b92c6d89f875f1e535ab2945"
+            "sha256": "3cd5c3680db2dc7bc6e13020c8085cd7307d0c73512930eca9d22a6bf1cd5d0a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -560,7 +560,6 @@
                 "sha256:49a72f5fa6ed26be1c964f0567d931d10bf3fdeeacdf97bc26ef1cd2a44e0bda",
                 "sha256:d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.3.1"
         },
         "exceptiongroup": {
@@ -573,19 +572,19 @@
         },
         "fastapi": {
             "hashes": [
-                "sha256:07032e53df9a57165047b4f38731c38bdcc3be5493220471015e2b4b51b486a4",
-                "sha256:254453a2e22f64e2a1b4e1d8baf67d239e55b6c8165c079d25746a5220c81bb4"
+                "sha256:266775f0dcc95af9d3ef39bad55cff525329a931d5fd51930aadd4f428bf7ff3",
+                "sha256:87a1f6fb632a218222c5984be540055346a8f5d8a68e8f6fb647b1dc9934de4b"
             ],
             "index": "pypi",
-            "version": "==0.87.0"
+            "version": "==0.110.0"
         },
         "fastapi-mail": {
             "hashes": [
-                "sha256:01ae8c221dd49d7b47ddab476766ecf720d7246e114a10b84d3e4fd9c3fc34d3",
-                "sha256:6dc41bd47c2276145a5e6d7d8271082a78b19fc4d506883b277f6f0428c7fa9f"
+                "sha256:c19cee2c410321f8eb27247c2fe736fcfde04adde55de7c0284e77c8566c4607",
+                "sha256:e85783a5a05fa8f48677b965ed8f2056535d7c78b8de714359a01f45f1cd3e21"
             ],
             "index": "pypi",
-            "version": "==1.2.5"
+            "version": "==1.2.9"
         },
         "firebase-admin": {
             "hashes": [
@@ -697,11 +696,11 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:0a62b60fbd61b61a455f15d925264b3301099b67cafd2d33cf8bf151f1fca4f4",
-                "sha256:51a0385cff65ec135106e8be60ee7112557396dde5f44113ae23912baddda143"
+                "sha256:299255fdb8dddf4eb96ab99e8358991160900b4109a9e0d3e3ac127c04b1e2ee",
+                "sha256:97c0410630e2bebd194d99e91bd620dab5bc6b6ec0bf033f9a9109b700b83acb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.125.0"
+            "version": "==2.126.0"
         },
         "google-auth": {
             "hashes": [
@@ -1919,11 +1918,11 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:0efc058261bbcddeca93cad577efd36d0c8a317e44376bcfc0e097a2b3dc24a7",
-                "sha256:b1b52305ee8f7cfc48cde383496f7c11ab897cd7112b33d998b1317dc8ef9027"
+                "sha256:13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044",
+                "sha256:90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.21.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.36.3"
         },
         "taskiq": {
             "extras": [
@@ -3641,11 +3640,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a",
-                "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
+                "sha256:6e1281a57849c8a54da89ba82e5eb7c8937b9d057ff01aaf5bc9afaa3552e90f",
+                "sha256:fa7edb8428620518010928242ec17aa7132ae435319c29c1651d1cf4c4173aad"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.25.1"
+            "version": "==20.25.2"
         },
         "wcwidth": {
             "hashes": [

--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -28,8 +28,8 @@ async def activity_retrieve(
         schema = await ActivitiesCRUD(session).get_by_id(activity_id)
         await CheckAccessService(session, user.id).check_applet_detail_access(schema.applet_id)
         activity = await ActivityService(session, user.id).get_single_language_by_id(activity_id, language)
-
-    return Response(result=ActivitySingleLanguageWithItemsDetailPublic.from_orm(activity))
+    result = ActivitySingleLanguageWithItemsDetailPublic.from_orm(activity)
+    return Response(result=result)
 
 
 async def public_activity_retrieve(

--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -389,30 +389,6 @@ class PerformanceTaskType(str, Enum):
         return [i.value for i in cls]
 
 
-# ResponseTypeConfigOptions = [
-#     TextConfig,
-#     SingleSelectionConfig,
-#     MultiSelectionConfig,
-#     SliderConfig,
-#     NumberSelectionConfig,
-#     TimeRangeConfig,
-#     GeolocationConfig,
-#     DrawingConfig,
-#     PhotoConfig,
-#     VideoConfig,
-#     DateConfig,
-#     SliderRowsConfig,
-#     SingleSelectionRowsConfig,
-#     MultiSelectionRowsConfig,
-#     AudioConfig,
-#     AudioPlayerConfig,
-#     MessageConfig,
-#     TimeConfig,
-#     FlankerConfig,
-#     StabilityTrackerConfig,
-#     ABTrailsConfig,
-# ]
-
 ResponseTypeConfig = (
     TextConfig
     | SingleSelectionConfig
@@ -436,15 +412,3 @@ ResponseTypeConfig = (
     | StabilityTrackerConfig
     | ABTrailsConfig
 )
-
-# ResponseTypeValueConfig = {}
-# index = 0
-
-# for response_type in ResponseType:
-#     zipped_type_value = list(zip(ResponseValueConfigOptions, ResponseTypeConfigOptions))
-
-#     ResponseTypeValueConfig[response_type] = {
-#         "config": zipped_type_value[index][1],
-#         "value": zipped_type_value[index][0],
-#     }
-#     index += 1

--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from pydantic import Field, NonNegativeInt, PositiveInt, validator
 
@@ -24,9 +25,50 @@ from apps.activities.domain.constants_ab_trails_tablet import (
     ABTrailsNodes,
     ABTrailsTutorial,
 )
-from apps.activities.domain.response_values import ResponseValueConfigOptions
+
+# from apps.activities.domain.response_values import ResponseValueConfigOptions
 from apps.activities.errors import CorrectAnswerRequiredError
 from apps.shared.domain import PublicModel
+
+
+class ResponseType(str, Enum):
+    TEXT = "text"
+    SINGLESELECT = "singleSelect"
+    MULTISELECT = "multiSelect"
+    SLIDER = "slider"
+    NUMBERSELECT = "numberSelect"
+    TIMERANGE = "timeRange"
+    GEOLOCATION = "geolocation"
+    DRAWING = "drawing"
+    PHOTO = "photo"
+    VIDEO = "video"
+    DATE = "date"
+    SLIDERROWS = "sliderRows"
+    SINGLESELECTROWS = "singleSelectRows"
+    MULTISELECTROWS = "multiSelectRows"
+    AUDIO = "audio"
+    AUDIOPLAYER = "audioPlayer"
+    MESSAGE = "message"
+    TIME = "time"
+    FLANKER = "flanker"
+    STABILITYTRACKER = "stabilityTracker"
+    ABTRAILS = "ABTrails"
+
+    @classmethod
+    def get_non_response_types(cls):
+        return (
+            cls.TEXT,
+            cls.MESSAGE,
+            cls.TIMERANGE,
+            cls.GEOLOCATION,
+            cls.PHOTO,
+            cls.VIDEO,
+            cls.DATE,
+            cls.TIME,
+            cls.FLANKER,
+            cls.STABILITYTRACKER,
+            cls.ABTRAILS,
+        )
 
 
 class AdditionalResponseOption(PublicModel):
@@ -40,6 +82,7 @@ class _ScreenConfig(PublicModel):
 
 
 class TextConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.TEXT] | None
     max_response_length: PositiveInt = 300
     correct_answer_required: bool
     correct_answer: str | None = Field(
@@ -72,19 +115,22 @@ class _SelectionConfig(_ScreenConfig, PublicModel):
 
 
 class SingleSelectionConfig(_SelectionConfig, PublicModel):
+    type: Literal[ResponseType.SINGLESELECT] | None
     auto_advance: bool = False
 
 
 class MultiSelectionConfig(_SelectionConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.MULTISELECT] | None
 
 
 class MessageConfig(PublicModel):
+    type: Literal[ResponseType.MESSAGE] | None
     remove_back_button: bool
     timer: NonNegativeInt | None
 
 
 class SliderConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.SLIDER] | None
     add_scores: bool
     set_alerts: bool
     additional_response_option: AdditionalResponseOption
@@ -95,6 +141,7 @@ class SliderConfig(_ScreenConfig, PublicModel):
 
 
 class NumberSelectionConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.NUMBERSELECT] | None
     additional_response_option: AdditionalResponseOption
 
 
@@ -104,18 +151,19 @@ class DefaultConfig(_ScreenConfig, PublicModel):
 
 
 class TimeRangeConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.TIMERANGE] | None
 
 
 class TimeConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.TIME] | None
 
 
 class GeolocationConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.GEOLOCATION] | None
 
 
 class DrawingConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.DRAWING] | None
     additional_response_option: AdditionalResponseOption
     timer: NonNegativeInt | None
     remove_undo_button: bool = False
@@ -123,24 +171,26 @@ class DrawingConfig(_ScreenConfig, PublicModel):
 
 
 class PhotoConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.PHOTO] | None
 
 
 class VideoConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.VIDEO] | None
 
 
 class DateConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.DATE] | None
 
 
 class SliderRowsConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.SLIDERROWS] | None
     add_scores: bool
     set_alerts: bool
     timer: NonNegativeInt | None
 
 
 class SingleSelectionRowsConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.SINGLESELECTROWS] | None
     timer: NonNegativeInt | None
     add_scores: bool
     set_alerts: bool
@@ -149,14 +199,15 @@ class SingleSelectionRowsConfig(_ScreenConfig, PublicModel):
 
 
 class MultiSelectionRowsConfig(SingleSelectionRowsConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.MULTISELECTROWS] | None  # type: ignore[assignment]
 
 
 class AudioConfig(DefaultConfig, PublicModel):
-    pass
+    type: Literal[ResponseType.AUDIO] | None
 
 
 class AudioPlayerConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.AUDIOPLAYER] | None
     additional_response_option: AdditionalResponseOption
     play_once: bool
 
@@ -172,7 +223,8 @@ class Phase(str, Enum):
 
 
 class StabilityTrackerConfig(PublicModel):
-    user_input_type: InputType
+    type: Literal[ResponseType.STABILITYTRACKER] | None
+    user_input_type: InputType | None
     phase: Phase
     trials_number: int = 0
     duration_minutes: float
@@ -234,6 +286,7 @@ class FixationScreen(PublicModel):
 
 
 class FlankerConfig(PublicModel):
+    type: Literal[ResponseType.FLANKER] | None
     stimulus_trials: list[StimulusConfiguration]
     blocks: list[BlockConfiguration]
     buttons: list[ButtonConfiguration]
@@ -266,7 +319,8 @@ class ABTrailsDeviceType(str, Enum):
 
 
 class ABTrailsConfig(PublicModel):
-    device_type: ABTrailsDeviceType
+    type: Literal[ResponseType.ABTRAILS] | None
+    device_type: ABTrailsDeviceType | None
     order_name: ABTrailsOrder
     tutorials: ABTrailsTutorial | None = None
     nodes: ABTrailsNodes | None = None
@@ -324,46 +378,6 @@ class ABTrailsConfig(PublicModel):
         return value
 
 
-class ResponseType(str, Enum):
-    TEXT = "text"
-    SINGLESELECT = "singleSelect"
-    MULTISELECT = "multiSelect"
-    SLIDER = "slider"
-    NUMBERSELECT = "numberSelect"
-    TIMERANGE = "timeRange"
-    GEOLOCATION = "geolocation"
-    DRAWING = "drawing"
-    PHOTO = "photo"
-    VIDEO = "video"
-    DATE = "date"
-    SLIDERROWS = "sliderRows"
-    SINGLESELECTROWS = "singleSelectRows"
-    MULTISELECTROWS = "multiSelectRows"
-    AUDIO = "audio"
-    AUDIOPLAYER = "audioPlayer"
-    MESSAGE = "message"
-    TIME = "time"
-    FLANKER = "flanker"
-    STABILITYTRACKER = "stabilityTracker"
-    ABTRAILS = "ABTrails"
-
-    @classmethod
-    def get_non_response_types(cls):
-        return (
-            cls.TEXT,
-            cls.MESSAGE,
-            cls.TIMERANGE,
-            cls.GEOLOCATION,
-            cls.PHOTO,
-            cls.VIDEO,
-            cls.DATE,
-            cls.TIME,
-            cls.FLANKER,
-            cls.STABILITYTRACKER,
-            cls.ABTRAILS,
-        )
-
-
 class PerformanceTaskType(str, Enum):
     FLANKER = "flanker"
     GYROSCOPE = "gyroscope"
@@ -375,29 +389,29 @@ class PerformanceTaskType(str, Enum):
         return [i.value for i in cls]
 
 
-ResponseTypeConfigOptions = [
-    TextConfig,
-    SingleSelectionConfig,
-    MultiSelectionConfig,
-    SliderConfig,
-    NumberSelectionConfig,
-    TimeRangeConfig,
-    GeolocationConfig,
-    DrawingConfig,
-    PhotoConfig,
-    VideoConfig,
-    DateConfig,
-    SliderRowsConfig,
-    SingleSelectionRowsConfig,
-    MultiSelectionRowsConfig,
-    AudioConfig,
-    AudioPlayerConfig,
-    MessageConfig,
-    TimeConfig,
-    FlankerConfig,
-    StabilityTrackerConfig,
-    ABTrailsConfig,
-]
+# ResponseTypeConfigOptions = [
+#     TextConfig,
+#     SingleSelectionConfig,
+#     MultiSelectionConfig,
+#     SliderConfig,
+#     NumberSelectionConfig,
+#     TimeRangeConfig,
+#     GeolocationConfig,
+#     DrawingConfig,
+#     PhotoConfig,
+#     VideoConfig,
+#     DateConfig,
+#     SliderRowsConfig,
+#     SingleSelectionRowsConfig,
+#     MultiSelectionRowsConfig,
+#     AudioConfig,
+#     AudioPlayerConfig,
+#     MessageConfig,
+#     TimeConfig,
+#     FlankerConfig,
+#     StabilityTrackerConfig,
+#     ABTrailsConfig,
+# ]
 
 ResponseTypeConfig = (
     TextConfig
@@ -423,14 +437,14 @@ ResponseTypeConfig = (
     | ABTrailsConfig
 )
 
-ResponseTypeValueConfig = {}
-index = 0
+# ResponseTypeValueConfig = {}
+# index = 0
 
-for response_type in ResponseType:
-    zipped_type_value = list(zip(ResponseValueConfigOptions, ResponseTypeConfigOptions))
+# for response_type in ResponseType:
+#     zipped_type_value = list(zip(ResponseValueConfigOptions, ResponseTypeConfigOptions))
 
-    ResponseTypeValueConfig[response_type] = {
-        "config": zipped_type_value[index][1],
-        "value": zipped_type_value[index][0],
-    }
-    index += 1
+#     ResponseTypeValueConfig[response_type] = {
+#         "config": zipped_type_value[index][1],
+#         "value": zipped_type_value[index][0],
+#     }
+#     index += 1

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -3,8 +3,30 @@ from typing import Literal
 from pydantic import Field, NonNegativeInt, root_validator, validator
 from pydantic.color import Color
 
-from apps.activities.domain import response_type_config
-from apps.activities.domain.response_type_config import ResponseType
+from apps.activities.domain.response_type_config import (
+    ABTrailsConfig,
+    AudioConfig,
+    AudioPlayerConfig,
+    DateConfig,
+    DrawingConfig,
+    FlankerConfig,
+    GeolocationConfig,
+    MessageConfig,
+    MultiSelectionConfig,
+    MultiSelectionRowsConfig,
+    NumberSelectionConfig,
+    PhotoConfig,
+    ResponseType,
+    SingleSelectionConfig,
+    SingleSelectionRowsConfig,
+    SliderConfig,
+    SliderRowsConfig,
+    StabilityTrackerConfig,
+    TextConfig,
+    TimeConfig,
+    TimeRangeConfig,
+    VideoConfig,
+)
 from apps.activities.errors import (
     InvalidDataMatrixByOptionError,
     InvalidDataMatrixError,
@@ -357,27 +379,27 @@ def validate_none_option_flag(options):
 
 
 ResponseTypeConfigOptions = [
-    response_type_config.TextConfig,
-    response_type_config.SingleSelectionConfig,
-    response_type_config.MultiSelectionConfig,
-    response_type_config.SliderConfig,
-    response_type_config.NumberSelectionConfig,
-    response_type_config.TimeRangeConfig,
-    response_type_config.GeolocationConfig,
-    response_type_config.DrawingConfig,
-    response_type_config.PhotoConfig,
-    response_type_config.VideoConfig,
-    response_type_config.DateConfig,
-    response_type_config.SliderRowsConfig,
-    response_type_config.SingleSelectionRowsConfig,
-    response_type_config.MultiSelectionRowsConfig,
-    response_type_config.AudioConfig,
-    response_type_config.AudioPlayerConfig,
-    response_type_config.MessageConfig,
-    response_type_config.TimeConfig,
-    response_type_config.FlankerConfig,
-    response_type_config.StabilityTrackerConfig,
-    response_type_config.ABTrailsConfig,
+    TextConfig,
+    SingleSelectionConfig,
+    MultiSelectionConfig,
+    SliderConfig,
+    NumberSelectionConfig,
+    TimeRangeConfig,
+    GeolocationConfig,
+    DrawingConfig,
+    PhotoConfig,
+    VideoConfig,
+    DateConfig,
+    SliderRowsConfig,
+    SingleSelectionRowsConfig,
+    MultiSelectionRowsConfig,
+    AudioConfig,
+    AudioPlayerConfig,
+    MessageConfig,
+    TimeConfig,
+    FlankerConfig,
+    StabilityTrackerConfig,
+    ABTrailsConfig,
 ]
 
 ResponseTypeValueConfig = {}

--- a/src/apps/activities/services/activity_item_change.py
+++ b/src/apps/activities/services/activity_item_change.py
@@ -72,6 +72,8 @@ class ConfigChangeService(BaseChangeGenerator):
         if not value:
             return
         for key, val in value:
+            if key == "type":
+                continue
             if isinstance(val, bool):
                 verbose_name = self.field_name_verbose_name_map[key]
                 self._populate_bool_changes(verbose_name, val, changes)

--- a/src/apps/activities/tests/fixtures/activities.py
+++ b/src/apps/activities/tests/fixtures/activities.py
@@ -42,28 +42,36 @@ def activity_ab_trails_ipad_create() -> ActivityCreate:
                 question={"en": "Sample A"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FIRST),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FIRST, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_tablet_1",
             ),
             ActivityItemCreate(
                 question={"en": "Test A"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.SECOND),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.SECOND, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_tablet_2",
             ),
             ActivityItemCreate(
                 question={"en": "Sample B"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.THIRD),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.THIRD, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_tablet_3",
             ),
             ActivityItemCreate(
                 question={"en": "Test B"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FOURTH),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.TABLET, order_name=ABTrailsOrder.FOURTH, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_tablet_4",
             ),
         ],
@@ -84,7 +92,9 @@ def activity_ab_trails_mobile_create() -> ActivityCreate:
                 question={"en": "Sample A"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FIRST),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FIRST, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_mobile_1",
                 is_hidden=False,
             ),
@@ -92,7 +102,9 @@ def activity_ab_trails_mobile_create() -> ActivityCreate:
                 question={"en": "Test A"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.SECOND),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.SECOND, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_mobile_2",
                 is_hidden=False,
             ),
@@ -100,7 +112,9 @@ def activity_ab_trails_mobile_create() -> ActivityCreate:
                 question={"en": "Sample B"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.THIRD),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.THIRD, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_mobile_3",
                 is_hidden=False,
             ),
@@ -108,7 +122,9 @@ def activity_ab_trails_mobile_create() -> ActivityCreate:
                 question={"en": "Test B"},
                 response_type=ResponseType.ABTRAILS,
                 response_values=None,
-                config=ABTrailsConfig(device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FOURTH),
+                config=ABTrailsConfig(
+                    device_type=ABTrailsDeviceType.MOBILE, order_name=ABTrailsOrder.FOURTH, type=ResponseType.ABTRAILS
+                ),
                 name="ABTrails_mobile_4",
                 is_hidden=False,
             ),
@@ -131,7 +147,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_VSR_instructions",
                 is_hidden=False,
             ),
@@ -139,7 +155,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_Practice_instructions_1",
                 is_hidden=False,
             ),
@@ -148,6 +164,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -187,7 +204,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_Practice_instructions_2",
                 is_hidden=False,
             ),
@@ -196,6 +213,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -243,7 +261,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_Practice_instructions_3",
             ),
             ActivityItemCreate(
@@ -251,6 +269,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -298,7 +317,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_test_instructions_1",
             ),
             ActivityItemCreate(
@@ -306,6 +325,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -353,7 +373,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_test_instructions_2",
             ),
             ActivityItemCreate(
@@ -361,6 +381,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -409,7 +430,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Flanker_test_instructions_3",
             ),
             ActivityItemCreate(
@@ -417,6 +438,7 @@ def activity_flanker_create(remote_image: str, local_image_name: str) -> Activit
                 response_type=ResponseType.FLANKER,
                 response_values=None,
                 config=FlankerConfig(
+                    type=ResponseType.FLANKER,
                     stimulus_trials=[
                         StimulusConfiguration(
                             id=StimulusConfigId(str(stimulus_id)),
@@ -478,14 +500,14 @@ def actvitiy_cst_gyroscope_create() -> ActivityCreate:
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Gyroscope_General_instruction",
             ),
             ActivityItemCreate(
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Gyroscope_Calibration_Practice_instruction",
             ),
             ActivityItemCreate(
@@ -498,6 +520,7 @@ def actvitiy_cst_gyroscope_create() -> ActivityCreate:
                     trials_number=3,
                     duration_minutes=5.0,
                     lambda_slope=20.0,
+                    type=ResponseType.STABILITYTRACKER,
                 ),
                 name="Gyroscope_Calibration_Practice",
             ),
@@ -505,7 +528,7 @@ def actvitiy_cst_gyroscope_create() -> ActivityCreate:
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Gyroscope_Test_instruction",
             ),
             ActivityItemCreate(
@@ -518,6 +541,7 @@ def actvitiy_cst_gyroscope_create() -> ActivityCreate:
                     trials_number=3,
                     duration_minutes=5.0,
                     lambda_slope=20.0,
+                    type=ResponseType.STABILITYTRACKER,
                 ),
                 name="Gyroscope_Test",
             ),
@@ -538,14 +562,14 @@ def actvitiy_cst_touch_create() -> ActivityCreate:
                 question={"en": "description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Touch_General_instruction",
             ),
             ActivityItemCreate(
                 question={"en": "Description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Touch_Calibration_Practice_instruction",
             ),
             ActivityItemCreate(
@@ -558,6 +582,7 @@ def actvitiy_cst_touch_create() -> ActivityCreate:
                     trials_number=3,
                     duration_minutes=5.0,
                     lambda_slope=20.0,
+                    type=ResponseType.STABILITYTRACKER,
                 ),
                 name="Touch_Calibration_Practice",
             ),
@@ -565,7 +590,7 @@ def actvitiy_cst_touch_create() -> ActivityCreate:
                 question={"en": "Description"},
                 response_type=ResponseType.MESSAGE,
                 response_values=None,
-                config=MessageConfig(remove_back_button=True, timer=None),
+                config=MessageConfig(remove_back_button=True, timer=None, type=ResponseType.MESSAGE),
                 name="Touch_Test_instruction",
             ),
             ActivityItemCreate(
@@ -578,6 +603,7 @@ def actvitiy_cst_touch_create() -> ActivityCreate:
                     trials_number=3,
                     duration_minutes=5.0,
                     lambda_slope=20.0,
+                    type=ResponseType.STABILITYTRACKER,
                 ),
                 name="Touch_Test",
             ),

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -13,6 +13,7 @@ from apps.activities.domain.response_type_config import (
     MultiSelectionRowsConfig,
     NumberSelectionConfig,
     PhotoConfig,
+    ResponseType,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
     SliderConfig,
@@ -46,12 +47,14 @@ def single_select_config(default_config: DefaultConfig) -> SingleSelectionConfig
         add_tooltip=False,
         set_palette=False,
         **default_config.dict(),
+        type=ResponseType.SINGLESELECT,
     )
 
 
 @pytest.fixture
 def multi_select_config(single_select_config: SingleSelectionConfig) -> MultiSelectionConfig:
     data = single_select_config.dict()
+    data["type"] = ResponseType.MULTISELECT
     return MultiSelectionConfig(**data)
 
 
@@ -64,33 +67,39 @@ def slider_config(default_config: DefaultConfig) -> SliderConfig:
         show_tick_labels=False,
         continuous_slider=False,
         **default_config.dict(),
+        type=ResponseType.SLIDER,
     )
 
 
 @pytest.fixture
 def date_config(default_config: DefaultConfig) -> DateConfig:
-    return DateConfig(**default_config.dict())
+    return DateConfig(**default_config.dict(), type=ResponseType.DATE)
 
 
 @pytest.fixture
 def number_selection_config(default_config: DefaultConfig) -> NumberSelectionConfig:
-    return NumberSelectionConfig(**default_config.dict())
+    return NumberSelectionConfig(**default_config.dict(), type=ResponseType.NUMBERSELECT)
 
 
 @pytest.fixture
 def time_config(default_config: DefaultConfig) -> TimeConfig:
-    return TimeConfig(**default_config.dict())
+    return TimeConfig(**default_config.dict(), type=ResponseType.TIME)
 
 
 @pytest.fixture
 def time_range_config(default_config: DefaultConfig) -> TimeRangeConfig:
-    return TimeRangeConfig(**default_config.dict())
+    return TimeRangeConfig(**default_config.dict(), type=ResponseType.TIMERANGE)
 
 
 @pytest.fixture
 def single_select_row_config(default_config: DefaultConfig) -> SingleSelectionRowsConfig:
     return SingleSelectionRowsConfig(
-        add_scores=False, set_alerts=False, add_tooltip=False, add_tokens=None, **default_config.dict()
+        add_scores=False,
+        set_alerts=False,
+        add_tooltip=False,
+        add_tokens=None,
+        **default_config.dict(),
+        type=ResponseType.SINGLESELECTROWS,
     )
 
 
@@ -98,12 +107,14 @@ def single_select_row_config(default_config: DefaultConfig) -> SingleSelectionRo
 def multi_select_row_config(
     single_select_row_config: SingleSelectionRowsConfig,
 ) -> MultiSelectionRowsConfig:
-    return MultiSelectionRowsConfig(**single_select_row_config.dict())
+    data = single_select_row_config.dict()
+    data["type"] = ResponseType.MULTISELECTROWS
+    return MultiSelectionRowsConfig(**data)
 
 
 @pytest.fixture
 def slider_rows_config(default_config: DefaultConfig) -> SliderRowsConfig:
-    return SliderRowsConfig(add_scores=False, set_alerts=False, **default_config.dict())
+    return SliderRowsConfig(add_scores=False, set_alerts=False, **default_config.dict(), type=ResponseType.SLIDERROWS)
 
 
 @pytest.fixture
@@ -114,39 +125,40 @@ def text_config(default_config: DefaultConfig) -> TextConfig:
         numerical_response_required=False,
         response_data_identifier=False,
         response_required=False,
+        type=ResponseType.TEXT,
     )
 
 
 @pytest.fixture
 def drawing_config(default_config: DefaultConfig) -> DrawingConfig:
-    return DrawingConfig(remove_undo_button=False, **default_config.dict())
+    return DrawingConfig(remove_undo_button=False, **default_config.dict(), type=ResponseType.DRAWING)
 
 
 @pytest.fixture
 def photo_config(default_config: DefaultConfig) -> PhotoConfig:
-    return PhotoConfig(**default_config.dict())
+    return PhotoConfig(**default_config.dict(), type=ResponseType.PHOTO)
 
 
 @pytest.fixture
 def video_config(default_config: DefaultConfig) -> VideoConfig:
-    return VideoConfig(**default_config.dict())
+    return VideoConfig(**default_config.dict(), type=ResponseType.VIDEO)
 
 
 @pytest.fixture
 def geolocation_config(default_config: DefaultConfig) -> GeolocationConfig:
-    return GeolocationConfig(**default_config.dict())
+    return GeolocationConfig(**default_config.dict(), type=ResponseType.GEOLOCATION)
 
 
 @pytest.fixture
 def audio_config(default_config: DefaultConfig) -> AudioConfig:
-    return AudioConfig(**default_config.dict())
+    return AudioConfig(**default_config.dict(), type=ResponseType.AUDIO)
 
 
 @pytest.fixture
 def message_config(default_config: DefaultConfig) -> MessageConfig:
-    return MessageConfig(**default_config.dict())
+    return MessageConfig(**default_config.dict(), type=ResponseType.MESSAGE)
 
 
 @pytest.fixture
 def audio_player_config(default_config: DefaultConfig) -> AudioPlayerConfig:
-    return AudioPlayerConfig(**default_config.dict(), play_once=False)
+    return AudioPlayerConfig(**default_config.dict(), play_once=False, type=ResponseType.AUDIOPLAYER)

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 
+from apps.activities.domain.response_type_config import ResponseType
 from apps.activities.domain.response_values import (
     AudioPlayerValues,
     AudioValues,
@@ -40,6 +41,7 @@ def single_select_response_values() -> SingleSelectionValues:
                 value=0,
             )
         ],
+        type=ResponseType.SINGLESELECT,
     )
 
 
@@ -48,6 +50,7 @@ def multi_select_response_values(
     single_select_response_values: SingleSelectionValues,
 ) -> MultiSelectionValues:
     data = single_select_response_values.dict()
+    data["type"] = ResponseType.MULTISELECT
     return MultiSelectionValues(**data)
 
 
@@ -63,17 +66,22 @@ def slider_response_values() -> SliderValues:
         max_label=None,
         scores=None,
         alerts=None,
+        type=ResponseType.SLIDER,
     )
 
 
 @pytest.fixture
 def number_selection_response_values() -> NumberSelectionValues:
-    return NumberSelectionValues()
+    return NumberSelectionValues(type=ResponseType.NUMBERSELECT)
 
 
 @pytest.fixture
 def drawing_response_values(remote_image: str) -> DrawingValues:
-    return DrawingValues(drawing_background=remote_image, drawing_example=remote_image)
+    return DrawingValues(
+        drawing_background=remote_image,
+        drawing_example=remote_image,
+        type=ResponseType.DRAWING,
+    )
 
 
 @pytest.fixture
@@ -86,7 +94,8 @@ def slider_rows_response_values() -> SliderRowsValues:
                 max_label=None,
                 label="label",
             )
-        ]
+        ],
+        type=ResponseType.SLIDERROWS,
     )
 
 
@@ -127,6 +136,7 @@ def single_select_row_response_values(
         rows=[single_select_row],
         options=[single_select_row_option],
         data_matrix=[single_select_row_data_row],
+        type=ResponseType.SINGLESELECTROWS,
     )
 
 
@@ -134,15 +144,17 @@ def single_select_row_response_values(
 def multi_select_row_response_values(
     single_select_row_response_values: SingleSelectionRowsValues,
 ) -> MultiSelectionRowsValues:
-    return MultiSelectionRowsValues(**single_select_row_response_values.dict())
+    data = single_select_row_response_values.dict()
+    data["type"] = ResponseType.MULTISELECTROWS
+    return MultiSelectionRowsValues(**data)
 
 
 @pytest.fixture
 def audio_response_values() -> AudioValues:
-    return AudioValues(max_duration=1)
+    return AudioValues(max_duration=1, type=ResponseType.AUDIO)
 
 
 @pytest.fixture
 def audio_player_response_values() -> AudioPlayerValues:
     # TODO: Add some audio file
-    return AudioPlayerValues(file=None)
+    return AudioPlayerValues(file=None, type=ResponseType.AUDIOPLAYER)

--- a/src/apps/activities/tests/unit/domain/test_activity_item_create.py
+++ b/src/apps/activities/tests/unit/domain/test_activity_item_create.py
@@ -240,7 +240,7 @@ def test_create_item_with_drawing_response_values_images_are_none(
     item = ActivityItemCreate(
         response_type=ResponseType.DRAWING,
         config=drawing_config,
-        response_values=DrawingValues(drawing_background=None, drawing_example=None),
+        response_values=DrawingValues(drawing_background=None, drawing_example=None, type=ResponseType.DRAWING),
         **base_item_data.dict(),
     )
     item.response_values = cast(DrawingValues, item.response_values)
@@ -526,9 +526,18 @@ def test_slider_rows_item_with_alert(
 
 
 @pytest.mark.parametrize("fixture_name", ("single_select_row_item_create", "multi_select_row_item_create"))
-def test_single_multi_select_item_withou_datamatrix(request, fixture_name: str):
+def test_single_multi_select_item_row_without_datamatrix(request, fixture_name: str):
     fixture = request.getfixturevalue(fixture_name)
     data = fixture.dict()
     data["response_values"].pop("data_matrix", None)
     item = ActivityItemCreate(**data)
     assert item.response_values.data_matrix is None  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize("fixture_name", ("single_select_row_item_create", "multi_select_row_item_create"))
+def test_single_multi_select_item_row__option_value_is_none(request, fixture_name: str):
+    fixture = request.getfixturevalue(fixture_name)
+    data = fixture.dict()
+    data["response_values"]["options"][0]["value"] = None
+    item = ActivityItemCreate(**data)
+    assert item.response_values.data_matrix[0].options[0].value == 0  # type: ignore

--- a/src/apps/activities/tests/unit/test_activity_item_change.py
+++ b/src/apps/activities/tests/unit/test_activity_item_change.py
@@ -59,6 +59,7 @@ def single_selection_values() -> SingleSelectionValues:
         options=[
             _SingleSelectionValue(id=str(TEST_UUID), text="o1", value=0),
         ],
+        type=ResponseType.SINGLESELECT,
     )
 
 
@@ -75,6 +76,7 @@ def single_selection_config() -> SingleSelectionConfig:
         remove_back_button=False,
         set_palette=False,
         skippable_item=False,
+        type=ResponseType.SINGLESELECT,
     )
 
 
@@ -90,7 +92,8 @@ def slider_rows_values() -> SliderRowsValues:
                 min_value=0,
                 max_value=5,
             )
-        ]
+        ],
+        type=ResponseType.SLIDERROWS,
     )
 
 
@@ -99,6 +102,7 @@ def single_select_rows_values() -> SingleSelectionRowsValues:
     return SingleSelectionRowsValues(
         rows=[_SingleSelectionRow(id=str(TEST_UUID), row_name="row1")],
         options=[_SingleSelectionOption(id=str(TEST_UUID), text="option 1")],
+        type=ResponseType.SINGLESELECTROWS,
     )
 
 

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -22,7 +22,7 @@ from apps.answers.domain import (
     AppletCompletedEntities,
     AssessmentAnswerCreate,
     AssessmentAnswerPublic,
-    IdentifierPublic,
+    Identifier,
     IdentifiersQueryParams,
     PublicAnswerDates,
     PublicAnswerExport,
@@ -235,7 +235,7 @@ async def applet_answer_assessment_delete(
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
-) -> Response:
+) -> None:
     await AppletService(session, user.id).exist_by_id(applet_id)
     await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
     service = AnswerService(session=session, user_id=user.id, arbitrary_session=answer_session)
@@ -247,7 +247,6 @@ async def applet_answer_assessment_delete(
     async with atomic(session):
         async with atomic(answer_session):
             await service.delete_assessment(assessment_id)
-    return Response()
 
 
 async def applet_activity_assessment_retrieve(
@@ -272,7 +271,7 @@ async def applet_activity_identifiers_retrieve(
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
-) -> ResponseMulti[IdentifierPublic]:
+) -> ResponseMulti[Identifier]:
     await AppletService(session, user.id).exist_by_id(applet_id)
     await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
     identifiers = await AnswerService(session, user.id, answer_session).get_activity_identifiers(

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -372,11 +372,6 @@ class VersionPublic(PublicModel):
     created_at: datetime.datetime
 
 
-class IdentifierPublic(PublicModel):
-    identifier: str
-    user_public_key: str
-
-
 class SafeApplet(AppletBaseInfo, InternalModel):
     id: uuid.UUID
     version: str

--- a/src/apps/answers/tasks.py
+++ b/src/apps/answers/tasks.py
@@ -50,9 +50,8 @@ async def create_report(
             if not response:
                 return
             file = UploadFile(
-                response.email.attachment,
                 io.BytesIO(base64.b64decode(response.pdf.encode())),
-                "application/pdf",
+                filename=response.email.attachment,
             )
 
             mail_service = MailingService()

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -88,7 +88,7 @@ async def applet_retrieve(
     user: User = Depends(get_current_user),
     language: str = Depends(get_language),
     session=Depends(get_session),
-) -> Response[AppletSingleLanguageDetailPublic]:
+) -> AppletRetrieveResponse[AppletSingleLanguageDetailPublic]:
     async with atomic(session):
         service = AppletService(session, user.id)
         await service.exist_by_id(applet_id)

--- a/src/apps/applets/domain/applet.py
+++ b/src/apps/applets/domain/applet.py
@@ -1,7 +1,9 @@
 import datetime
 import uuid
+from typing import Generic
 
 from pydantic import Field, IPvAnyAddress, PositiveInt, root_validator
+from pydantic.generics import GenericModel
 
 from apps.activities.domain.activity import (
     ActivityBaseInfo,
@@ -18,7 +20,7 @@ from apps.activity_flows.domain.flow import (
     FlowSingleLanguageMobileDetailPublic,
 )
 from apps.applets.domain.base import AppletBaseInfo, AppletFetchBase, Encryption
-from apps.shared.domain import InternalModel, PublicModel, Response
+from apps.shared.domain import InternalModel, PublicModel, _BaseModel
 from apps.themes.domain import PublicTheme, PublicThemeMobile, Theme
 from apps.workspaces.domain.constants import DataRetention
 
@@ -126,7 +128,8 @@ class AppletDataRetention(InternalModel):
         return values
 
 
-class AppletRetrieveResponse(Response[AppletSingleLanguageDetailPublic]):
+class AppletRetrieveResponse(PublicModel, GenericModel, Generic[_BaseModel]):
+    result: _BaseModel
     respondent_meta: dict | None = None
 
 

--- a/src/apps/applets/domain/applet_create_update.py
+++ b/src/apps/applets/domain/applet_create_update.py
@@ -37,10 +37,6 @@ class AppletCreate(AppletReportConfigurationBase, AppletBase, InternalModel):
             activity_names.add(activity.name)
             activity_keys.add(activity.key)
             assessments_count += int(activity.is_reviewable)
-            # for item in activity.items:
-            #     item.config.type = item.response_type
-            #     if item.response_values:
-            #         item.response_values.type = item.response_type
 
         if assessments_count > 1:
             raise AssessmentLimitExceed()
@@ -85,10 +81,6 @@ class AppletUpdate(AppletBase, PublicModel):
             activity_keys.add(activity.key)
 
             assessments_count += int(activity.is_reviewable)
-            # for item in activity.items:
-            #     item.config.type = item.response_type
-            #     if item.response_values:
-            #         item.response_values.type = item.response_type
 
         if assessments_count > 1:
             raise AssessmentLimitExceed()

--- a/src/apps/applets/domain/applet_create_update.py
+++ b/src/apps/applets/domain/applet_create_update.py
@@ -37,6 +37,10 @@ class AppletCreate(AppletReportConfigurationBase, AppletBase, InternalModel):
             activity_names.add(activity.name)
             activity_keys.add(activity.key)
             assessments_count += int(activity.is_reviewable)
+            # for item in activity.items:
+            #     item.config.type = item.response_type
+            #     if item.response_values:
+            #         item.response_values.type = item.response_type
 
         if assessments_count > 1:
             raise AssessmentLimitExceed()
@@ -81,6 +85,10 @@ class AppletUpdate(AppletBase, PublicModel):
             activity_keys.add(activity.key)
 
             assessments_count += int(activity.is_reviewable)
+            # for item in activity.items:
+            #     item.config.type = item.response_type
+            #     if item.response_values:
+            #         item.response_values.type = item.response_type
 
         if assessments_count > 1:
             raise AssessmentLimitExceed()

--- a/src/apps/applets/router.py
+++ b/src/apps/applets/router.py
@@ -31,6 +31,7 @@ from apps.applets.domain.applet import (
     AppletActivitiesBaseInfo,
     AppletRetrieveResponse,
     AppletSingleLanguageDetailForPublic,
+    AppletSingleLanguageDetailPublic,
     AppletSingleLanguageInfoPublic,
 )
 from apps.applets.domain.applet_link import AppletLink
@@ -60,7 +61,7 @@ router.get(
     "/{applet_id}",
     status_code=status.HTTP_200_OK,
     responses={
-        status.HTTP_200_OK: {"model": AppletRetrieveResponse},
+        status.HTTP_200_OK: {"model": AppletRetrieveResponse[AppletSingleLanguageDetailPublic]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },

--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -85,6 +85,7 @@ def item_response_values() -> SingleSelectionValues:
                 value=0,
             )
         ],
+        type=ResponseType.SINGLESELECT,
     )
 
 
@@ -101,6 +102,7 @@ def item_config() -> SingleSelectionConfig:
         remove_back_button=False,
         skippable_item=False,
         additional_response_option=AdditionalResponseOption(text_input_option=False, text_input_required=False),
+        type=ResponseType.SINGLESELECT,
     )
 
 

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -346,6 +346,7 @@ class TestApplet:
         assert result["displayName"] == applet_one_with_flow.display_name
         assert len(result["activities"]) == 1
         assert len(result["activityFlows"]) == 1
+        assert response.json()["respondentMeta"]["nickname"] == tom.get_full_name()
 
     async def test_public_applet_detail(self, client: TestClient, applet_one_with_public_link: AppletFull):
         response = await client.get(self.public_applet_detail_url.format(key=applet_one_with_public_link.link))

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -251,7 +251,10 @@ class TestActivityItems:
         response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
         assert response.status_code == http.HTTPStatus.CREATED
         response_values = response.json()["result"]["activities"][0]["items"][0]["responseValues"]
-        assert response_values["options"][0]["value"] == 0
+        if "dataMatrix" in response_values:
+            assert response_values["dataMatrix"][0]["options"][0]["value"] == 0
+        else:
+            assert response_values["options"][0]["value"] == 0
 
     @pytest.mark.parametrize("response_type", (ResponseType.SINGLESELECT, ResponseType.MULTISELECT))
     async def test_create_applet_single_multi_select_response_values_value_null_auto_set_value(

--- a/src/apps/file/api/file.py
+++ b/src/apps/file/api/file.py
@@ -96,6 +96,7 @@ async def _copy(file: UploadFile, path: str):
 
 
 async def convert_not_supported_audio(file: UploadFile):
+    file.filename = cast(str, file.filename)
     type_ = mimetypes.guess_type(file.filename)[0] or ""
     if type_.lower() == "video/webm":
         # store file, create task to convert
@@ -122,6 +123,7 @@ async def convert_not_supported_audio(file: UploadFile):
 
 
 async def convert_not_supported_image(file: UploadFile):
+    file.filename = cast(str, file.filename)
     type_ = mimetypes.guess_type(file.filename)[0] or ""
     if type_.lower() == "image/heic":
         # store file, create task to convert
@@ -343,6 +345,7 @@ async def logs_upload(
 ) -> Response[AnswerUploadedFile]:
     service = LogFileService(user.id, cdn_client)
     try:
+        file.filename = cast(str, file.filename)
         key = service.key(device_id=device_id, file_name=file.filename)
         await service.upload(device_id, file, file_id)
         url = await cdn_client.generate_presigned_url(key)

--- a/src/apps/invitations/services.py
+++ b/src/apps/invitations/services.py
@@ -325,7 +325,7 @@ class InvitationsService:
         )
         access, invitation = await asyncio.gather(access_coro, invitation_coro)
         if access or invitation:
-            raise NonUniqueValue(message=f"In applet with id {applet_id} " f"secret User Id is non-unique.")
+            raise NonUniqueValue(message=f"In applet with id {applet_id} secret User Id is non-unique.")
 
     async def _do_respondents_exist(
         self,

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -265,7 +265,10 @@ class TestInvite(BaseTest):
             invitation_respondent_data,
         )
         assert response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
-        assert response.json()["result"][0]["message"] == NonUniqueValue.message
+        result = response.json()["result"]
+        assert len(result) == 1
+        assert result[0]["message"] == NonUniqueValue.message
+        assert result[0]["path"] == ["body", "secretUserId"]
 
     async def test_manager_invite_manager_success(self, client, invitation_manager_data, applet_one_lucy_manager, lucy):
         client.login(lucy)

--- a/src/apps/shared/test/client.py
+++ b/src/apps/shared/test/client.py
@@ -4,7 +4,7 @@ import uuid
 from io import BytesIO
 from typing import Any, Mapping
 
-from httpx import AsyncClient, Response
+from httpx import ASGITransport, AsyncClient, Response
 from pydantic import BaseModel
 
 from apps.authentication.domain.token import JWTClaim
@@ -15,7 +15,7 @@ from config import settings
 
 class TestClient:
     def __init__(self, app) -> None:
-        self.client = AsyncClient(app=app, base_url="http://test.com")
+        self.client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test.com")
         self.headers: dict[str, Any] = {}
 
     @staticmethod

--- a/src/export_spec.py
+++ b/src/export_spec.py
@@ -1,0 +1,58 @@
+import json
+from typing import Any
+
+import httpx
+
+from infrastructure.app import create_app
+
+
+def fix_exclusive_values(spec: dict[str, Any]):
+    """FastApi generates broken openapi specification for version 3.0. By some reasons exclusive values are generated
+    in format for version 3.1. So just fix it manually. Can be removed after migration on openapi v3.1
+    Difference in versions are described here https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
+    See 'Tweak exclusiveMinimum and exclusiveMaximum'
+    """
+    schemas = spec["components"]["schemas"]
+    for schema in schemas.values():
+        properties = schema.get("properties", {})
+        for prop in properties.values():
+            exclusive_minimum = prop.get("exclusiveMinimum")
+            exclusive_maximum = prop.get("exclusiveMaximum")
+            if exclusive_minimum is not None:
+                prop["minimum"] = exclusive_minimum
+                prop["exclusiveMinimum"] = True
+            if exclusive_maximum is not None:
+                prop["maximum"] = exclusive_maximum
+                prop["exclusiveMaximum"] = True
+    paths = spec["paths"]
+    for path in paths.values():
+        for method in path.values():
+            for parameter in method.get("parameters", []):
+                schema = parameter.get("schema", {})
+                exclusive_minimum = schema.get("exclusiveMinimum")
+                exclusive_maximum = schema.get("exclusiveMaximum")
+                if exclusive_minimum is not None:
+                    schema["minimum"] = exclusive_minimum
+                    schema["exclusiveMinimum"] = True
+                if exclusive_maximum is not None:
+                    schema["maximum"] = exclusive_maximum
+                    schema["exclusiveMaximum"] = True
+
+
+def save_to_file(spec: dict[str, Any], file_name: str):
+    with open(f"/tmp/{file_name}", "w") as f:
+        json.dump(spec, f, indent=4)
+
+
+def main():
+    current_specification_url = "https://api-dev.cmiml.net/openapi.json"
+    new_spec = create_app().openapi()
+    current_spec = httpx.get(current_specification_url).json()
+    fix_exclusive_values(new_spec)
+    fix_exclusive_values(current_spec)
+    save_to_file(new_spec, "new_spec.json")
+    save_to_file(current_spec, "current_spec.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/infrastructure/app.py
+++ b/src/infrastructure/app.py
@@ -100,6 +100,8 @@ def create_app():
     app.add_exception_handler(RequestValidationError, pydantic_validation_errors_handler)
     app.add_exception_handler(BaseError, custom_base_errors_handler)
     app.add_exception_handler(Exception, python_base_error_handler)
+    # TODO: Remove when oasdiff starts support OpenAPI 3.1
+    # https://github.com/Tufin/oasdiff/issues/52
     app.openapi_version = "3.0.3"
 
     return app

--- a/src/infrastructure/app.py
+++ b/src/infrastructure/app.py
@@ -100,5 +100,6 @@ def create_app():
     app.add_exception_handler(RequestValidationError, pydantic_validation_errors_handler)
     app.add_exception_handler(BaseError, custom_base_errors_handler)
     app.add_exception_handler(Exception, python_base_error_handler)
+    app.openapi_version = "3.0.3"
 
     return app

--- a/src/infrastructure/http/execeptions.py
+++ b/src/infrastructure/http/execeptions.py
@@ -49,16 +49,17 @@ def python_base_error_handler(_: Request, error: Exception) -> JSONResponse:
 
 def pydantic_validation_errors_handler(_: Request, error: RequestValidationError) -> JSONResponse:
     """This function is called if the Pydantic validation error was raised."""
-
-    response = ErrorResponseMulti(
-        result=[
-            ErrorResponse(
-                message=err["msg"],
-                path=list(err["loc"]),
-            )
-            for err in error.errors()
-        ]
-    )
+    # TODO: remove it later. This is a fix after updating fastapi version.
+    errors = []
+    for err in error.errors():
+        if isinstance(err, dict):
+            message = err["msg"]
+            path = list(err["loc"])
+        else:
+            message = str(err.exc)
+            path = list(err.loc_tuple())
+        errors.append(ErrorResponse(message=message, path=path))
+    response = ErrorResponseMulti(result=errors)
 
     return JSONResponse(
         content=jsonable_encoder(response.dict(by_alias=True)),


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6050](https://mindlogger.atlassian.net/browse/M2-6050)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Upgrade fastapi to latest version, fix errors with error wrapper
- Replace PublicModel with union and discriminator
- Upgrade mypy, fix httpx warnings
- Specify openapi_version 3.0.3
- Add script to export new and old openapi specifications
- Add github action to compare new and current existing openapi specification using oasdiff to prevent unexpected breaking changes


<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- oasdiff currently is not working with the OpenAPI 3.1 specification version.
- FastAPI does not generate correct openapi 3.0 specification version.
- In FastAPI version [0.89.0](https://github.com/tiangolo/fastapi/releases/tag/0.89.0) added response_model, so some hacks for response_values and config in activity_item_base which use PublicModel instead of Union don't work anymore, added discriminator for correct matching response_values and configs in items.
- Add simple **temporary** script which fix issues in specifications for correct work oasdiff