### PR TITLE
M2-6669 : Reports activity export update file to map to correct mi fields

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -898,9 +898,8 @@ class AnswerService:
                 # assessment
                 respondent = user_map[answer.respondent_id]  # type: ignore
             else:
-                subject = subject_map[answer.target_subject_id]  # type: ignore
-                answer.respondent_id = subject.user_id
-                respondent = subject
+                respondent = subject_map[answer.target_subject_id]  # type: ignore
+
             answer.respondent_secret_id = respondent.secret_id
             answer.respondent_email = respondent.email
             answer.is_manager = respondent.is_manager


### PR DESCRIPTION
### 📝 Description

Update export data mapping, repondentId should be logged userId and respondentSecretId should be target user secret id

🔗 [Jira Ticket M2-6669](https://mindlogger.atlassian.net/browse/M2-6669)
🔗 [Jira Ticket M2-6557](https://mindlogger.atlassian.net/browse/M2-6557)

