### PR TITLE
feat(mi): Implement get activity flow (M2-6521)

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -10,7 +10,6 @@ from apps.activities.domain.activity import (
 )
 from apps.activities.filters import AppletActivityFilter
 from apps.activities.services.activity import ActivityItemService, ActivityService
-from apps.activity_flows.crud import FlowsCRUD
 from apps.activity_flows.domain.flow_full import PublicFlowFull
 from apps.activity_flows.service.flow import FlowService
 from apps.answers.deps.preprocess_arbitrary import get_answer_session

--- a/src/apps/activities/errors.py
+++ b/src/apps/activities/errors.py
@@ -250,5 +250,10 @@ class FlowItemActivityKeyNotFoundError(ValidationError):
     message = _("Activity key from activity flow item is not found in activity list.")
 
 
+class FlowNotFoundError(NotFoundError):
+    message_is_template: bool = True
+    message = _("No such flow with {key}={value}.")
+
+
 class MultiSelectNoneOptionError(ValidationError):
     message = _("No more than 1 none option is not allowed for multiselect.")

--- a/src/apps/activities/router.py
+++ b/src/apps/activities/router.py
@@ -5,8 +5,8 @@ from apps.activities.api.activities import (
     activity_retrieve,
     applet_activities,
     applet_activities_and_flows,
-    public_activity_retrieve,
     applet_flow,
+    public_activity_retrieve,
 )
 from apps.activities.api.reusable_item_choices import item_choice_create, item_choice_delete, item_choice_retrieve
 from apps.activities.domain.activity import ActivitySingleLanguageWithItemsDetailPublic

--- a/src/apps/activities/router.py
+++ b/src/apps/activities/router.py
@@ -6,6 +6,7 @@ from apps.activities.api.activities import (
     applet_activities,
     applet_activities_and_flows,
     public_activity_retrieve,
+    applet_flow,
 )
 from apps.activities.api.reusable_item_choices import item_choice_create, item_choice_delete, item_choice_retrieve
 from apps.activities.domain.activity import ActivitySingleLanguageWithItemsDetailPublic
@@ -87,3 +88,13 @@ router.get(
         **DEFAULT_OPENAPI_RESPONSE,
     },
 )(applet_activities_and_flows)
+
+router.get(
+    "/applet/{applet_id}/flows/{flow_id}",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {"model": Response[AppletActivitiesAndFlowsDetailsPublic]},
+        **AUTHENTICATION_ERROR_RESPONSES,
+        **DEFAULT_OPENAPI_RESPONSE,
+    },
+)(applet_flow)

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -430,7 +430,9 @@ class TestActivities:
     async def test_activity_flow_detail_invalid_flow_id(self, client, applet_activity_flow: AppletFull, tom: User):
         fake_flow_id = uuid.uuid4()
         client.login(tom)
-        response = await client.get(self.applet_flow_detail.format(applet_id=applet_activity_flow.id, flow_id=fake_flow_id))
+        response = await client.get(
+            self.applet_flow_detail.format(applet_id=applet_activity_flow.id, flow_id=fake_flow_id)
+        )
 
         assert response.status_code == http.HTTPStatus.NOT_FOUND
         result = response.json()["result"]


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-6521](https://mindlogger.atlassian.net/browse/M2-6521)

This PR implements the `/activities/applet/{applet_id}/flows/{flow_id}` endpoint to get details of an activity flow. The endpoint returns the following properties:
- name
- description
- isSingleReport
- hideBadge
- reportIncludedActivityName
- reportIncludedItemName
- isHidden
- id
- items
- order
- createdAt

This is identical to the `/activities/flows/applet/{applet_id}` endpoint

### 🪤 Peer Testing

Observe the automated tests, then go to https://localhost:8000/docs#/Activities/applet_flow_activities_applet__applet_id__flows__flow_id__get and test it out yourself

### ✏️ Notes

I originally implemented this as a pre-requisite of another Jira ticket (see comments for ticket number), but I later realised it's actually not necessary. However, I already implemented it so I might as well share the code. Whether we still want to merge it, I'll accept feedback on.
