### PR TITLE
fix(sanitizing): Patch for ampersand desinitizing (M2-6757)

### DIFF
--- a/src/apps/shared/commands/patch_commands.py
+++ b/src/apps/shared/commands/patch_commands.py
@@ -84,6 +84,11 @@ PatchRegister.register(
     task_id="M2-5116",
     description="[Subject] Populate alerts with subject ids",
 )
+PatchRegister.register(
+    file_path="m2_6757_replace_amp_sanitizer.py",
+    task_id="M2-6757",
+    description="Change ampersand sanitizer to symbol '&'",
+)
 
 app = typer.Typer()
 

--- a/src/apps/shared/commands/patches/m2_6757_replace_amp_sanitizer.py
+++ b/src/apps/shared/commands/patches/m2_6757_replace_amp_sanitizer.py
@@ -1,0 +1,116 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+UPDATE_APPLET_SQL = """
+    UPDATE applets
+    SET
+        "display_name" = regexp_replace("display_name", '&amp;', '&', 'g'),
+        "about" = regexp_replace(about::text, '&amp;', '&', 'g')::jsonb,
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE
+        "display_name" LIKE '%&amp;%'
+        OR (about->>'en' LIKE '%&amp;%' OR about->>'fr' LIKE '%&amp;%')
+        OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+UPDATE_APPLET_HISTORY_SQL = """
+    UPDATE applet_histories
+    SET
+        "display_name" = regexp_replace("display_name", '&amp;', '&', 'g'),
+        "about" = regexp_replace(about::text, '&amp;', '&', 'g')::jsonb,
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE
+        "display_name" LIKE '%&amp;%'
+        OR (about->>'en' LIKE '%&amp;%' OR about->>'fr' LIKE '%&amp;%')
+        OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+UPDATE_ACTIVITY_SQL = """
+    UPDATE activities
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+UPDATE_ACTIVITY_HISTORY_SQL = """
+    UPDATE activity_histories
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+
+UPDATE_ACTIVITY_SCORES_AND_REPORTS_SQL = """
+    UPDATE activities
+    SET scores_and_reports = regexp_replace(scores_and_reports::text, '&amp;', '&', 'g')::jsonb
+    WHERE EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(scores_and_reports->'reports') AS report
+        WHERE report->>'message' LIKE '%&amp;%'
+    );
+"""
+
+UPDATE_ACTIVITY_HISTORY_SCORES_AND_REPORTS_SQL = """
+    UPDATE activity_histories
+    SET scores_and_reports = regexp_replace(scores_and_reports::text, '&amp;', '&', 'g')::jsonb
+    WHERE EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(scores_and_reports->'reports') AS report
+        WHERE report->>'message' LIKE '%&amp;%'
+    );
+"""
+
+UPDATE_ACTIVITY_ITEM_SQL = """
+    UPDATE activity_items
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "question" = regexp_replace(question::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (question->>'en' LIKE '%&amp;%' OR question->>'fr' LIKE '%&amp;%');
+"""
+UPDATE_ACTIVITY_ITEM_HISTORY_SQL = """
+    UPDATE activity_item_histories
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "question" = regexp_replace(question::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (question->>'en' LIKE '%&amp;%' OR question->>'fr' LIKE '%&amp;%');
+"""
+
+UPDATE_FLOW_SQL = """
+    UPDATE flows
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+UPDATE_FLOW_HISTORY__SQL = """
+    UPDATE flow_histories
+    SET 
+        "name" = regexp_replace("name", '&amp;', '&', 'g'),
+        "description" = regexp_replace(description::text, '&amp;', '&', 'g')::jsonb
+    WHERE "name" LIKE '%&amp;%' OR (description->>'en' LIKE '%&amp;%' OR description->>'fr' LIKE '%&amp;%');
+"""
+
+QUERIES = [
+    UPDATE_APPLET_SQL,
+    UPDATE_APPLET_HISTORY_SQL,
+    UPDATE_ACTIVITY_SQL,
+    UPDATE_ACTIVITY_HISTORY_SQL,
+    UPDATE_ACTIVITY_SCORES_AND_REPORTS_SQL,
+    UPDATE_ACTIVITY_HISTORY_SCORES_AND_REPORTS_SQL,
+    UPDATE_ACTIVITY_ITEM_SQL,
+    UPDATE_ACTIVITY_ITEM_HISTORY_SQL,
+    UPDATE_FLOW_SQL,
+    UPDATE_FLOW_HISTORY__SQL,
+]
+
+
+async def main(session: AsyncSession, *args, **kwargs):
+    try:
+        for sql in QUERIES:
+            await session.execute(sql)
+        await session.commit()
+    except Exception as ex:
+        await session.rollback()
+        raise ex

--- a/src/apps/shared/domain/custom_validations.py
+++ b/src/apps/shared/domain/custom_validations.py
@@ -153,6 +153,7 @@ def array_from_string(comma_separated: bool = False):
 
 
 nh3_attributes = deepcopy(nh3.ALLOWED_ATTRIBUTES)
+nh3_rollback = {"&amp;": "&"}
 default_attributes = {
     "id",
     "data-line",
@@ -186,4 +187,6 @@ nh3_attributes["a"].add("class")
 
 def sanitize_string(value: str) -> str:
     value = nh3.clean(value, attributes=nh3_attributes, link_rel=None)
+    for key in nh3_rollback:
+        value = value.replace(key, nh3_rollback[key])
     return value


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6757](https://mindlogger.atlassian.net/browse/M2-6757)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- De sanitizing of &amp: to &

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:
Create applet with ampersand '&; in name, description,  question, report message: 

1. Activity
2. Flow
3. Score and reports 
4. Report 

Ampersand symbol should be ‘&' insted of &amp;

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
