### PR TITLE
Fix: Error returning latest submission when there is a deleted subject (M2-7308)

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -964,8 +964,10 @@ class AnswerService:
                 activity_hist_ids.add(answer.activity_history_id)
 
         activities_coro = ActivityHistoriesCRUD(self.session).get_by_history_ids(list(activity_hist_ids))
-        subject_map_coro = SubjectsCrud(self.session).get_by_ids(list(subject_ids))
-        user_subject_coro = SubjectsCrud(self.session).get_by_user_ids(applet_id, list(respondent_ids))
+        subject_map_coro = SubjectsCrud(self.session).get_by_ids(list(subject_ids), include_deleted=True)
+        user_subject_coro = SubjectsCrud(self.session).get_by_user_ids(
+            applet_id, list(respondent_ids), include_deleted=True
+        )
 
         coros_result = await asyncio.gather(
             activities_coro,
@@ -987,8 +989,10 @@ class AnswerService:
         submissions: list[AppletSubmission] = []
 
         for answer in answers:
-            activity = activities_map[answer.activity_history_id]
-            respondent_subject = users_subjects_map[answer.respondent_id]
+            activity = activities_map.get(answer.activity_history_id)
+            respondent_subject = users_subjects_map.get(answer.respondent_id)
+            if activity is None or respondent_subject is None:
+                continue
             target_subject = subject_map.get(answer.target_subject_id) or respondent_subject
             source_subject = subject_map.get(answer.source_subject_id) or respondent_subject
 

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -3292,6 +3292,45 @@ class TestAnswerActivityItems(BaseTest):
         data = response.json()
         assert data["submissionsCount"] == 1
         assert data["participantsCount"] == 2
+        assert len(data["submissions"]) == data["submissionsCount"]
+        for s in data["submissions"]:
+            assert s["targetSubjectId"] == str(answer_shell_account_target["target_subject_id"])
+            assert s["targetSubjectTag"] == answer_shell_account_target["target_subject_tag"]
+            assert s["targetNickname"] == answer_shell_account_target["target_nickname"]
+            assert s["targetSecretUserId"] == str(answer_shell_account_target["target_secret_user_id"])
+            assert s["respondentSubjectId"] == str(answer_shell_account_target["respondent_subject_id"])
+            assert s["respondentSubjectTag"] == answer_shell_account_target["respondent_subject_tag"]
+            assert s["respondentNickname"] == answer_shell_account_target["respondent_nickname"]
+            assert s["respondentSecretUserId"] == str(answer_shell_account_target["respondent_secret_user_id"])
+            assert s["sourceSubjectId"] == str(answer_shell_account_target["source_subject_id"])
+            assert s["sourceSubjectTag"] == answer_shell_account_target["source_subject_tag"]
+            assert s["sourceNickname"] == answer_shell_account_target["source_nickname"]
+            assert s["sourceSecretUserId"] == str(answer_shell_account_target["source_secret_user_id"])
+            assert s["activityName"] is not None
+            assert s["activityId"] is not None
+
+    async def test_get_applet_latest_submissions_with_deleted_subjects(
+        self,
+        client,
+        tom: User,
+        applet: AppletFull,
+        answer_shell_account_target: dict,
+        session: AsyncSession,
+    ):
+        service = SubjectsService(session, tom.id)
+        await service.delete(answer_shell_account_target["target_subject_id"])
+        await service.delete(answer_shell_account_target["respondent_subject_id"])
+        await service.delete(answer_shell_account_target["source_subject_id"])
+
+        client.login(tom)
+
+        response = await client.get(self.applet_submissions_list_url.format(applet_id=applet.id))
+
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["submissionsCount"] == 1
+        assert len(data["submissions"]) == data["submissionsCount"]
+        assert data["participantsCount"] == 2
         for s in data["submissions"]:
             assert s["targetSubjectId"] == str(answer_shell_account_target["target_subject_id"])
             assert s["targetSubjectTag"] == answer_shell_account_target["target_subject_tag"]

--- a/src/apps/subjects/crud/subject.py
+++ b/src/apps/subjects/crud/subject.py
@@ -39,21 +39,23 @@ class SubjectsCrud(BaseCRUD[SubjectSchema]):
     async def get_by_id(self, _id: uuid.UUID) -> SubjectSchema | None:
         return await self._get("id", _id)
 
-    async def get_by_ids(self, ids: list[uuid.UUID]) -> list[SubjectSchema]:
+    async def get_by_ids(self, ids: list[uuid.UUID], include_deleted=False) -> list[SubjectSchema]:
         query: Query = select(SubjectSchema)
         query = query.where(
             SubjectSchema.id.in_(ids),
-            SubjectSchema.soft_exists(),
+            SubjectSchema.soft_exists() if not include_deleted else True,
         )
         res = await self._execute(query)
         return res.scalars().all()
 
-    async def get_by_user_ids(self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]) -> list[SubjectSchema]:
+    async def get_by_user_ids(
+        self, applet_id: uuid.UUID, user_ids: list[uuid.UUID], include_deleted=False
+    ) -> list[SubjectSchema]:
         query: Query = select(SubjectSchema)
         query = query.where(
             SubjectSchema.user_id.in_(user_ids),
             SubjectSchema.applet_id == applet_id,
-            SubjectSchema.soft_exists(),
+            SubjectSchema.soft_exists() if not include_deleted else True,
         )
         res = await self._execute(query)
         return res.scalars().all()

--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -575,7 +575,6 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
             .select_from(SubjectSchema)
             .where(
                 SubjectSchema.applet_id == applet_id,
-                SubjectSchema.soft_exists(),
             )
         )
 


### PR DESCRIPTION
### 📝 Description
Fix a ISE (500) on latest submissions endpoint when subjects had been deleted after send any answer

Solution:
  Duplicate queries returning subjects by id or user_ids (because it is used in many places) and removed filter is_deleted = false in those new queries


🔗 [Jira Ticket M2-7308](https://mindlogger.atlassian.net/browse/M2-7308)

