### PR TITLE
fix: Missing removal former owner team tag after transfer owner (M2-7134)

### DIFF
--- a/src/apps/transfer_ownership/service.py
+++ b/src/apps/transfer_ownership/service.py
@@ -96,6 +96,12 @@ class TransferService:
                 Role.OWNER,
             ],
         )
+        subject_service = SubjectsService(self.session, self._user.id)
+        previous_owner_subject = await subject_service.get_by_user_and_applet(
+            previous_owner.user_id, transfer.applet_id
+        )
+        if previous_owner_subject and previous_owner_subject.id:
+            await subject_service.update(previous_owner_subject.id, tag=None)
 
         await TransferCRUD(self.session).approve_by_key(key, self._user.id)
         await TransferCRUD(self.session).decline_all_pending_by_applet_id(applet_id=transfer.applet_id)
@@ -120,7 +126,7 @@ class TransferService:
                 **roles_data,
             ),
         ]
-        subject_service = SubjectsService(self.session, self._user.id)
+
         await UserAppletAccessCRUD(self.session).upsert_user_applet_access_list(roles_to_add)
         subject = await subject_service.get_by_user_and_applet(self._user.id, transfer.applet_id)
         if subject and subject.id:


### PR DESCRIPTION
### 📝 Description

Missed to remove former owner "Team" tag in other fix, this impacts take now screens

🔗 [Jira Ticket M2-7134](https://mindlogger.atlassian.net/browse/M2-7134)

