### PR TITLE
fix(mi): support ordering by encrypted fields (M2-6664)

### DIFF
--- a/src/apps/shared/domain/response/core.py
+++ b/src/apps/shared/domain/response/core.py
@@ -7,13 +7,19 @@ from apps.shared.domain.types import _BaseModel
 
 
 class ResponseMulti(PublicModel, GenericModel, Generic[_BaseModel]):
-    """Generic response model that consist multiple result."""
+    """Generic response model that consists of multiple results."""
 
     result: list[_BaseModel]
     count: int = 0
 
 
+class ResponseMultiOrdering(ResponseMulti, GenericModel, Generic[_BaseModel]):
+    """Generic response model that consists of multiple results and a list of sortable fields."""
+
+    ordering_fields: list[str]
+
+
 class Response(PublicModel, GenericModel, Generic[_BaseModel]):
-    """Generic response model that consist only one result."""
+    """Generic response model that consists of only one result."""
 
     result: _BaseModel | None

--- a/src/apps/shared/ordering.py
+++ b/src/apps/shared/ordering.py
@@ -182,6 +182,9 @@ class Ordering:
                     result = (left_value > right_value) - (left_value < right_value)
                 elif isinstance(left_value, str):
                     right_value = cast(str, right_value)
+                    # Convert to lowercase for case-insensitive ordering
+                    left_value = left_value.lower()
+                    right_value = right_value.lower()
                     result = (left_value > right_value) - (left_value < right_value)
 
                 multiplier = -1 if direction == "-" else 1

--- a/src/apps/shared/ordering.py
+++ b/src/apps/shared/ordering.py
@@ -1,21 +1,58 @@
+from functools import cmp_to_key
+from typing import Literal, cast
+
 from sqlalchemy import Column, asc, desc
+
+from .domain.base import to_camelcase
 
 __all__ = ["Ordering"]
 
 from sqlalchemy.orm import InstrumentedAttribute
 
+OrderingDirection = Literal["+", "-"]
+OrderingField = str | tuple[str, int]
+
 
 class Ordering:
     """
-    Generates clauses for ordering
+    Generates clauses for SQL ordering and utilities for manual ordering & pagination, if needed.
+
+    For SQL ordering, add supported fields directly as class attributes as schema columns or
+    ordering clauses.
+
+    For manual ordering (i.e. required by encrypted fields), add them to the manual_fields
+    dictionary, with the key representing the requested ordering field, and the value representing
+    the column name as returned in each result record.
+        **Note:** Also include in this dictionary any fields that are also supported by SQL
+        ordering so that multi-key ordering continues to be supported when ordering manually.
+
     Example:
         class ExampleOrdering(Ordering):
             id = Schema.id
-            name = Schema.first_name
+            date = Schema.created_at
 
-        ExampleOrdering().get_clauses('-id', 'name')
-        will give result as sql:
-        select * from schema order by id desc, first_name asc
+            # manual_fields is optional, only needed if one or more fields are encrypted
+            manual_fields = {
+                "email": "email_encrypted",     # encrypted scalar field
+                "nicknames": ("nicknames", 0),  # encrypted array field, index 0
+                "id": "id",
+                "date": "created_at",
+            }
+
+        ordering = ExampleOrdering()
+        query.order_by(*ordering.get_clauses('-id', 'date'))
+        # will give result as SQL:
+        # select * from schema order by id desc, created_at asc
+
+        manual_fields = ordering.get_manual_fields("nicknames", "email", "-date")
+        if manual_fields:
+            # run SQL query without ORDER BY query
+            # then manually sort the results using manual_sort utility:
+            data = ordering.manual_sort(data, manual_fields)
+            # manually sorts decrypted data by:
+            #   nicknames[0] (asc), email_encrypted (asc), then created_at (desc)
+            data = ordering.manual_paginate(data, 1, 10)
+            # manually paginates data, returns slice of first 10 records
     """
 
     class Clause:
@@ -26,13 +63,16 @@ class Ordering:
         def __init__(self, clause):
             self.clause = clause
 
+    sql_fields: dict[str, Column] = dict()
+    manual_fields: dict[str, OrderingField] = dict()
+
     actions = {
         "+": asc,
         "-": desc,
     }
 
     def __init__(self):
-        self.fields = dict()
+        self.sql_fields = dict()
         for key, val in self.__class__.__dict__.items():
             _val = None
             if isinstance(val, (InstrumentedAttribute, Column)):
@@ -40,26 +80,116 @@ class Ordering:
             elif isinstance(val, Ordering.Clause):
                 _val = val.clause
             if _val is not None:
-                self.fields[key] = _val
+                self.sql_fields[key] = _val
 
-    def get_clauses(self, *args):
-        sorting_fields = []
+    # Returns array of parsed ordering arguments if any of the fields require manual sorting
+    # (defined is self.manual_fields, but not in self.fields), else returns None.
+    def get_manual_fields(self, *args: str):
+        has_manual_only_fields = False
+        parsed_fields: list[tuple[OrderingDirection, OrderingField]] = []
         for value in args:
