### PR TITLE
M2-6457: Update the `/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}` endpoint to account for multiple applets

### DIFF
--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -221,6 +221,16 @@ async def applet_two(
         await teardown_applet(global_session, applet.id)
 
 
+@pytest.fixture
+async def tom_applet_two_subject(session: AsyncSession, tom: User, applet_two: AppletFull) -> Subject:
+    applet_id = applet_two.id
+    user_id = tom.id
+    query = select(SubjectSchema).where(SubjectSchema.user_id == user_id, SubjectSchema.applet_id == applet_id)
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    model = res.scalars().one()
+    return Subject.from_orm(model)
+
+
 @pytest.fixture(autouse=True, scope="session")
 async def applet_three(
     global_session: AsyncSession,

--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -1090,7 +1090,13 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
             UserAppletAccessSchema.role == Role.RESPONDENT,
             UserAppletAccessSchema.soft_exists(),
         )
-        query = query.join(SubjectSchema, SubjectSchema.user_id == UserAppletAccessSchema.user_id)
+        query = query.join(
+            SubjectSchema,
+            and_(
+                SubjectSchema.user_id == UserAppletAccessSchema.user_id,
+                SubjectSchema.applet_id == UserAppletAccessSchema.applet_id,
+            ),
+        )
         db_result = await self._execute(query)
         db_result = db_result.all()  # noqa
         return db_result[0] if db_result else None

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -827,7 +827,7 @@ class TestWorkspaces(BaseTest):
         assert response.json()["count"] == 1
         assert response.json()["result"][0]["type"] == "applet"
 
-    async def test_applet_get_respondent_success(self, client, tom, applet_one):
+    async def test_applet_get_respondent_success(self, client, tom, applet_one, tom_applet_one_subject: Subject):
         client.login(tom)
         url = self.workspace_get_applet_respondent.format(
             owner_id=tom.id,
@@ -842,6 +842,24 @@ class TestWorkspaces(BaseTest):
         # Secret User id is random uuid, so just check that secretUserId exists
         assert respondent["secretUserId"]
         assert respondent["lastSeen"] is None
+        assert uuid.UUID(respondent["subjectId"]) == tom_applet_one_subject.id
+
+    async def test_applet_two_get_respondent_success(self, client, tom, applet_two, tom_applet_two_subject: Subject):
+        client.login(tom)
+        url = self.workspace_get_applet_respondent.format(
+            owner_id=tom.id,
+            applet_id=str(applet_two.id),
+            respondent_id=tom.id,
+        )
+        res = await client.get(url)
+        assert res.status_code == 200
+        body = res.json()
+        respondent = body.get("result")
+        assert respondent["nickname"] == f"{tom.first_name} {tom.last_name}"
+        # Secret User id is random uuid, so just check that secretUserId exists
+        assert respondent["secretUserId"]
+        assert respondent["lastSeen"] is None
+        assert uuid.UUID(respondent["subjectId"]) == tom_applet_two_subject.id
 
     async def test_applet_get_respondent_not_found(self, client, tom, applet_two):
         client.login(tom)


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6457](https://mindlogger.atlassian.net/browse/M2-6457)

This PR is a simple change to account for multiple applets in the `/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}` endpoint. The current implementation will return multiple results in an undefined order if the respondent being fetched has that role in multiple applets (and therefore has multiple entries in the `subjects` table).

By updating the join condition between `user_applet_accesses` and `subjects` to include both the `user_id` and `applet_id` columns, we ensure that the result set will have a single entry.

### 🪤 Peer Testing

For manual testing, you'll need to create a workspace with two applets. Then, consume the `/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}` endpoint with both applet IDs (you can use the `owner_id` as the `respondent_id`) and confirm that the data returned contain different values for `subjectId`

### ✏️ Notes

N/A
