### PR TITLE
fix: set redis container name in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
 
   redis:
     image: redis
+    container_name: mindlogger_redis
     ports:
       - 6379:6379
 


### PR DESCRIPTION
* provide a name for the redis container in the docker-compose file instead of the default one (mindlogger-backend-refactor-redis-1)

Feel free to disregard :)