### PR TITLE
fix: activity order mismatch (M2-6238)

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1051,7 +1051,7 @@ class AnswerService:
         current_activity_histories = await act_hst_crud.retrieve_by_applet_version(f"{applet.id}_{applet.version}")
         current_activities_map = {str(ah.id): ah for ah in current_activity_histories}
         results = []
-        for activity in activities:
+        for activity in sorted(activities, key=lambda a: current_activities_map[str(a.id)].order):
             activity_history_answer_date = submitted_activities.get(
                 activity.id_version, submitted_activities.get(str(activity.id))
             )

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1051,7 +1051,7 @@ class AnswerService:
         current_activity_histories = await act_hst_crud.retrieve_by_applet_version(f"{applet.id}_{applet.version}")
         current_activities_map = {str(ah.id): ah for ah in current_activity_histories}
         results = []
-        for activity in sorted(activities, key=lambda a: current_activities_map[str(a.id)].order):
+        for activity in sorted(activities, key=lambda a: a.order):
             activity_history_answer_date = submitted_activities.get(
                 activity.id_version, submitted_activities.get(str(activity.id))
             )

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -538,3 +538,23 @@ async def applet__deleted_flow_without_answers(
     update_data = AppletUpdate(**data)
     updated_applet = await srv.update(applet_with_flow.id, update_data)
     return updated_applet
+
+
+@pytest.fixture
+async def applet__with_ordered_activities(session: AsyncSession, tom: User, applet_data: AppletCreate) -> AppletFull:
+    srv = AppletService(session, tom.id)
+    applet = await srv.create(applet_data)
+    data = AppletUpdate(**applet.dict())
+    activities = []
+    for i in range(3):
+        activity_new = data.activities[0].copy(deep=True)
+        activity_new.id = uuid.uuid4()
+        activity_new.key = uuid.uuid4()
+        for j in range(len(activity_new.items)):
+            activity_new.items[j].id = uuid.uuid4()
+        activity_new.name = f"ordered_activity_{i}"
+        activities.append(activity_new)
+
+    data.activities = activities
+    updated_applet = await srv.update(applet.id, data)
+    return updated_applet

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -546,7 +546,7 @@ async def applet__with_ordered_activities(session: AsyncSession, tom: User, appl
     applet = await srv.create(applet_data)
     data = AppletUpdate(**applet.dict())
     activities = []
-    for i in range(3):
+    for i in range(4):
         activity_new = data.activities[0].copy(deep=True)
         activity_new.id = uuid.uuid4()
         activity_new.key = uuid.uuid4()
@@ -555,6 +555,7 @@ async def applet__with_ordered_activities(session: AsyncSession, tom: User, appl
         activity_new.name = f"ordered_activity_{i}"
         activities.append(activity_new)
 
+    # create version with all activities
     data.activities = activities
     updated_applet = await srv.update(applet.id, data)
     return updated_applet

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -3,7 +3,7 @@ import http
 import re
 import uuid
 from collections import defaultdict
-from typing import Any, cast
+from typing import Any, Tuple, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -11,13 +11,16 @@ from pytest import FixtureRequest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.activities.domain.activity_update import ActivityUpdate
 from apps.answers.crud import AnswerItemsCRUD
 from apps.answers.crud.answers import AnswersCRUD
 from apps.answers.db.schemas import AnswerItemSchema, AnswerNoteSchema, AnswerSchema
 from apps.answers.domain import AnswerNote, AppletAnswerCreate, AssessmentAnswerCreate, ClientMeta, ItemAnswerCreate
 from apps.answers.service import AnswerService
+from apps.applets.domain.applet_create_update import AppletUpdate
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.errors import InvalidVersionError
+from apps.applets.service import AppletService
 from apps.mailing.services import TestMail
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
@@ -370,6 +373,74 @@ async def tom_answer_activity_flow_not_completed(
             client=ClientMeta(app_id=f"{uuid.uuid4()}", app_version="1.1", width=984, height=623),
         )
     )
+
+
+@pytest.fixture
+async def applet__with_deleted_activities_and_answers(
+    session: AsyncSession, tom: User, applet__with_ordered_activities: AppletFull
+):
+    data = AppletUpdate(**applet__with_ordered_activities.dict())
+    applet_service = AppletService(session, tom.id)
+    answer_service = AnswerService(session, tom.id)
+    applet_id = applet__with_ordered_activities.id
+    version = applet__with_ordered_activities.version
+    for activity in applet__with_ordered_activities.activities:
+        create_data = AppletAnswerCreate(
+            applet_id=applet_id,
+            version=version,
+            submit_id=uuid.uuid4(),
+            activity_id=activity.id,
+            answer=ItemAnswerCreate(
+                item_ids=[activity.items[0].id],
+                start_time=datetime.datetime.utcnow(),
+                end_time=datetime.datetime.utcnow(),
+                user_public_key=str(tom.id),
+                identifier="encrypted_identifier",
+            ),
+            client=ClientMeta(app_id=f"{uuid.uuid4()}", app_version="1.1", width=984, height=623),
+        )
+        await answer_service.create_answer(create_data)
+    # delete first two activities
+    data.activities = [ActivityUpdate(**a.dict()) for a in applet__with_ordered_activities.activities[2:]]
+    return await applet_service.update(applet_id, data)
+
+
+@pytest.fixture
+async def applet__with_deleted_and_order(
+    session: AsyncSession, tom: User, applet_with_flow: AppletFull
+) -> Tuple[AppletFull, list[uuid.UUID]]:
+    applet_service = AppletService(session, tom.id)
+    answer_service = AnswerService(session, tom.id)
+    applet_id = applet_with_flow.id
+    version = applet_with_flow.version
+    flows = applet_with_flow.activity_flows.copy()
+    for flow_item in applet_with_flow.activity_flows[0].items:
+        activity = next(filter(lambda x: x.id == flow_item.activity_id, applet_with_flow.activities))
+        create_data = AppletAnswerCreate(
+            applet_id=applet_id,
+            version=version,
+            submit_id=uuid.uuid4(),
+            activity_id=activity.id,
+            flow_id=applet_with_flow.activity_flows[0].id,
+            is_flow_completed=True,
+            answer=ItemAnswerCreate(
+                item_ids=[activity.items[0].id],
+                start_time=datetime.datetime.utcnow(),
+                end_time=datetime.datetime.utcnow(),
+                user_public_key=str(tom.id),
+                identifier="encrypted_identifier",
+            ),
+            client=ClientMeta(app_id=f"{uuid.uuid4()}", app_version="1.1", width=984, height=623),
+        )
+        await answer_service.create_answer(create_data)
+    applet_with_flow.activity_flows = [applet_with_flow.activity_flows[1]]
+    data = applet_with_flow.dict()
+    for i in range(len(data["activity_flows"])):
+        activity_flow = data["activity_flows"][i]
+        for j in range(len(activity_flow["items"])):
+            activity_flow["items"][j]["activity_key"] = data["activities"][j]["key"]
+    data_update = AppletUpdate(**data)
+    return await applet_service.update(applet_id, data_update), [flows[1].id, flows[0].id]
 
 
 @pytest.mark.usefixtures("mock_kiq_report")
@@ -2033,6 +2104,21 @@ class TestAnswerActivityItems(BaseTest):
         flows_order_actual = [flow["id"] for flow in payload["result"]]
         assert flows_order_actual == flows_order_expected
 
+    async def test_summary_activity_flow_order_with_deleted_flows(
+        self, client, tom: User, applet__with_deleted_and_order: tuple[AppletFull, list[uuid.UUID]]
+    ):
+        client.login(tom)
+        applet_id = applet__with_deleted_and_order[0].id
+        flow_order_expected = applet__with_deleted_and_order[1]
+        url = self.summary_activity_flows_url.format(applet_id=str(applet_id))
+        response = await client.get(url)
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload
+        assert len(payload["result"]) == 2
+        flow_order_actual = [uuid.UUID(flow["id"]) for flow in payload["result"]]
+        assert flow_order_expected == flow_order_actual
+
     async def test_summary_activity_order(self, client, tom: User, applet__with_ordered_activities: AppletFull):
         client.login(tom)
         applet_id = str(applet__with_ordered_activities.id)
@@ -2046,3 +2132,25 @@ class TestAnswerActivityItems(BaseTest):
         for i in range(len(activity_ids)):
             activity_id = activity_ids[i]
             assert expected_order_map[activity_id] == i + 1
+
+    async def test_summary_activity_order_with_deleted(
+        self, client, tom: User, applet__with_deleted_activities_and_answers: AppletFull
+    ):
+        client.login(tom)
+        applet_id = str(applet__with_deleted_activities_and_answers.id)
+        activities = applet__with_deleted_activities_and_answers.activities
+        response = await client.get(self.summary_activities_url.format(applet_id=applet_id))
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload
+        activities_applet = sorted(activities, key=lambda x: x.order)
+        activities_payload = payload["result"]
+        # Validation actual activities sorted by activity.order
+        for i in range(len(activities_applet)):
+            activity_exp = activities[i]
+            activity = activities_payload[i]
+            assert str(activity_exp.id) == activity["id"]
+
+        not_deleted_ids = [str(a.id) for a in activities_applet]
+        deleted_activities = list(filter(lambda a: a["id"] not in not_deleted_ids, activities_payload))
+        assert sorted(deleted_activities, key=lambda x: x["name"]) == deleted_activities

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -2032,3 +2032,17 @@ class TestAnswerActivityItems(BaseTest):
         flows_order_expected = [str(flow.id) for flow in sorted(applet_with_flow.activity_flows, key=lambda x: x.order)]
         flows_order_actual = [flow["id"] for flow in payload["result"]]
         assert flows_order_actual == flows_order_expected
+
+    async def test_summary_activity_order(self, client, tom: User, applet__with_ordered_activities: AppletFull):
+        client.login(tom)
+        applet_id = str(applet__with_ordered_activities.id)
+        activities = applet__with_ordered_activities.activities
+        response = await client.get(self.summary_activities_url.format(applet_id=applet_id))
+        assert response.status_code == 200
+        payload = response.json()
+        expected_order_map = {str(a.id): a.order for a in activities}
+        activity_ids = list(map(lambda x: x["id"], payload["result"]))
+        assert payload
+        for i in range(len(activity_ids)):
+            activity_id = activity_ids[i]
+            assert expected_order_map[activity_id] == i + 1


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6238](https://mindlogger.atlassian.net/browse/M2-6238)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Activity sorting in summary fixed
### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
