### PR TITLE
fix: Missing subject tag after transferownership (M2-7134)

### DIFF
--- a/src/apps/transfer_ownership/service.py
+++ b/src/apps/transfer_ownership/service.py
@@ -8,6 +8,7 @@ from apps.applets.domain import Role
 from apps.authentication.errors import PermissionsError
 from apps.mailing.domain import MessageSchema
 from apps.mailing.services import MailingService
+from apps.subjects.constants import SubjectTag
 from apps.subjects.domain import SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.transfer_ownership.constants import TransferOwnershipStatus
@@ -129,6 +130,7 @@ class TransferService:
                 first_name=self._user.first_name,
                 email=EmailStr(self._user.email_encrypted),
                 is_deleted=False,
+                tag=SubjectTag.TEAM,
             )
         else:
             await subject_service.create(
@@ -141,6 +143,7 @@ class TransferService:
                     last_name=self._user.last_name,
                     secret_user_id=f"{uuid.uuid4()}",
                     nickname=self._user.get_full_name(),
+                    tag=SubjectTag.TEAM,
                 )
             )
 

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -16,6 +16,7 @@ from apps.invitations.errors import ManagerInvitationExist
 from apps.mailing.services import TestMail
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.subjects.constants import SubjectTag
 from apps.subjects.services import SubjectsService
 from apps.transfer_ownership.crud import TransferCRUD
 from apps.transfer_ownership.errors import TransferEmailError
@@ -160,6 +161,7 @@ class TestTransfer(BaseTest):
         assert lucy_subject
         assert lucy_subject.email == lucy.email_encrypted
         assert lucy_subject.nickname == f"{lucy.first_name} {lucy.last_name}"
+        assert lucy_subject.tag == SubjectTag.TEAM
 
     async def test_accept_transfer_if_subject_already_exists(
         self,


### PR DESCRIPTION
### 📝 Description

Fix missing subject tag "team" in subject entry created to owner of applet id after transfer ownership.

This subject tag is used as filter managers subject in take now initiate dialog 

🔗 [Jira Ticket M2-7134](https://mindlogger.atlassian.net/browse/M2-7134)