-            ordering_field = self._prepare_ordered_field(value)
-            if ordering_field is not None:
-                sorting_fields.append(ordering_field)
-        return sorting_fields
+            parsed_field = self._parse_ordered_field(value)
+            if parsed_field is None:
+                continue
+            direction, field = parsed_field
+            if not self._is_manual_field(field):
+                continue
+            parsed_fields.append((direction, self.manual_fields[field]))
+            # Flag if any of the fields cannot be sorted by SQL (i.e. manual only)
+            if not self._is_sql_field(field):
+                has_manual_only_fields = True
+        return parsed_fields if has_manual_only_fields else None
 
-    def _prepare_ordered_field(self, value: str):
+    # Returns SQL clauses suitable for Query.order_by based on provided "+field"-style args
+    def get_clauses(self, *args):
+        clauses: list[str] = []
+        for value in args:
+            parsed_field = self._parse_ordered_field(value)
+            if parsed_field is None:
+                continue
+            _direction, field = parsed_field
+            if not self._is_sql_field(field):
+                continue
+            clause = self._prepare_sql_clause(parsed_field)
+            if clause is not None:
+                clauses.append(clause)
+        return clauses
+
+    # Returns list of fields that this Ordering class supports for sorting, based on whether
+    # to use manual sorting or not. Returns field names in camelCase suitable for API output.
+    def get_ordering_fields(self, use_manual_sorting: bool = False):
+        use_manual_sorting = use_manual_sorting and bool(self.manual_fields)
+        fields = (self.manual_fields if use_manual_sorting else self.sql_fields).keys()
+        return list(to_camelcase(word) for word in fields)
+
+    def _is_sql_field(self, field: str):
+        return field in self.sql_fields
+
+    def _is_manual_field(self, field: str):
+        return field in self.manual_fields
+
+    def _parse_ordered_field(self, value: str):
         if not value:
             return None
-        sign, field = value[0], value[1:]
-        if sign != "-":
+        direction, field = value[0], value[1:]
+        if direction != "-":
             field = value
-            sign = "+"
+            direction = "+"
         field = field.lstrip("+")
+        return (direction, field)
 
-        if field not in self.fields:
+    def _prepare_sql_clause(self, value: tuple[OrderingDirection, str]):
+        direction, field = value
+        if not self._is_sql_field(field):
             return None
 
-        return self.actions[sign](self.fields[field])
+        return self.actions[direction](self.sql_fields[field])
+
+    def manual_sort(self, data: list, fields: list[tuple[OrderingDirection, OrderingField]]):
+        def comparer(left, right):
+            for direction, field in fields:
+                left_value = right_value = None
+                # Extract array field value
+                if isinstance(field, tuple):
+                    field, index = field
+                    left_value = left[field][index]
+                    right_value = right[field][index]
+                # Extract scalar field value
+                else:
+                    left_value = left[field]
+                    right_value = right[field]
+
+                # Protect against None values (None ranks lowest in SQL by default)
+                if left_value is None and right_value is None:
+                    continue
+                elif left_value is None:
+                    # Set left value to maximum possible value for the type
+                    if isinstance(right_value, (int, float)):
+                        left_value = float("inf")  # maximum number
+                    elif isinstance(right_value, str):
+                        left_value = chr(1114111)  # maximum string
+                elif right_value is None:
+                    # Set right value to maximum possible value for the type
+                    if isinstance(left_value, (int, float)):
+                        right_value = float("inf")  # maximum number
+                    elif isinstance(left_value, str):
+                        right_value = chr(1114111)  # maximum string
+
+                result = 0
+                # Need to do conditional type casting strictly to satisfy type checker
+                if isinstance(left_value, (int, float)):
+                    right_value = cast(float, right_value)
+                    result = (left_value > right_value) - (left_value < right_value)
+                elif isinstance(left_value, str):
+                    right_value = cast(str, right_value)
+                    result = (left_value > right_value) - (left_value < right_value)
+
+                multiplier = -1 if direction == "-" else 1
+                if result:
+                    return multiplier * result
+            return 0
+
+        return sorted(data, key=cmp_to_key(comparer))
+
+    def manual_paginate(self, data: list, page_number: int, page_size: int):
+        return data[(page_number - 1) * page_size : page_number * page_size]

--- a/src/apps/shared/ordering.py
+++ b/src/apps/shared/ordering.py
@@ -1,5 +1,4 @@
-from functools import cmp_to_key
-from typing import Literal, cast
+from typing import Literal
 
 from sqlalchemy import Column, asc, desc
 
@@ -10,49 +9,59 @@ __all__ = ["Ordering"]
 from sqlalchemy.orm import InstrumentedAttribute
 
 OrderingDirection = Literal["+", "-"]
