### PR TITLE
feat: Implement emergency message endpoint (M2-7094)

### DIFF
--- a/src/apps/authentication/deps.py
+++ b/src/apps/authentication/deps.py
@@ -5,6 +5,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from fastapi.websockets import WebSocket
 from jose import JWTError, jwt
 from pydantic import EmailStr, ValidationError
+from starlette.requests import Request
 
 from apps.authentication.domain.login import UserLoginRequest
 from apps.authentication.domain.token import InternalToken, JWTClaim, TokenPayload, TokenPurpose
@@ -98,6 +99,14 @@ async def get_current_user(
         await UsersCRUD(session).update_last_seen_by_id(token.payload.sub)
 
     return user
+
+
+async def get_optional_current_user(request: Request, session=Depends(get_session)) -> User | None:
+    try:
+        user = await get_current_user(await get_current_token()(await oauth2_oauth(request)), session)
+        return user
+    except Exception:
+        return None
 
 
 async def openapi_auth(

--- a/src/apps/healthcheck/api.py
+++ b/src/apps/healthcheck/api.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from fastapi import Query
+from fastapi import Body, Depends, Query
 from fastapi.responses import Response
 from starlette import status
+
+from apps.authentication.deps import get_optional_current_user
+from apps.healthcheck.domain import AppInfo, EmergencyMessage, EmergencyMessageType
+from apps.shared.domain import Response as ResponseModel
+from apps.users import User
+from config import settings
 
 
 def readiness():
@@ -23,3 +29,24 @@ async def statuscode(code: int = 200, timeout: float = Query(0.0, ge=0.0, le=60.
         return Response("Wrong status code", status_code=400)
     await asyncio.sleep(timeout)
     return Response(status_code=code)
+
+
+async def emergency_message(
+    info: AppInfo = Body(...),
+    user: User | None = Depends(get_optional_current_user),
+    test: bool = Query(False),
+) -> ResponseModel[EmergencyMessage]:
+    # Logic to generate response message based on the user info and app os/version
+
+    result = EmergencyMessage()
+
+    if test:
+        message = (
+            f"User: {user.email_encrypted if user else None}, "
+            f"request: {info.json()}, "
+            f"test url: [url](https://{settings.service.urls.frontend.web_base})"
+        )
+
+        result = EmergencyMessage(message=message, message_type=EmergencyMessageType.blocker, dismissible=False)
+
+    return ResponseModel(result=result)

--- a/src/apps/healthcheck/domain.py
+++ b/src/apps/healthcheck/domain.py
@@ -1,0 +1,27 @@
+import enum
+
+from pydantic import Field
+
+from apps.shared.domain import PublicModel
+
+
+class EmergencyMessageType(str, enum.Enum):
+    info = "info"
+    warning = "warning"
+    blocker = "blocker"
+
+
+class EmergencyMessage(PublicModel):
+    message: str | None = None
+    message_type: EmergencyMessageType | None = Field(None, alias="type")
+    dismissible: bool = True
+
+
+class AppInfoOS(PublicModel):
+    name: str
+    version: str
+
+
+class AppInfo(PublicModel):
+    os: AppInfoOS
+    app_version: str

--- a/src/apps/healthcheck/router.py
+++ b/src/apps/healthcheck/router.py
@@ -1,7 +1,7 @@
 from fastapi import status
 from fastapi.routing import APIRouter
 
-from apps.healthcheck.api import liveness, readiness, statuscode
+from apps.healthcheck.api import emergency_message, liveness, readiness, statuscode
 
 router = APIRouter(tags=["Health check"])
 
@@ -9,3 +9,4 @@ router.get("/readiness", status_code=status.HTTP_200_OK)(readiness)
 router.get("/liveness", status_code=status.HTTP_200_OK)(liveness)
 router.get("/statuscode")(statuscode)
 router.post("/statuscode")(statuscode)
+router.post("/emergency-message")(emergency_message)

--- a/src/apps/healthcheck/tests.py
+++ b/src/apps/healthcheck/tests.py
@@ -1,4 +1,19 @@
+import pytest
+
+from apps.healthcheck.domain import EmergencyMessageType
 from apps.shared.test import BaseTest
+from apps.users import User
+
+
+@pytest.fixture
+def emergency_message_payload() -> dict:
+    return {
+        "os": {
+            "name": "ios",
+            "version": "14.0.0",
+        },
+        "appVersion": "1.0.0",
+    }
 
 
 class TestHealthcheck(BaseTest):
@@ -11,3 +26,38 @@ class TestHealthcheck(BaseTest):
         response = await client.get("liveness")
         assert response.status_code == 200
         assert response.content == b"Liveness - OK!"
+
+    async def test_emergency_message__unauthorized(self, client, emergency_message_payload):
+        response = await client.post("emergency-message", data=emergency_message_payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "result" in data
+        data = data["result"]
+        assert set(data.keys()) == {"message", "type", "dismissible"}
+        assert data["message"] is None
+        assert data["type"] is None
+        assert data["dismissible"] is True
+
+    async def test_emergency_message__authorized(self, client, emergency_message_payload, tom: User):
+        client.login(tom)
+        response = await client.post("emergency-message", data=emergency_message_payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "result" in data
+        data = data["result"]
+        assert set(data.keys()) == {"message", "type", "dismissible"}
+        assert data["message"] is None
+        assert data["type"] is None
+        assert data["dismissible"] is True
+
+    async def test_emergency_message__authorized_testflag(self, client, emergency_message_payload, tom: User):
+        client.login(tom)
+        response = await client.post("emergency-message", data=emergency_message_payload, query={"test": 1})
+        assert response.status_code == 200
+        data = response.json()
+        assert "result" in data
+        data = data["result"]
+        assert set(data.keys()) == {"message", "type", "dismissible"}
+        assert data["message"] is not None
+        assert data["type"] == EmergencyMessageType.blocker
+        assert data["dismissible"] is False


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7094](https://mindlogger.atlassian.net/browse/M2-7094)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Endpoint `POST /emengency-message` for forced updates and notifications to enable the display of system messages and notifications managed from the backend on mobile devices

