### PR TITLE
fix: user_public_key can be none (M2-6460)

### DIFF
--- a/src/apps/answers/domain/answer_items.py
+++ b/src/apps/answers/domain/answer_items.py
@@ -15,7 +15,7 @@ class AnswerItem(InternalModel):
     events: str | None
     item_ids: list
     identifier: str | None
-    user_public_key: str
+    user_public_key: str | None
     scheduled_datetime: datetime.datetime | None = None
     start_datetime: datetime.datetime
     end_datetime: datetime.datetime


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6460](https://mindlogger.atlassian.net/browse/M2-6460)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- user_public_key in ItemAnswer DTO can be none

### ✏️ Notes

You can look into ItemAnswerCreate DTO here:  https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/a68b0674c0204e849c1989e8629c8434967aa897/src/apps/answers/domain/answer_items.py#L61-L73