-OrderingField = str | tuple[str, int]
+
+# Record limit for ordering by encrypted fields to minimize performance impact
+ENCRYPTED_ORDERING_LIMIT = 300
 
 
 class Ordering:
     """
-    Generates clauses for SQL ordering and utilities for manual ordering & pagination, if needed.
+    Generates clauses for SQL ordering, with support for conditional ordering by encrypted fields.
 
-    For SQL ordering, add supported fields directly as class attributes as schema columns or
+    For unencrypted fields, define them directly as class attributes as schema columns or
     ordering clauses.
 
-    For manual ordering (i.e. required by encrypted fields), add them to the manual_fields
-    dictionary, with the key representing the requested ordering field, and the value representing
-    the column name as returned in each result record.
-        **Note:** Also include in this dictionary any fields that are also supported by SQL
-        ordering so that multi-key ordering continues to be supported when ordering manually.
+    For encrypted fields, add them to the encrypted_fields dictionary as ordering clauses
+    (including decryption logic).
+
+    Clauses returned by get_clauses will only include requested encrypted fields only if record
+    count is below ENCRYPTED_ORDERING_LIMIT.
 
     Example:
-        class ExampleOrdering(Ordering):
+
+    ```
+        class BasicOrdering(Ordering):
             id = Schema.id
             date = Schema.created_at
 
-            # manual_fields is optional, only needed if one or more fields are encrypted
-            manual_fields = {
-                "email": "email_encrypted",     # encrypted scalar field
-                "nicknames": ("nicknames", 0),  # encrypted array field, index 0
-                "id": "id",
-                "date": "created_at",
+        ordering = BasicOrdering()
+        query.order_by(*ordering.get_clauses('-id', 'date'))
+        # Will give result as SQL:
+        #   select * from schema order by id desc, created_at asc
+
+
+        class EncryptedOrdering(Ordering):
+            id = Schema.id
+            date = Schema.created_at
+
+            # encrypted_fields is optional, only needed if one or more fields are encrypted
+            encrypted_fields = {
+                "email": Ordering.Clause(func.decrypt_internal(UserSchema.email, get_key())),
             }
 
-        ordering = ExampleOrdering()
-        query.order_by(*ordering.get_clauses('-id', 'date'))
-        # will give result as SQL:
-        # select * from schema order by id desc, created_at asc
-
-        manual_fields = ordering.get_manual_fields("nicknames", "email", "-date")
-        if manual_fields:
-            # run SQL query without ORDER BY query
-            # then manually sort the results using manual_sort utility:
-            data = ordering.manual_sort(data, manual_fields)
-            # manually sorts decrypted data by:
-            #   nicknames[0] (asc), email_encrypted (asc), then created_at (desc)
-            data = ordering.manual_paginate(data, 1, 10)
-            # manually paginates data, returns slice of first 10 records
+        ordering = EncryptedOrdering()
+        count = (await session.execute(
+            select(count()).select_from(query.with_only_columns(Schema.id).subquery())
+        )).scalar()
+        query.order_by(*ordering.get_clauses_encrypted("email", "-date", count=count))
+        # If count < ENCRYPTED_ORDERING_LIMIT, will give result as SQL:
+        #   select * from schema order by decrypt_internal(email, …) asc, created_at desc
+        # and EncryptedOrdering().get_ordering_fields(count) will return ["id", "date", "email"]
+        #
+        # Else if count >= ENCRYPTED_ORDERING_LIMIT, will give result as SQL:
+        #   select * from schema order by created_at desc
+        # and EncryptedOrdering().get_ordering_fields(count) will return ["id", "date"]
+    ```
     """
 
     class Clause:
@@ -63,8 +72,8 @@ class Ordering:
         def __init__(self, clause):
             self.clause = clause
 
-    sql_fields: dict[str, Column] = dict()
-    manual_fields: dict[str, OrderingField] = dict()
+    fields: dict[str, InstrumentedAttribute | Column | Clause] = dict()
+    encrypted_fields: dict[str, InstrumentedAttribute | Column | Clause] = dict()
 
     actions = {
         "+": asc,
@@ -72,7 +81,7 @@ class Ordering:
     }
 
     def __init__(self):
-        self.sql_fields = dict()
+        self.fields = dict()
         for key, val in self.__class__.__dict__.items():
             _val = None
             if isinstance(val, (InstrumentedAttribute, Column)):
@@ -80,53 +89,54 @@ class Ordering:
             elif isinstance(val, Ordering.Clause):
                 _val = val.clause
             if _val is not None:
-                self.sql_fields[key] = _val
+                self.fields[key] = _val
 
-    # Returns array of parsed ordering arguments if any of the fields require manual sorting
-    # (defined is self.manual_fields, but not in self.fields), else returns None.
-    def get_manual_fields(self, *args: str):
-        has_manual_only_fields = False
-        parsed_fields: list[tuple[OrderingDirection, OrderingField]] = []
-        for value in args:
-            parsed_field = self._parse_ordered_field(value)
-            if parsed_field is None:
-                continue
-            direction, field = parsed_field
-            if not self._is_manual_field(field):
-                continue
-            parsed_fields.append((direction, self.manual_fields[field]))
-            # Flag if any of the fields cannot be sorted by SQL (i.e. manual only)
-            if not self._is_sql_field(field):
-                has_manual_only_fields = True
-        return parsed_fields if has_manual_only_fields else None
+        for key, val in self.encrypted_fields.items():
+            _val = None
+            if isinstance(val, (InstrumentedAttribute, Column)):
+                _val = val
+            elif isinstance(val, Ordering.Clause):
+                _val = val.clause
+            if _val is not None:
+                self.encrypted_fields[key] = _val
 
