### PR TITLE
chore: Update OASDIFF workflow to check api only on dev and main branches

### DIFF
--- a/.github/workflows/oasdif.yaml
+++ b/.github/workflows/oasdif.yaml
@@ -1,5 +1,9 @@
 name: OASDIFF breaking changes
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
 jobs:
   compare:
     runs-on: ubuntu-latest
@@ -7,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: KengoTODA/actions-setup-docker-compose@v1
         with:
-          version: '2.23.3'
+          version: "2.23.3"
       - name: "Save openapi.json files"
         run: |
           cp .env.default .env
@@ -32,4 +36,4 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_TITLE: Changes Found!
-          SLACK_MESSAGE: 'Oasdiff step failed. API changes found!'
+          SLACK_MESSAGE: "Oasdiff step failed. API changes found!"


### PR DESCRIPTION
### 📝 Description

Update OASDIFF workflow to check api changes only when open PR against develope and main branches

This will avoid error checking during development in other branches and will not affect the main goal of this workflow, prevent breaking changes in production without being properly handle


