### PR TITLE
M2-6159: add missing fields to invitations

### DIFF
--- a/src/apps/invitations/domain.py
+++ b/src/apps/invitations/domain.py
@@ -226,6 +226,8 @@ class _InvitationDetail(InternalModel):
     applet_name: str
     status: str
     key: uuid.UUID
+    first_name: str
+    last_name: str
     user_id: uuid.UUID | None
     tag: str | None
 
@@ -248,6 +250,7 @@ class InvitationDetailForReviewer(_InvitationDetail):
     email: EmailStr
     role: Role = Role.REVIEWER
     subjects: list[uuid.UUID]
+    title: str | None
 
 
 class InvitationDetailForManagers(_InvitationDetail):
@@ -306,6 +309,12 @@ class _InvitationResponse(PublicModel):
     status: InvitationStatus = Field(
         description="This field represents the status for invitation",
     )
+    first_name: str = Field(
+        description="This field represents the first name of invited user",
+    )
+    last_name: str = Field(
+        description="This field represents the last name of invited user",
+    )
     user_id: uuid.UUID | None = Field(
         None,
         description="This field respresents registered user or not. " "Used for tests",
@@ -339,6 +348,9 @@ class InvitationReviewerResponse(_InvitationResponse):
     for reviewer role.
     """
 
+    email: EmailStr = Field(
+        description="This field represents the email of invited reviewer",
+    )
     subjects: list[uuid.UUID] = Field(description="This field represents the list of subject id's")
     role: Role = Role.REVIEWER
     title: str | None = Field(description="This field represents the team member title")

--- a/src/apps/invitations/services.py
+++ b/src/apps/invitations/services.py
@@ -137,6 +137,8 @@ class InvitationsService:
             applet_name=applet.display_name,
             role=invitation_internal.role,
             status=invitation_internal.status,
+            first_name=invitation_internal.first_name,
+            last_name=invitation_internal.last_name,
             key=invitation_internal.key,
             user_id=invitation_internal.user_id,
             tag=invitation_internal.tag,
@@ -167,6 +169,7 @@ class InvitationsService:
             "nickname": None,
             "meta": meta.dict(),
             "tag": schema.tag,
+            "title": schema.title,
         }
 
         pending_invitation = await self.invitations_crud.get_pending_invitation(schema.email, applet_id)
@@ -212,10 +215,13 @@ class InvitationsService:
             applet_name=applet.display_name,
             role=invitation_internal.role,
             status=invitation_internal.status,
+            first_name=invitation_internal.first_name,
+            last_name=invitation_internal.last_name,
             key=invitation_internal.key,
             subjects=schema.subjects,
             user_id=invitation_internal.user_id,
             tag=invitation_internal.tag,
+            title=invitation_internal.title,
         )
 
     async def send_managers_invitation(
@@ -283,6 +289,8 @@ class InvitationsService:
             applet_name=applet.display_name,
             role=invitation_internal.role,
             status=invitation_internal.status,
+            first_name=invitation_internal.first_name,
+            last_name=invitation_internal.last_name,
             key=invitation_internal.key,
             user_id=invitation_internal.user_id,
             tag=invitation_internal.tag,

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -213,6 +213,8 @@ class TestInvite(BaseTest):
 
         assert response.json()["result"]["appletId"] == str(applet_one.id)
         assert response.json()["result"]["role"] == Role.MANAGER
+        assert response.json()["result"]["firstName"] == "first_name"
+        assert response.json()["result"]["lastName"] == "last_name"
         assert response.json()["result"]["tag"] is not None
         assert response.json()["result"]["title"] == "PHD"
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6159](https://mindlogger.atlassian.net/browse/M2-6159)

Ensures `firstName`, `lastName`, `email`, and `title` fields are all available in the responses for each POST request:

- `invitations/{applet id}/managers`
- `invitations/{applet id}/reviewer`

Also ensures the `title` field propagates to the reviewer user account.

### 🪤 Peer Testing

From http://127.0.0.1:8000/docs:

- Create a valid POST request to `invitations/{applet id}/managers`
    **Expected outcome:** The fields `firstName`, `lastName`, `email` and `title` are all returned in the response.
- Create a valid POST request to `invitations/{applet id}/reviewer`
    **Expected outcome:** The fields `firstName`, `lastName`, `email` and `title` are all returned in the response.
- Accept an invitation to a newly invited **Reviewer** and observe the newly created user.
    **Expected outcome:** User should have the same `title` field that was included in the invitation request.