-    # Returns SQL clauses suitable for Query.order_by based on provided "+field"-style args
-    def get_clauses(self, *args):
+    def get_clauses(self, *args: str, count: int = 0):
+        """
+        Returns SQL clauses suitable for Query.order_by based on provided "+field"-style args,
+        including any requested encrypted fields only if provided record count is below
+        ENCRYPTED_ORDERING_LIMIT.
+        """
         clauses: list[str] = []
         for value in args:
             parsed_field = self._parse_ordered_field(value)
             if parsed_field is None:
                 continue
-            _direction, field = parsed_field
-            if not self._is_sql_field(field):
+
+            direction, field = parsed_field
+            clause = None
+            if field in self.fields:
+                clause = self._prepare_sql_clause((direction, self.fields[field]))
+            elif field in self.encrypted_fields and count < ENCRYPTED_ORDERING_LIMIT:
+                clause = self._prepare_sql_clause((direction, self.encrypted_fields[field]))
+            else:
                 continue
-            clause = self._prepare_sql_clause(parsed_field)
+
             if clause is not None:
                 clauses.append(clause)
         return clauses
 
-    # Returns list of fields that this Ordering class supports for sorting, based on whether
-    # to use manual sorting or not. Returns field names in camelCase suitable for API output.
-    def get_ordering_fields(self, use_manual_sorting: bool = False):
-        use_manual_sorting = use_manual_sorting and bool(self.manual_fields)
-        fields = (self.manual_fields if use_manual_sorting else self.sql_fields).keys()
+    def get_ordering_fields(self, count: int = 0):
+        """
+        Returns list of fields that this Ordering class supports for sorting, which includes
+        encrypted fields only if provided record count is below ENCRYPTED_ORDERING_LIMIT.
+
+        Returns field names in camelCase suitable for API output.
+        """
+        fields = [*self.fields.keys()]
+        include_encrypted_fields = bool(self.encrypted_fields) and count < ENCRYPTED_ORDERING_LIMIT
+        if include_encrypted_fields:
+            fields += self.encrypted_fields.keys()
         return list(to_camelcase(word) for word in fields)
-
-    def _is_sql_field(self, field: str):
-        return field in self.sql_fields
-
-    def _is_manual_field(self, field: str):
-        return field in self.manual_fields
 
     def _parse_ordered_field(self, value: str):
         if not value:
@@ -138,61 +148,7 @@ class Ordering:
         field = field.lstrip("+")
         return (direction, field)
 
-    def _prepare_sql_clause(self, value: tuple[OrderingDirection, str]):
-        direction, field = value
-        if not self._is_sql_field(field):
-            return None
+    def _prepare_sql_clause(self, value: tuple[OrderingDirection, InstrumentedAttribute | Column | Clause]):
+        direction, expression = value
 
-        return self.actions[direction](self.sql_fields[field])
-
-    def manual_sort(self, data: list, fields: list[tuple[OrderingDirection, OrderingField]]):
-        def comparer(left, right):
-            for direction, field in fields:
-                left_value = right_value = None
-                # Extract array field value
-                if isinstance(field, tuple):
-                    field, index = field
-                    left_value = left[field][index]
-                    right_value = right[field][index]
-                # Extract scalar field value
-                else:
-                    left_value = left[field]
-                    right_value = right[field]
-
-                # Protect against None values (None ranks lowest in SQL by default)
-                if left_value is None and right_value is None:
-                    continue
-                elif left_value is None:
-                    # Set left value to maximum possible value for the type
-                    if isinstance(right_value, (int, float)):
-                        left_value = float("inf")  # maximum number
-                    elif isinstance(right_value, str):
-                        left_value = chr(1114111)  # maximum string
-                elif right_value is None:
-                    # Set right value to maximum possible value for the type
-                    if isinstance(left_value, (int, float)):
-                        right_value = float("inf")  # maximum number
-                    elif isinstance(left_value, str):
-                        right_value = chr(1114111)  # maximum string
-
-                result = 0
-                # Need to do conditional type casting strictly to satisfy type checker
-                if isinstance(left_value, (int, float)):
-                    right_value = cast(float, right_value)
-                    result = (left_value > right_value) - (left_value < right_value)
-                elif isinstance(left_value, str):
-                    right_value = cast(str, right_value)
-                    # Convert to lowercase for case-insensitive ordering
-                    left_value = left_value.lower()
-                    right_value = right_value.lower()
-                    result = (left_value > right_value) - (left_value < right_value)
-
-                multiplier = -1 if direction == "-" else 1
-                if result:
-                    return multiplier * result
-            return 0
-
-        return sorted(data, key=cmp_to_key(comparer))
-
-    def manual_paginate(self, data: list, page_number: int, page_size: int):
-        return data[(page_number - 1) * page_size : page_number * page_size]
+        return self.actions[direction](expression)

