### PR TITLE
fix: Allow answers for flow containing same activity multiple times (M2-7213)

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -141,7 +141,7 @@ class AnswerService:
         activity_history_id = pk(applet_answer.activity_id)
         flow_history_id = pk(applet_answer.flow_id) if applet_answer.flow_id else None
 
-        activity_index = None
+        activity_indexes = set()  # same activity is allowed multiple times in flow
         if flow_history_id:
             flow_histories = await FlowsHistoryCRUD(self.session).load_full(
                 [pk(applet_answer.flow_id)], load_activities=False
@@ -153,9 +153,8 @@ class AnswerService:
             # check activity in the flow
             for i, item in enumerate(flow_history.items):
                 if item.activity_id == activity_history_id:
-                    activity_index = i
-                    break
-            if activity_index is None:
+                    activity_indexes.add(i)
+            if not activity_indexes:
                 raise ValidationError("Activity not found in the flow")
 
         if existed_answers:
@@ -177,13 +176,12 @@ class AnswerService:
 
             # check current answer is provided in right order in the flow, so prev activities already answered
             prev_answers_count = len(existed_answers)
-            if prev_answers_count != activity_index:
-                assert activity_index is not None
-                if prev_answers_count < activity_index:
-                    raise ValidationError("Wrong activity order in the flow")
-                raise ValidationError("Wrong activity order in the flow: previous activity answer missed")
+            if prev_answers_count not in activity_indexes:
+                if prev_answers_count > max(activity_indexes):
+                    raise ValidationError("Wrong activity order in the flow: previous activity answer missed")
+                raise ValidationError("Wrong activity order in the flow")
 
-        elif flow_history_id and activity_index != 0:
+        elif flow_history_id and 0 not in activity_indexes:
             # check first flow answer
             raise ValidationError("Wrong activity order in the flow")
 

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -164,6 +164,36 @@ async def applet_with_flow(
 
 
 @pytest.fixture
+async def applet_with_flow_duplicated_activities(
+    session: AsyncSession,
+    applet_minimal_data: AppletCreate,
+    tom: User,
+    applet_report_configuration_data: AppletReportConfigurationBase,
+) -> AppletFull:
+    data = applet_minimal_data.copy(deep=True)
+    data.display_name = "applet with flow"
+
+    data.activity_flows = [
+        FlowCreate(
+            name="flow",
+            description={Language.ENGLISH: "description"},
+            items=[
+                FlowItemCreate(activity_key=data.activities[0].key),
+                FlowItemCreate(activity_key=data.activities[0].key),
+            ],
+        ),
+    ]
+    data.report_server_ip = applet_report_configuration_data.report_server_ip
+    data.report_public_key = applet_report_configuration_data.report_public_key
+    data.report_recipients = applet_report_configuration_data.report_recipients
+    applet_create = AppletCreate(**data.dict())
+    srv = AppletService(session, tom.id)
+    applet = await srv.create(applet_create, applet_id=uuid.uuid4())
+
+    return applet
+
+
+@pytest.fixture
 def answer_item_create(
     applet: AppletFull,
     single_select_item_create: ActivityItemCreate,

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -699,6 +699,27 @@ class TestAnswerActivityItems(BaseTest):
         response = await client.post(self.answer_url, data=data)
         assert response.status_code == http.HTTPStatus.BAD_REQUEST
 
+    async def test_create_flow_duplicate_activities_answer__submit(
+        self,
+        client: TestClient,
+        tom: User,
+        answer_create: AppletAnswerCreate,
+        applet_with_flow_duplicated_activities: AppletFull,
+    ):
+        client.login(tom)
+        data: AppletAnswerCreate = answer_create.copy(deep=True)
+        data.submit_id = uuid.uuid4()
+        data.applet_id = applet_with_flow_duplicated_activities.id
+        data.flow_id = applet_with_flow_duplicated_activities.activity_flows[0].id
+        data.activity_id = applet_with_flow_duplicated_activities.activity_flows[0].items[0].activity_id
+
+        response = await client.post(self.answer_url, data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        data.activity_id = applet_with_flow_duplicated_activities.activity_flows[0].items[1].activity_id
+        response = await client.post(self.answer_url, data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+
     async def test_create_flow_answer__correct_order(
         self,
         client: TestClient,


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7213](https://mindlogger.atlassian.net/browse/M2-7213)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Fix validation for flow submissions when flow contains same activity multiple times
