### PR TITLE
M2-6393 Add updated_at to answer reviews list

### DIFF
--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -359,6 +359,7 @@ class AnswerReview(InternalModel):
     items: list[PublicActivityItemFull] = Field(default_factory=list)
     reviewer: Reviewer
     created_at: datetime.datetime
+    updated_at: datetime.datetime
 
 
 class AppletActivityAnswerPublic(PublicModel):
@@ -389,6 +390,7 @@ class AnswerReviewPublic(PublicModel):
     items: list[PublicActivityItemFull] = Field(default_factory=list)
     reviewer: ReviewerPublic
     created_at: datetime.datetime
+    updated_at: datetime.datetime
 
 
 class AssessmentAnswerPublic(PublicModel):

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -627,6 +627,7 @@ class AnswerService:
                     items=current_activity_items,
                     reviewer=dict(id=user.id, first_name=user.first_name, last_name=user.last_name),
                     created_at=schema.created_at,
+                    updated_at=schema.updated_at,
                 )
             )
         return results

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -893,6 +893,16 @@ class TestAnswerActivityItems(BaseTest):
         )
         assert response.status_code == 200, response.json()
         assert response.json()["count"] == 1
+        assert set(response.json()["result"][0].keys()) == {
+            "answer",
+            "createdAt",
+            "updatedAt",
+            "id",
+            "itemIds",
+            "items",
+            "reviewer",
+            "reviewerPublicKey",
+        }
         assert response.json()["result"][0]["answer"] == "some answer"
         assert response.json()["result"][0]["reviewerPublicKey"] == "some public key"
         assert response.json()["result"][0]["itemIds"] == [


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6393](https://mindlogger.atlassian.net/browse/M2-6393)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Add updated_at field to answer reviews list:
`GET /answers/applet/{applet_id}/answers/{answer_id}/reviews`
