### PR TITLE
feature(mi): Add `activityId` to applet submissions and stats endpoint (M2-7002)

### DIFF
--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -294,6 +294,7 @@ class AppletSubmission(PublicModel):
     created_at: datetime.datetime
     updated_at: datetime.datetime
     activity_name: str
+    activity_id: uuid.UUID
 
 
 class FlowSubmission(PublicModel):

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -909,6 +909,7 @@ class AnswerService:
                 AppletSubmission(
                     applet_id=applet_id,
                     activity_name=activity.name,
+                    activity_id=activity.id,
                     created_at=answer.created_at,
                     updated_at=answer.end_datetime,
                     target_secret_user_id=target_subject.secret_user_id,

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -2393,6 +2393,7 @@ class TestAnswerActivityItems(BaseTest):
             assert s["sourceNickname"] == answer_shell_account_target["source_nickname"]
             assert s["sourceSecretUserId"] == str(answer_shell_account_target["source_secret_user_id"])
             assert s["activityName"] is not None
+            assert s["activityId"] is not None
 
     @pytest.mark.usefixtures("applet_lucy_respondent")
     async def test_get_applet_latest_submissions_pagination(


### PR DESCRIPTION
### 📝 Description

🔗 [M2-7002](https://mindlogger.atlassian.net/browse/M2-7002): [Overview] Nothing happens if select an item in the 'Recent Submissions' block

This PR makes a minor tweak to the existing `/answers/applet/{applet_id}/submissions` endpoint, to include `activityId` in the response fields for entries in the `submissions` array.

This is necessary for the frontend to generate the URL for linking to the Participant Details page for the specific activity data.

### 🪤 Peer Testing

For an Applet with some response data…

1. Go to [localhost:8000/docs#/Answers/applet_submissions_list_answers_applet__applet_id__submissions_get](https://localhost:8000/docs#/Answers/applet_submissions_list_answers_applet__applet_id__submissions_get)
2. Plug in the applet ID, and inspect the data returned for the new properties.

[M2-6555]: https://mindlogger.atlassian.net/browse/M2-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-7002]: https://mindlogger.atlassian.net/browse/M2-7002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