### PR TITLE
feat: add performance task fields to activities/applets (M2-7091)

### DIFF
--- a/src/apps/activities/crud/activity.py
+++ b/src/apps/activities/crud/activity.py
@@ -58,6 +58,8 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
             ActivitySchema.response_is_editable,
             ActivitySchema.order,
             ActivitySchema.scores_and_reports,
+            ActivitySchema.performance_task_type,
+            ActivitySchema.is_performance_task,
         )
 
         query = query.where(ActivitySchema.applet_id == applet_id)

--- a/src/apps/activities/domain/activity.py
+++ b/src/apps/activities/domain/activity.py
@@ -9,7 +9,7 @@ from apps.activities.domain.activity_item import (
     ActivityItemSingleLanguageDetail,
     ActivityItemSingleLanguageDetailPublic,
 )
-from apps.activities.domain.response_type_config import ResponseType
+from apps.activities.domain.response_type_config import PerformanceTaskType, ResponseType
 from apps.activities.domain.scores_reports import ScoresAndReports
 from apps.shared.domain import InternalModel, PublicModel
 
@@ -92,6 +92,8 @@ class ActivityLanguageWithItemsMobileDetailPublic(PublicModel):
     order: int
     items: list[ActivityItemSingleLanguageDetailPublic] = Field(default_factory=list)
     scores_and_reports: ScoresAndReports | None = None
+    performance_task_type: PerformanceTaskType | None = None
+    is_performance_task: bool = False
 
 
 class ActivityBaseInfo(ActivityMinimumInfo, InternalModel):

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -274,6 +274,8 @@ class ActivityService:
                 response_is_editable=schema.response_is_editable,
                 order=schema.order,
                 scores_and_reports=schema.scores_and_reports,
+                performance_task_type=schema.performance_task_type,
+                is_performance_task=schema.is_performance_task,
             )
 
             activities.append(activity)


### PR DESCRIPTION
### 📝 Description

Adds `performance_task_type` and `is_performance_task` to the response of `/activities/applets/{appletId}`

🔗 [Jira Ticket M2-7091](https://mindlogger.atlassian.net/browse/M2-7091)

### 🪤 Peer Testing

- Easier to test with the companion [Admin PR](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1826)
- Perform a request to `/activities/applet/:appletId` and verify `performanceTaskType` and `isPerformanceTask` are present in `result.activitiesDetails[*]`


### ✏️ Notes

I decided to include the fields in this response as opposed to using `/workspace/{ownerId}/applets` or any of the other endpoints that already include these fields because this endpoint will eventually require filtering by `subjectId` [M2-6223](https://mindlogger.atlassian.net/browse/M2-6223) 

[M2-6223]: https://mindlogger.atlassian.net/browse/M2-6223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