### PR TITLE
M2-6378: Update the Get Subjects endpoint to return more data

### DIFF
--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -180,5 +180,6 @@ async def get_subject(
             nickname=subject.nickname,
             last_seen=answer_dates.get(subject.id),
             tag=subject.tag,
+            applet_id=subject.applet_id,
         )
     )

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -176,6 +176,7 @@ async def get_subject(
 
     return Response(
         result=SubjectReadResponse(
+            id=subject.id,
             secret_user_id=subject.secret_user_id,
             nickname=subject.nickname,
             last_seen=answer_dates.get(subject.id),

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -78,3 +78,4 @@ class SubjectDeleteRequest(PublicModel):
 
 class SubjectReadResponse(SubjectUpdateRequest):
     last_seen: datetime.datetime | None
+    applet_id: uuid.UUID

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -77,5 +77,6 @@ class SubjectDeleteRequest(PublicModel):
 
 
 class SubjectReadResponse(SubjectUpdateRequest):
+    id: uuid.UUID
     last_seen: datetime.datetime | None
     applet_id: uuid.UUID

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -444,10 +444,11 @@ class TestSubjects(BaseTest):
         data = response.json()
         assert data
         res = data["result"]
-        assert set(res.keys()) == {"secretUserId", "nickname", "lastSeen", "tag"}
+        assert set(res.keys()) == {"secretUserId", "nickname", "lastSeen", "tag", "appletId"}
         assert res["secretUserId"] == tom_applet_one_subject.secret_user_id
         assert res["nickname"] == tom_applet_one_subject.nickname
         assert res["tag"] == tom_applet_one_subject.tag
+        assert uuid.UUID(res["appletId"]) == tom_applet_one_subject.applet_id
 
         # not found
         response = await client.get(self.subject_detail_url.format(subject_id=uuid.uuid4()))

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -444,7 +444,8 @@ class TestSubjects(BaseTest):
         data = response.json()
         assert data
         res = data["result"]
-        assert set(res.keys()) == {"secretUserId", "nickname", "lastSeen", "tag", "appletId"}
+        assert set(res.keys()) == {"id", "secretUserId", "nickname", "lastSeen", "tag", "appletId"}
+        assert uuid.UUID(res["id"]) == tom_applet_one_subject.id
         assert res["secretUserId"] == tom_applet_one_subject.secret_user_id
         assert res["nickname"] == tom_applet_one_subject.nickname
         assert res["tag"] == tom_applet_one_subject.tag


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6378](https://mindlogger.atlassian.net/browse/M2-6378)

This PR updates GET `/subjects/{subject_id}` to return more data in the form of the following fields:
- Applet ID
- Subject ID

### 🪤 Peer Testing

Send an HTTP GET request to `/subjects/{subject_id}` with a valid Subject ID, and confirm that it returns the corresponding Applet ID and the Subject ID that was passed.

### ✏️ Notes

N/A
