### PR TITLE
M2-6097:  Split subject internal and subject[create] pydantic models

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -127,15 +127,14 @@ async def summary_activity_list(
 ) -> ResponseMulti[PublicSummaryActivity]:
     filters = SummaryActivityFilter(**query_params.filters)
     await AppletService(session, user.id).exist_by_id(applet_id)
-    if filters.respondent_id and not filters.target_subject_id:
+    target_subject_id = filters.target_subject_id
+    if filters.respondent_id and not target_subject_id:
         target_subject = await SubjectsService(session, user.id).get_by_user_and_applet(
             filters.respondent_id, applet_id
         )
         if not target_subject:
             raise NotFoundError()
         target_subject_id = target_subject.id
-    else:
-        target_subject_id = filters.target_subject_id
     await CheckAccessService(session, user.id).check_subject_answer_access(applet_id, target_subject_id)
     activities = await AnswerService(session, user.id, answer_session).get_summary_activities(applet_id, filters)
     return ResponseMulti(
@@ -177,8 +176,8 @@ async def summary_latest_report_retrieve(
 ) -> FastApiResponse:
     await AppletService(session, user.id).exist_by_id(applet_id)
     await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    subject = await SubjectsService(session, user.id).get(subject_id)
-    if not subject or not subject.soft_exists():
+    subject = await SubjectsService(session, user.id).get_if_soft_exist(subject_id)
+    if not subject:
         raise NotFoundError(f"Subject {subject_id} not found.")
 
     report = await AnswerService(session, user.id, answer_session).get_summary_latest_report(

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -17,7 +17,7 @@ from apps.applets.domain.applet_full import AppletFull
 from apps.mailing.services import TestMail
 from apps.shared.test import BaseTest
 from apps.subjects.db.schemas import SubjectSchema
-from apps.subjects.domain import Subject
+from apps.subjects.domain import SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User
 from apps.workspaces.crud.user_applet_access import UserAppletAccessCRUD
@@ -1963,7 +1963,7 @@ class TestAnswerActivityItems(BaseTest):
         url = self.summary_activities_url.format(applet_id=f"{applet_id}")
         if role == Role.REVIEWER:
             subject = await SubjectsService(session, tom.id).create(
-                Subject(
+                SubjectCreate(
                     applet_id=applet_id,
                     creator_id=tom.id,
                     first_name="first_name",

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -42,7 +42,7 @@ from apps.shared.version import (
     VERSION_DIFFERENCE_ITEM,
     VERSION_DIFFERENCE_MINOR,
 )
-from apps.subjects.domain import Subject
+from apps.subjects.domain import SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.themes.service import ThemeService
 from apps.users.services.user import UserService
@@ -611,7 +611,7 @@ class AppletService:
             anonym = await UserService(self.session).create_anonymous_respondent()
             await UserAppletAccessService(self.session, self.user_id, applet_id).add_role_for_anonymous_respondent()
             await SubjectsService(self.session, self.user_id).create(
-                Subject(
+                SubjectCreate(
                     applet_id=applet_id,
                     creator_id=self.user_id,
                     user_id=anonym.id,

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -30,7 +30,7 @@ from apps.invitations.errors import (
 from apps.mailing.services import TestMail
 from apps.shared.test import BaseTest
 from apps.subjects.crud import SubjectsCrud
-from apps.subjects.domain import Subject
+from apps.subjects.domain import Subject, SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import UserSchema
 from apps.users.domain import User, UserCreate, UserCreateRequest
@@ -154,7 +154,7 @@ def shell_create_data():
 @pytest.fixture
 async def applet_one_shell_account(session: AsyncSession, applet_one: AppletFull, tom: User) -> Subject:
     return await SubjectsService(session, tom.id).create(
-        Subject(
+        SubjectCreate(
             applet_id=applet_one.id,
             creator_id=tom.id,
             first_name="Shell",

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -16,6 +16,7 @@ from apps.shared.exception import NotFoundError, ValidationError
 from apps.shared.response import EmptyResponse
 from apps.subjects.domain import (
     Subject,
+    SubjectCreate,
     SubjectCreateRequest,
     SubjectDeleteRequest,
     SubjectReadResponse,
@@ -45,14 +46,14 @@ async def create_subject(
         service = SubjectsService(session, user.id)
 
         try:
-            subject = await service.create(Subject(creator_id=user.id, **schema.dict(by_alias=False)))
+            subject = await service.create(SubjectCreate(creator_id=user.id, **schema.dict(by_alias=False)))
         except SecretIDUniqueViolationError:
             wrapper = ErrorWrapper(
                 ValueError(NonUniqueValue()), ("body", SubjectCreateRequest.field_alias("secret_user_id"))
             )
             raise RequestValidationError([wrapper])
 
-        return Response(result=Subject.from_orm(subject))
+        return Response(result=subject)
 
 
 async def create_relation(
@@ -63,11 +64,11 @@ async def create_relation(
     session: AsyncSession = Depends(get_session),
 ):
     service = SubjectsService(session, user.id)
-    source_subject = await service.get(source_subject_id)
-    target_subject = await service.get(subject_id)
-    if not source_subject or not source_subject.soft_exists():
+    source_subject = await service.get_if_soft_exist(source_subject_id)
+    target_subject = await service.get_if_soft_exist(subject_id)
+    if not source_subject:
         raise NotFoundError(f"Subject {source_subject_id} not found")
-    if not target_subject or not target_subject.soft_exists():
+    if not target_subject:
         raise NotFoundError(f"Subject {subject_id} not found")
     if source_subject.applet_id != target_subject.applet_id:
         raise ValidationError("applet_id doesn't match")
@@ -106,7 +107,7 @@ async def update_subject(
     schema: SubjectUpdateRequest = Body(...),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
-) -> Response[Subject]:
+) -> Response[SubjectReadResponse]:
     subject_srv = SubjectsService(session, user.id)
     subject = await subject_srv.get(subject_id)
     if not subject:
@@ -119,7 +120,7 @@ async def update_subject(
         subject.secret_user_id = schema.secret_user_id
         subject.nickname = schema.nickname
         subject = await subject_srv.update(subject.id, **schema.dict(by_alias=False))
-        return Response(result=Subject.from_orm(subject))
+        return Response(result=SubjectReadResponse(secret_user_id=subject.secret_user_id, nickname=subject.nickname))
 
 
 async def delete_subject(
@@ -136,11 +137,6 @@ async def delete_subject(
     # Check that user has right on applet
     await UserAccessService(session, user.id).validate_subject_delete_access(subject.applet_id)
     async with atomic(session):
-        # Remove respondent role for user
-        await UserAppletAccessService(session, user.id, subject.applet_id).remove_access_by_user_and_applet_to_role(
-            subject.user_id, subject.applet_id, Role.RESPONDENT
-        )
-
         if params.delete_answers:
             # Remove subject and answers
             await SubjectsService(session, user.id).delete_hard(subject.id)
@@ -158,6 +154,10 @@ async def delete_subject(
             ex_resp = await UserService(session).get(subject.user_id)
             if ex_resp:
                 await InvitationsService(session, ex_resp).delete_for_respondents([subject.applet_id])
+            # Remove respondent role for user
+            await UserAppletAccessService(session, user.id, subject.applet_id).remove_access_by_user_and_applet_to_role(
+                subject.user_id, subject.applet_id, Role.RESPONDENT
+            )
 
 
 async def get_subject(

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -7,8 +7,7 @@ from apps.shared.domain import InternalModel, PublicModel
 from apps.shared.domain.custom_validations import lowercase
 
 
-class Subject(InternalModel):
-    id: uuid.UUID | None
+class SubjectCreate(InternalModel):
     applet_id: uuid.UUID
     email: EmailStr | None
     creator_id: uuid.UUID
@@ -19,6 +18,10 @@ class Subject(InternalModel):
     secret_user_id: str
     nickname: str | None
     is_deleted: bool = False
+
+
+class Subject(SubjectCreate):
+    id: uuid.UUID
 
 
 class SubjectRespondent(PublicModel):

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -11,7 +11,7 @@ from apps.answers.crud.answers import AnswersCRUD
 from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
 from apps.subjects.crud import SubjectsCrud
-from apps.subjects.domain import Subject, SubjectCreateRequest, SubjectRelationCreate
+from apps.subjects.domain import Subject, SubjectCreate, SubjectCreateRequest, SubjectRelationCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User
 from apps.users.domain import UserCreate
@@ -33,7 +33,7 @@ def create_shell_body(applet_one):
 
 @pytest.fixture
 def subject_schema():
-    return Subject(
+    return SubjectCreate(
         applet_id=uuid.UUID("92917a56-d586-4613-b7aa-991f2c4b15b1"),
         email="subject@mail.com",
         creator_id=uuid.UUID("7484f34a-3acc-4ee6-8a94-fd7299502fa1"),
@@ -48,7 +48,7 @@ def subject_schema():
 
 @pytest.fixture
 def subject_updated_schema(subject_schema):
-    return Subject(
+    return SubjectCreate(
         applet_id=subject_schema.applet_id,
         email=f"new-{subject_schema.email}",
         creator_id=subject_schema.user_id,
@@ -340,7 +340,7 @@ class TestSubjects(BaseTest):
         assert result_subject.id
         actual_subject = await service.get(result_subject.id)
         assert actual_subject
-        for field_name in Subject.__fields__.keys():
+        for field_name in SubjectCreate.__fields__.keys():
             actual = getattr(actual_subject, field_name)
             expected = getattr(result_subject, field_name)
             assert actual == expected
@@ -358,7 +358,7 @@ class TestSubjects(BaseTest):
         assert original_subject.id
         actual_subject = await service.get(original_subject.id)
         assert actual_subject
-        for field_name in Subject.__fields__.keys():
+        for field_name in SubjectCreate.__fields__.keys():
             actual = getattr(actual_subject, field_name)
             expected = getattr(original_subject, field_name)
             assert actual == expected

--- a/src/apps/transfer_ownership/service.py
+++ b/src/apps/transfer_ownership/service.py
@@ -8,7 +8,7 @@ from apps.applets.domain import Role
 from apps.authentication.errors import PermissionsError
 from apps.mailing.domain import MessageSchema
 from apps.mailing.services import MailingService
-from apps.subjects.domain import Subject
+from apps.subjects.domain import SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.transfer_ownership.constants import TransferOwnershipStatus
 from apps.transfer_ownership.crud import TransferCRUD
@@ -135,17 +135,18 @@ class TransferService:
                 is_deleted=False,
             )
         else:
-            subject = Subject(
-                applet_id=transfer.applet_id,
-                email=self._user.email_encrypted,
-                creator_id=self._user.id,
-                user_id=self._user.id,
-                first_name=self._user.first_name,
-                last_name=self._user.last_name,
-                secret_user_id=f"{uuid.uuid4()}",
-                nickname=self._user.get_full_name(),
+            await subject_service.create(
+                SubjectCreate(
+                    applet_id=transfer.applet_id,
+                    email=self._user.email_encrypted,
+                    creator_id=self._user.id,
+                    user_id=self._user.id,
+                    first_name=self._user.first_name,
+                    last_name=self._user.last_name,
+                    secret_user_id=f"{uuid.uuid4()}",
+                    nickname=self._user.get_full_name(),
+                )
             )
-            await subject_service.create(subject)
 
         # remove other roles of new owner
         await UserAppletAccessCRUD(self.session).remove_access_by_user_and_applet_to_role(

--- a/src/apps/workspaces/service/user_applet_access.py
+++ b/src/apps/workspaces/service/user_applet_access.py
@@ -10,7 +10,7 @@ from apps.invitations.domain import InvitationDetailGeneric, RespondentMeta
 from apps.shared.exception import NotFoundError
 from apps.subjects.crud import SubjectsCrud
 from apps.subjects.db.schemas import SubjectSchema
-from apps.subjects.domain import Subject
+from apps.subjects.domain import SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User, UserNotFound, UsersCRUD
 from apps.workspaces.db.schemas import UserAppletAccessSchema
@@ -164,7 +164,7 @@ class UserAppletAccessService:
                 await UserAppletAccessCRUD(self.session).upsert_user_applet_access(schema)
 
                 await SubjectsService(self.session, self._user_id).create(
-                    Subject(
+                    SubjectCreate(
                         applet_id=invitation.applet_id,
                         email=invitation.email,
                         creator_id=invitation.invitor_id,
@@ -210,7 +210,7 @@ class UserAppletAccessService:
                 where=UserAppletAccessSchema.soft_exists(exists=False),
             )
             await SubjectsService(self.session, self._user_id).create(
-                Subject(
+                SubjectCreate(
                     applet_id=self._applet_id,
                     email=user.email_encrypted,
                     creator_id=owner_access.user_id,

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -18,7 +18,7 @@ from apps.shared.enums import Language
 from apps.shared.query_params import QueryParams
 from apps.shared.test import BaseTest
 from apps.subjects.constants import SubjectStatus
-from apps.subjects.domain import Subject
+from apps.subjects.domain import Subject, SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User, UserSchema, UsersCRUD
 from apps.workspaces.domain.workspace import WorkspaceApplet
@@ -100,7 +100,7 @@ async def applet_one_lucy_roles(
 @pytest.fixture
 async def applet_one_shell_account(session: AsyncSession, applet_one: AppletFull, tom: User) -> Subject:
     return await SubjectsService(session, tom.id).create(
-        Subject(
+        SubjectCreate(
             applet_id=applet_one.id,
             creator_id=tom.id,
             first_name="Shell",
@@ -146,7 +146,7 @@ async def tom_answer_applet_one(session, tom: User, applet_one: AppletFull):
 @pytest.fixture
 async def applet_one_shell_has_pending_invitation(session, tom: User, user: User, applet_one: AppletFull):
     subject = await SubjectsService(session, tom.id).create(
-        Subject(
+        SubjectCreate(
             applet_id=applet_one.id,
             creator_id=tom.id,
             first_name="Invited",
@@ -463,7 +463,7 @@ class TestWorkspaces(BaseTest):
         client,
         tom,
         applet_one,
-        tom_applet_one_subject: Subject,
+        tom_applet_one_subject: SubjectCreate,
         lucy: User,
         applet_one_lucy_respondent,
     ):


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-6097](https://mindlogger.atlassian.net/browse/M2-6097)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Subject's Pydantic models for create and retrieve was splited

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
