### PR TITLE
bugfix: Allow subscale score to be decimal, negative (M2-6726)

### DIFF
--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -5,10 +5,10 @@ def validate_score_subscale_table(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
         # make sure x is float with 5 decimal points
-        x: float
+        val: float
         try:
-            x = float(value)  # noqa: F841
-            if len(str(x).split(".")[1]) > 5:
+            val = float(value)  # noqa: F841
+            if len(str(val).split(".")[1]) > 5:
                 raise InvalidScoreSubscaleError()
         except ValueError:
             raise InvalidScoreSubscaleError()
@@ -34,10 +34,10 @@ def validate_raw_score_subscale(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
         # make sure x is float with 5 decimal points
-        x: float
+        val: float
         try:
-            x = float(value)  # noqa: F841
-            if len(str(x).split(".")[1]) > 2:
+            val = float(value)  # noqa: F841
+            if len(str(val).split(".")[1]) > 2:
                 raise InvalidRawScoreSubscaleError()
         except ValueError:
             raise InvalidRawScoreSubscaleError()

--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -4,11 +4,17 @@ from apps.activities.errors import InvalidRawScoreSubscaleError, InvalidScoreSub
 def validate_score_subscale_table(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
-        if not value.isnumeric():
+        # make sure x is float with 5 decimal points
+        x: float
+        try:
+            x = float(value)  # noqa: F841
+            if len(str(x).split(".")[1]) > 5:
+                raise InvalidScoreSubscaleError()
+        except ValueError:
             raise InvalidScoreSubscaleError()
 
     if "~" in value:
-        # make sure x and y are integers
+        # make sure x and y are float with 5 decimal points
         x: str | float
         y: str | float
         x, y = value.split("~")
@@ -16,7 +22,7 @@ def validate_score_subscale_table(value: str):
             x = float(x)  # noqa: F841
             y = float(y)  # noqa: F841
 
-            if len(str(x).split(".")[1]) > 5 or len(str(x).split(".")[1]) > 5:
+            if len(str(x).split(".")[1]) > 5 or len(str(y).split(".")[1]) > 5:
                 raise InvalidScoreSubscaleError()
         except ValueError:
             raise InvalidScoreSubscaleError()
@@ -27,17 +33,26 @@ def validate_score_subscale_table(value: str):
 def validate_raw_score_subscale(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
-        if not value.lstrip("-").isnumeric():
+        # make sure x is float with 5 decimal points
+        x: float
+        try:
+            x = float(value)  # noqa: F841
+            if len(str(x).split(".")[1]) > 2:
+                raise InvalidRawScoreSubscaleError()
+        except ValueError:
             raise InvalidRawScoreSubscaleError()
 
     if "~" in value:
-        # make sure x and y are integers
-        x: str | int
-        y: str | int
+        # make sure x and y are float with 5 decimal points
+        x: str | float
+        y: str | float
         x, y = value.split("~")
         try:
-            x = int(x.lstrip("-"))  # noqa: F841
-            y = int(y.lstrip("-"))  # noqa: F841
+            x = float(x)  # noqa: F841
+            y = float(y)  # noqa: F841
+
+            if len(str(x).split(".")[1]) > 2 or len(str(y).split(".")[1]) > 2:
+                raise InvalidRawScoreSubscaleError()
         except ValueError:
             raise InvalidRawScoreSubscaleError()
 

--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -4,7 +4,7 @@ from apps.activities.errors import InvalidRawScoreSubscaleError, InvalidScoreSub
 def validate_score_subscale_table(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
-        # make sure x is float with 5 decimal points
+        # make sure value is float with 5 decimal points
         val: float
         try:
             val = float(value)  # noqa: F841
@@ -33,7 +33,7 @@ def validate_score_subscale_table(value: str):
 def validate_raw_score_subscale(value: str):
     # make sure it's format is "x~y" or "x"
     if "~" not in value:
-        # make sure x is float with 5 decimal points
+        # make sure value is float with 2 decimal points
         val: float
         try:
             val = float(value)  # noqa: F841
@@ -43,7 +43,7 @@ def validate_raw_score_subscale(value: str):
             raise InvalidRawScoreSubscaleError()
 
     if "~" in value:
-        # make sure x and y are float with 5 decimal points
+        # make sure x and y are float with 2 decimal points
         x: str | float
         y: str | float
         x, y = value.split("~")

--- a/src/apps/activities/tests/unit/domain/test_custom_validation_subscale.py
+++ b/src/apps/activities/tests/unit/domain/test_custom_validation_subscale.py
@@ -19,11 +19,12 @@ class TestValidateScoreSubscaleTable:
         assert score == validate_score_subscale_table(score)
         score = "1.2342~1231.12333"
         assert score == validate_score_subscale_table(score)
-
-    def test_tilda_not_in_float_value_error(self):
-        score = "1.1"
-        with pytest.raises(InvalidScoreSubscaleError):
-            validate_score_subscale_table(score)
+        score = "1.2342"
+        assert score == validate_score_subscale_table(score)
+        score = "-1.2342"
+        assert score == validate_score_subscale_table(score)
+        score = "-1"
+        assert score == validate_score_subscale_table(score)
 
     def test_not_float_value_error(self):
         score = "1.2342s~1231"
@@ -42,16 +43,20 @@ class TestValidateRawScoreSubscale:
         assert raw_score == validate_raw_score_subscale(raw_score)
         raw_score = "12342~1231"
         assert raw_score == validate_raw_score_subscale(raw_score)
+        raw_score = "12342.12~1231.12"
+        assert raw_score == validate_raw_score_subscale(raw_score)
+        raw_score = "12342.12"
+        assert raw_score == validate_raw_score_subscale(raw_score)
 
-    def test_tilda_not_in_integer_value_error(self):
-        raw_score = "1.1"
+    def test_too_long_float_value_error(self):
+        raw_score = "12342.123~1231.123"
         with pytest.raises(InvalidRawScoreSubscaleError):
             validate_raw_score_subscale(raw_score)
 
-    def test_not_integer_value_error(self):
-        raw_score = "12342.1~1231"
+    def test_not_float_value_error(self):
+        score = "1.2342s~1231"
         with pytest.raises(InvalidRawScoreSubscaleError):
-            validate_raw_score_subscale(raw_score)
+            validate_raw_score_subscale(score)
 
     def test_successful_negative_validation(self):
         raw_score = "-1"


### PR DESCRIPTION

- [x] Tests for the changes have been added
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6726](https://mindlogger.atlassian.net/browse/M2-6726)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Allow subscale score to be decimal, negative
