### PR TITLE
M2-6279: Fix issue with many roles for summary

### DIFF
--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1717,3 +1717,13 @@ class TestAnswerActivityItems(BaseTest):
             submit_id = uuid.UUID(s["submitId"])
             assert submit_id in filtered_submissions
             assert len(filtered_submissions[submit_id]) == len(s["answers"])
+
+    @pytest.mark.usefixtures("applet_one_lucy_reviewer", "applet_one_lucy_coordinator")
+    async def test_get_summary_activity_list_admin_with_role_reviewer_and_any_other_manager_role_can_view_summary(
+        self, client: TestClient, applet_one: AppletFull, lucy: User, tom: User
+    ):
+        client.login(lucy)
+        resp = await client.get(
+            self.summary_activities_url.format(applet_id=applet_one.id), query={"respondentId": tom.id}
+        )
+        assert resp.status_code == http.HTTPStatus.OK

--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 
 import pytest
 from pytest import Config
+from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.activities.domain.activity_create import ActivityCreate, ActivityItemCreate
@@ -236,6 +237,18 @@ async def applet_one_lucy_editor(session: AsyncSession, applet_one: AppletFull, 
 @pytest.fixture
 async def applet_one_lucy_coordinator(session: AsyncSession, applet_one: AppletFull, tom, lucy) -> AppletFull:
     await UserAppletAccessService(session, tom.id, applet_one.id).add_role(lucy.id, Role.COORDINATOR)
+    return applet_one
+
+
+@pytest.fixture
+async def applet_one_lucy_reviewer(
+    session: AsyncSession, applet_one: AppletFull, mocker: MockerFixture, tom: User, lucy: User
+) -> AppletFull:
+    mocker.patch(
+        "apps.workspaces.service.user_applet_access.UserAppletAccessService._get_default_role_meta",
+        return_value={"respondents": [str(tom.id)]},
+    )
+    await UserAppletAccessService(session, tom.id, applet_one.id).add_role(lucy.id, Role.REVIEWER)
     return applet_one
 
 

--- a/src/apps/workspaces/crud/applet_access.py
+++ b/src/apps/workspaces/crud/applet_access.py
@@ -245,3 +245,12 @@ class AppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
         data = db_result.all()
 
         return {row.id: RespondentExportData.from_orm(row) for row in data}
+
+    async def get_user_roles_for_applet(self, applet_id: uuid.UUID, user_id: uuid.UUID) -> list[Role]:
+        query: Query = select(UserAppletAccessSchema.role)
+        query = query.where(UserAppletAccessSchema.soft_exists())
+        query = query.where(UserAppletAccessSchema.user_id == user_id)
+        query = query.where(UserAppletAccessSchema.applet_id == applet_id)
+        db_result = await self._execute(query)
+        result = db_result.scalars().all()
+        return [Role(i) for i in result]

--- a/src/apps/workspaces/service/check_access.py
+++ b/src/apps/workspaces/service/check_access.py
@@ -198,15 +198,11 @@ class CheckAccessService:
 
     async def check_summary_access(self, applet_id: uuid.UUID, respondent_id: uuid.UUID | None):
         applet_access_crud = AppletAccessCRUD(self.session)
-        has_access = await applet_access_crud.can_see_data(applet_id, self.user_id)
-        if not has_access:
-            raise AnswerViewAccessDenied()
-
-        role = await applet_access_crud.get_applets_priority_role(applet_id, self.user_id)
-        if role in Role.super_reviewers():
+        user_roles = await applet_access_crud.get_user_roles_for_applet(applet_id, self.user_id)
+        if set(user_roles) & set(Role.super_reviewers()):
             return
-        elif role == Role.REVIEWER:
-            schema = await UserAppletAccessCRUD(self.session).get(self.user_id, applet_id, role)
+        elif Role.REVIEWER in user_roles:
+            schema = await UserAppletAccessCRUD(self.session).get(self.user_id, applet_id, Role.REVIEWER)
             respondents = schema.meta.get("respondents", []) if schema else []
             if str(respondent_id) in respondents:
                 return


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6279](https://mindlogger.atlassian.net/browse/M2-6279)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Add method to get all user roles for applet to check correctly user access to the activity summary