### PR TITLE
Update `upload_url` validation

### DIFF
--- a/src/apps/file/domain.py
+++ b/src/apps/file/domain.py
@@ -1,6 +1,6 @@
 import enum
 
-from pydantic import HttpUrl
+from pydantic import AnyHttpUrl
 
 from apps.shared.domain import PublicModel
 
@@ -52,7 +52,7 @@ class FileIdRequest(PublicModel):
 
 
 class PresignedUrl(PublicModel):
-    upload_url: HttpUrl
+    upload_url: AnyHttpUrl
     url: str
     # Use dict because fields can be different depend storage (AWS S3, Minio, GCS)
     fields: dict[str, str]


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-#](https://mindlogger.atlassian.net/browse/M2-#)

This PR doesn't have an associated ticket, I'll file one after opening in order to track this.

Currently, the `/file/upload-url` endpoint (eg, for adding image assets for Activity & Applet thumbnails) fails in local development environments. 

This is because the generated URLs (`http://localhost:9000/[path]/[to]/[image]`) fail pydantic's HttpUrl validation, with the given reason of "lacking a valid TLD", causing the endpoint to respond with an error. 

This PR swaps the validation performed from "HttpUrl" to "AnyHttpUrl", in order to allow `localhost` addresses to pass validation and return successfully.