--- a/src/apps/shared/test/base.py
+++ b/src/apps/shared/test/base.py
@@ -16,6 +16,7 @@ class BaseTest:
     @pytest.fixture(scope="class", autouse=True)
     async def initialize(self):
         try:
+            await self.initialize_db()
             await self.populate_db()
             yield
         finally:
@@ -24,6 +25,13 @@ class BaseTest:
     @pytest.fixture(autouse=True)
     async def clear_mails(self):
         TestMail.clear_mails()
+
+    async def initialize_db(self):
+        AsyncSession = session_manager.get_session()
+        async with AsyncSession() as session:
+            query = text("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+            await session.execute(query)
+            await session.commit()
 
     async def populate_db(self):
         for fixture in self.fixtures:

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -11,7 +11,7 @@ from apps.applets.service import AppletService
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
-from apps.shared.domain import Response, ResponseMulti
+from apps.shared.domain import Response, ResponseMulti, ResponseMultiOrdering
 from apps.shared.exception import NotFoundError
 from apps.shared.query_params import BaseQueryParams, QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
@@ -237,17 +237,17 @@ async def workspace_respondents_list(
     query_params: QueryParams = Depends(parse_query_params(WorkspaceUsersQueryParams)),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
-) -> ResponseMulti[PublicWorkspaceRespondent]:
+) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
     service = WorkspaceService(session, user.id)
     await service.exists_by_owner_id(owner_id)
 
     await CheckAccessService(session, user.id).check_workspace_respondent_list_access(owner_id)
 
-    data, total = await service.get_workspace_respondents(owner_id, None, deepcopy(query_params))
+    data, total, ordering_fields = await service.get_workspace_respondents(owner_id, None, deepcopy(query_params))
     respondents = await AnswerService(
         session=session, arbitrary_session=answer_session
     ).fill_last_activity_workspace_respondent(data)
-    return ResponseMulti(result=respondents, count=total)
+    return ResponseMultiOrdering(result=respondents, count=total, ordering_fields=ordering_fields)
 
 
 async def workspace_applet_respondents_list(
@@ -263,11 +263,11 @@ async def workspace_applet_respondents_list(
 
     await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
-    data, total = await service.get_workspace_respondents(owner_id, applet_id, deepcopy(query_params))
+    data, total, ordering_fields = await service.get_workspace_respondents(owner_id, applet_id, deepcopy(query_params))
     respondents = await AnswerService(
         session=session, arbitrary_session=answer_session
     ).fill_last_activity_workspace_respondent(data, applet_id)
-    return ResponseMulti(result=respondents, count=total)
+    return ResponseMultiOrdering(result=respondents, count=total, ordering_fields=ordering_fields)
 
 
 async def workspace_managers_list(
@@ -275,13 +275,13 @@ async def workspace_managers_list(
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(WorkspaceUsersQueryParams)),
     session=Depends(get_session),
-) -> ResponseMulti[PublicWorkspaceManager]:
+) -> ResponseMultiOrdering[PublicWorkspaceManager]:
     service = WorkspaceService(session, user.id)
     await service.exists_by_owner_id(owner_id)
 
     await CheckAccessService(session, user.id).check_workspace_manager_list_access(owner_id)
 
-    data, total = await service.get_workspace_managers(owner_id, None, deepcopy(query_params))
+    data, total, ordering_fields = await service.get_workspace_managers(owner_id, None, deepcopy(query_params))
     workspaces_manager = []
     for workspace_manager in data:
         workspaces_manager.append(
@@ -297,7 +297,7 @@ async def workspace_managers_list(
                 title=workspace_manager.title,
             )
         )
-    return ResponseMulti(result=workspaces_manager, count=total)
+    return ResponseMultiOrdering(result=workspaces_manager, count=total, ordering_fields=ordering_fields)
 
 
 async def workspace_applet_managers_list(
@@ -306,13 +306,13 @@ async def workspace_applet_managers_list(
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(WorkspaceUsersQueryParams)),
     session=Depends(get_session),
-) -> ResponseMulti[PublicWorkspaceManager]:
+) -> ResponseMultiOrdering[PublicWorkspaceManager]:
     service = WorkspaceService(session, user.id)
     await service.exists_by_owner_id(owner_id)
 
     await CheckAccessService(session, user.id).check_applet_manager_list_access(applet_id)
 
-    data, total = await service.get_workspace_managers(owner_id, applet_id, deepcopy(query_params))
+    data, total, ordering_fields = await service.get_workspace_managers(owner_id, applet_id, deepcopy(query_params))
     workspaces_manager = []
     for workspace_manager in data:
         workspaces_manager.append(
@@ -328,7 +328,7 @@ async def workspace_applet_managers_list(
                 title=workspace_manager.title,
             )
         )
