### PR TITLE
feat(mi): Add `userId` to get subjects query (M2-6582)

### DIFF
--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -182,5 +182,6 @@ async def get_subject(
             last_seen=answer_dates.get(subject.id),
             tag=subject.tag,
             applet_id=subject.applet_id,
+            user_id=subject.user_id,
         )
     )

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -80,3 +80,4 @@ class SubjectReadResponse(SubjectUpdateRequest):
     id: uuid.UUID
     last_seen: datetime.datetime | None
     applet_id: uuid.UUID
+    user_id: uuid.UUID | None


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-6582](https://mindlogger.atlassian.net/browse/M2-6582)

This PR updates GET `/subjects/{subject_id}` to return more data in the form of the following fields:
- User ID

### 🪤 Peer Testing

Send an HTTP GET request to `/subjects/{subject_id}` with a valid Subject ID, and confirm that it returns the User ID field. It should be null for limited accounts.

### ✏️ Notes

N/A