-    return ResponseMulti(result=workspaces_manager, count=total)
+    return ResponseMultiOrdering(result=workspaces_manager, count=total, ordering_fields=ordering_fields)
 
 
 async def workspace_respondent_pin(

--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -69,6 +69,8 @@ class _WorkspaceRespondentOrdering(Ordering):
     tags = Ordering.Clause(literal_column("tags_order"))
     created_at = Ordering.Clause(func.min(UserAppletAccessSchema.created_at))
     status = Ordering.Clause(literal_column("status_order"))
+    # TODO: https://mindlogger.atlassian.net/browse/M2-6834
+    # Add support to order by last_seen
 
     # Because nickname is encrypted, we need to support manual sorting by that field as well as any
     # other field (in order to support manual sorting by multiple keys)

--- a/src/apps/workspaces/router.py
+++ b/src/apps/workspaces/router.py
@@ -6,7 +6,7 @@ from starlette import status
 from apps.applets.api import applet_create
 from apps.applets.domain.applet_full import PublicAppletFull
 from apps.applets.domain.applets import public_detail
-from apps.shared.domain import Response, ResponseMulti
+from apps.shared.domain import Response, ResponseMulti, ResponseMultiOrdering
 from apps.shared.domain.response import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE
 from apps.shared.response import EmptyResponse
 from apps.workspaces.api import (
@@ -163,9 +163,9 @@ router.post(
 router.get(
     "/{owner_id}/respondents",
     status_code=status.HTTP_200_OK,
-    response_model=ResponseMulti[PublicWorkspaceRespondent],
+    response_model=ResponseMultiOrdering[PublicWorkspaceRespondent],
     responses={
-        status.HTTP_200_OK: {"model": ResponseMulti[PublicWorkspaceRespondent]},
+        status.HTTP_200_OK: {"model": ResponseMultiOrdering[PublicWorkspaceRespondent]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },
@@ -174,9 +174,9 @@ router.get(
 router.get(
     "/{owner_id}/applets/{applet_id}/respondents",
     status_code=status.HTTP_200_OK,
-    response_model=ResponseMulti[PublicWorkspaceRespondent],
+    response_model=ResponseMultiOrdering[PublicWorkspaceRespondent],
     responses={
-        status.HTTP_200_OK: {"model": ResponseMulti[PublicWorkspaceRespondent]},
+        status.HTTP_200_OK: {"model": ResponseMultiOrdering[PublicWorkspaceRespondent]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },
@@ -185,9 +185,9 @@ router.get(
 router.get(
     "/{owner_id}/managers",
     status_code=status.HTTP_200_OK,
-    response_model=ResponseMulti[PublicWorkspaceManager],
+    response_model=ResponseMultiOrdering[PublicWorkspaceManager],
     responses={
-        status.HTTP_200_OK: {"model": ResponseMulti[PublicWorkspaceManager]},
+        status.HTTP_200_OK: {"model": ResponseMultiOrdering[PublicWorkspaceManager]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },
@@ -196,9 +196,9 @@ router.get(
 router.get(
     "/{owner_id}/applets/{applet_id}/managers",
     status_code=status.HTTP_200_OK,
-    response_model=ResponseMulti[PublicWorkspaceManager],
+    response_model=ResponseMultiOrdering[PublicWorkspaceManager],
     responses={
-        status.HTTP_200_OK: {"model": ResponseMulti[PublicWorkspaceManager]},
+        status.HTTP_200_OK: {"model": ResponseMultiOrdering[PublicWorkspaceManager]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },

--- a/src/apps/workspaces/service/workspace.py
+++ b/src/apps/workspaces/service/workspace.py
@@ -90,28 +90,28 @@ class WorkspaceService:
         owner_id: uuid.UUID,
         applet_id: uuid.UUID | None,
         query_params: QueryParams,
-    ) -> Tuple[list[WorkspaceRespondent], int]:
-        users, total = await UserAppletAccessCRUD(self.session).get_workspace_respondents(
+    ) -> Tuple[list[WorkspaceRespondent], int, list[str]]:
+        users, total, ordering_fields = await UserAppletAccessCRUD(self.session).get_workspace_respondents(
             self._user_id, owner_id, applet_id, query_params
         )
-        return users, total
+        return users, total, ordering_fields
 
     async def get_workspace_managers(
         self,
         owner_id: uuid.UUID,
         applet_id: uuid.UUID | None,
         query_params: QueryParams,
-    ) -> Tuple[list[WorkspaceManager], int]:
+    ) -> Tuple[list[WorkspaceManager], int, list[str]]:
         # TODO: Investigate if we do need the search by email
         # hash the email is exist in the search
         # if query_params.search and EMAIL_REGEX.match(query_params.search):
         #     query_params.search = hash_sha224(query_params.search)
 
-        users, total = await UserAppletAccessCRUD(self.session).get_workspace_managers(
+        users, total, ordering_fields = await UserAppletAccessCRUD(self.session).get_workspace_managers(
             self._user_id, owner_id, applet_id, query_params
         )
 
-        return users, total
+        return users, total, ordering_fields
 
     async def get_workspace_applets(
         self, owner_id: uuid.UUID, language: str, query_params: QueryParams
@@ -309,8 +309,8 @@ class WorkspaceService:
         owner_id: uuid.UUID,
         applet_id: uuid.UUID | None,
         query_params: QueryParams,
-    ) -> Tuple[list[WorkspaceRespondent], int]:
-        users, total = await UserAppletAccessCRUD(self.session).get_workspace_respondents(
+    ) -> Tuple[list[WorkspaceRespondent], int, list[str]]:
+        users, total, sortable_fields = await UserAppletAccessCRUD(self.session).get_workspace_respondents(
             self._user_id, owner_id, applet_id, query_params
         )
-        return users, total
+        return users, total, sortable_fields

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -386,12 +386,12 @@ class TestWorkspaces(BaseTest):
         # test manual, case-insensitive ordering by encrypted nicknames field
         assert set(data.keys()) == {"count", "result", "orderingFields"}
         assert data["orderingFields"] == [
-            "nicknames",
             "isPinned",
             "secretIds",
             "tags",
             "createdAt",
             "status",
+            "nicknames",
         ]
         assert data["result"][0]["nicknames"] == ["Lucy Gabel"]
         assert data["result"][1]["nicknames"] == ["shell-account-0"]
@@ -528,13 +528,13 @@ class TestWorkspaces(BaseTest):
         # test manual ordering by encrypted email field
         assert set(data.keys()) == {"count", "result", "orderingFields"}
         assert data["orderingFields"] == [
-            "email",
-            "firstName",
-            "lastName",
             "createdAt",
             "isPinned",
             "lastSeen",
             "roles",
+            "email",
+            "firstName",
+            "lastName",
         ]
         assert data["result"][0]["email"] == lucy.email_encrypted
         assert data["result"][1]["email"] == tom.email_encrypted

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -358,18 +358,45 @@ class TestWorkspaces(BaseTest):
         response = await client.get(self.workspace_applets_url.format(owner_id="00000000-0000-0000-0000-000000000000"))
         assert response.status_code == 404
 
-    async def test_get_workspace_respondents(self, client, tom, applet_one_lucy_respondent):
+    async def test_get_workspace_respondents(
+        self,
+        client,
+        tom,
+        user: User,
+        lucy: User,
+        applet_one_lucy_respondent,
+        applet_one_user_respondent,
+        applet_three_tom_respondent,
+        applet_three_user_respondent,
+        applet_one_shell_account: Subject,
+    ):
         client.login(tom)
         response = await client.get(
             self.workspace_respondents_url.format(owner_id=tom.id),
+            dict(ordering="+nicknames"),
         )
 
         assert response.status_code == 200
         data = response.json()
-        assert data["count"] == 2  # tom(applet1, applet2), lucy(applet1)
+        assert data["count"] == 4  # lucy, tom, shell account, user
         assert data["count"] == len(data["result"])
         assert data["result"][0]["nicknames"]
         assert data["result"][0]["secretIds"]
+
+        # test manual, case-insensitive ordering by encrypted nicknames field
+        assert set(data.keys()) == {"count", "result", "orderingFields"}
+        assert data["orderingFields"] == [
+            "nicknames",
+            "isPinned",
+            "secretIds",
+            "tags",
+            "createdAt",
+            "status",
+        ]
+        assert data["result"][0]["nicknames"] == ["Lucy Gabel"]
+        assert data["result"][1]["nicknames"] == ["shell-account-0"]
+        assert data["result"][2]["nicknames"] == ["Tom Isaak"]
+        assert data["result"][3]["nicknames"] == ["user test"]
 
         # test search
         access_id_0 = data["result"][0]["details"][0]["accessId"]
@@ -388,7 +415,7 @@ class TestWorkspaces(BaseTest):
                 )
                 assert response.status_code == 200
                 data = response.json()
-                assert set(data.keys()) == {"count", "result"}
+                assert set(data.keys()) == {"count", "result", "orderingFields"}
                 assert data["count"] == 1
                 result = data["result"]
                 assert len(result) == 1
@@ -491,15 +518,26 @@ class TestWorkspaces(BaseTest):
         client.login(tom)
         response = await client.get(
             self.workspace_managers_url.format(owner_id=tom.id),
+            dict(ordering="+email"),
         )
 
         assert response.status_code == 200
-        assert response.json()["count"] == 2
+        data = response.json()
+        assert data["count"] == 2
 
-        plain_emails = [tom.email_encrypted, lucy.email_encrypted]
-
-        for result in response.json()["result"]:
-            assert result["email"] in plain_emails
+        # test manual ordering by encrypted email field
+        assert set(data.keys()) == {"count", "result", "orderingFields"}
+        assert data["orderingFields"] == [
+            "email",
+            "firstName",
+            "lastName",
+            "createdAt",
+            "isPinned",
+            "lastSeen",
+            "roles",
+        ]
+        assert data["result"][0]["email"] == lucy.email_encrypted
+        assert data["result"][1]["email"] == tom.email_encrypted
 
         # test search
         search_params = {
@@ -519,7 +557,7 @@ class TestWorkspaces(BaseTest):
 
                 assert response.status_code == 200
                 data = response.json()
-                assert set(data.keys()) == {"count", "result"}
+                assert set(data.keys()) == {"count", "result", "orderingFields"}
                 assert data["count"] == 1
                 result = data["result"]
                 assert len(result) == 1
@@ -563,7 +601,7 @@ class TestWorkspaces(BaseTest):
 
                 assert response.status_code == 200
                 data = response.json()
-                assert set(data.keys()) == {"count", "result"}
+                assert set(data.keys()) == {"count", "result", "orderingFields"}
                 assert data["count"] == 1
                 result = data["result"]
                 assert len(result) == 1


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [x] Related documentation has been added / updated

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6664](https://mindlogger.atlassian.net/browse/M2-6664)

Adds support to order respondents and managers by encrypted fields (manager `first_name`, `last_name` & `email`, and respondent `nicknames`), and some fields that were not previously supported.

- Extended the `Ordering` class to support ordering by regular fields, as well as by encrypted fields conditional on # of records. Due to SQL decryption being a more expensive operation, ordering by encrypted fields is conditional on result set being small enough to not overload SQL server (currently set to 300 results).
- `respondents` & `managers` endpoints now also report which fields are supported for ordering via the `orderingFields` key in the response so that frontends can disable ordering on unsupported columns (in the case of exceeding the result limit threshold).
-  Also adds more nuanced sorting by the respondent `status` field (first grouping pending & full accounts before listing limited accounts).

> [!NOTE]
> Sorting by respondent `last_seen` field was not working, and is still unsupported due to it being calculated dynamically post-SQL and post-pagination. Created `M2-6834` to handle it.

### 🪤 Peer Testing

Prerequisites:

- an admin account
- an applet in that account
- several **managers** associated with the applet, with different **first & last names** & **emails** but **at least two managers with the same last name**
- several **respondents** associated with the applet, with different nicknames, including **limited**, **pending**, and **full** accounts
- get your `owner_id` from `GET /workspaces` via http://127.0.0.1:8000/docs.

1. Execute `/workspaces/{owner_id}/managers` using the returned `owner_id`
    **Expected outcome:** Response should include `orderingFields` attribute containing:
    ```json
    "orderingFields": [
      "createdAt",
      "isPinned",
      "lastSeen",
      "roles",
      "email",
      "firstName",
      "lastName"
    ]
    ```
2. Repeat step 1 with `ordering` parameter set to `+lastName,+firstName`
    **Expected outcome:** Response should return results in ascending order by last name, then ascending order by first name
3. Repeat step 1 with `ordering` parameter set to `+lastName,-firstName`
    **Expected outcome:** Response should return results in ascending order by last name, then descending order by first name
4. Edit [line 14](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/b406b295987c05a2af7129289aa89559a8662d06/src/apps/shared/ordering.py#L14) of `src/apps/shared/ordering.py` to temporarily set `ENCRYPTED_ORDERING_LIMIT` to a value that is less than the total # of records. Repeat step 1.
    **Expected outcome:** Response should include `orderingFields` attribute containing:
    ```json
    "orderingFields": [
      "createdAt",
      "isPinned",
      "lastSeen",
      "roles"
    ]
    ```
5. Restore the original value of `ENCRYPTED_ORDERING_LIMIT`.
6. Execute `/workspaces/{owner_id}/respondents` using the returned `owner_id`
    **Expected outcome:** Response should include `orderingFields` attribute containing:
    ```json
    "orderingFields": [
      "isPinned",
      "secretIds",
      "tags",
      "createdAt",
      "status",
      "nicknames"
    ]
    ```
6. Repeat step 6 with `ordering` parameter set to `+nicknames`
    **Expected outcome:** Response should return results in ascending order by first value of `nicknames` array
7. Repeat step 6 with `ordering` parameter set to `-nicknames`
    **Expected outcome:** Response should return results in descending order by first value of `nicknames` array
8. Repeat step 6 with `ordering=+nicknames`, `limit=3` , `page=2`
    **Expected outcome:** Response should return 2nd page of results, paginated in 3 results for page, in ascending order by first value of `nicknames` array
9. Edit [line 14](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/b406b295987c05a2af7129289aa89559a8662d06/src/apps/shared/ordering.py#L14) of `src/apps/shared/ordering.py` to temporarily set `ENCRYPTED_ORDERING_LIMIT` to a value that is less than the total # of records. Repeat step 6.
    **Expected outcome:** Response should include `orderingFields` attribute containing:
    ```json
    "orderingFields": [
      "isPinned",
      "secretIds",
      "tags",
      "createdAt",
      "status"
    ]
    ```
10. Repeat step 6 with `ordering` parameter set to `+status`
    **Expected outcome:** Response should return results in order by status: `pending`, `invited`, `not_invited`