### PR TITLE
feat: added new Paragraph Item in the backend by copying all Text Item coincidences in the code (M2-7239)

### DIFF
--- a/src/apps/activities/domain/activity_item_base.py
+++ b/src/apps/activities/domain/activity_item_base.py
@@ -162,6 +162,7 @@ class BaseActivityItem(BaseModel):
             ResponseType.MULTISELECT,
             ResponseType.SLIDER,
             ResponseType.TEXT,
+            ResponseType.PARAGRAPHTEXT,
             ResponseType.TIME,
             ResponseType.TIMERANGE,
         ]:

--- a/src/apps/activities/domain/custom_validation.py
+++ b/src/apps/activities/domain/custom_validation.py
@@ -102,6 +102,7 @@ def validate_score_and_sections(values: dict):  # noqa: C901
                         ResponseType.MULTISELECT,
                         ResponseType.SLIDER,
                         ResponseType.TEXT,
+                        ResponseType.PARAGRAPHTEXT,
                     ]:
                         raise IncorrectScorePrintItemTypeError()
 
@@ -117,6 +118,7 @@ def validate_score_and_sections(values: dict):  # noqa: C901
                                 ResponseType.MULTISELECT,
                                 ResponseType.SLIDER,
                                 ResponseType.TEXT,
+                                ResponseType.PARAGRAPHTEXT,
                             ]:
                                 raise IncorrectScorePrintItemTypeError()
 
@@ -130,6 +132,7 @@ def validate_score_and_sections(values: dict):  # noqa: C901
                         ResponseType.MULTISELECT,
                         ResponseType.SLIDER,
                         ResponseType.TEXT,
+                        ResponseType.PARAGRAPHTEXT,
                     ]:
                         raise IncorrectSectionPrintItemTypeError()
 

--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -33,6 +33,7 @@ from apps.shared.domain import PublicModel
 
 class ResponseType(str, Enum):
     TEXT = "text"
+    PARAGRAPHTEXT = "paragraphText"
     SINGLESELECT = "singleSelect"
     MULTISELECT = "multiSelect"
     SLIDER = "slider"
@@ -59,6 +60,7 @@ class ResponseType(str, Enum):
     def get_non_response_types(cls):
         return (
             cls.TEXT,
+            cls.PARAGRAPHTEXT,
             cls.MESSAGE,
             cls.TIMERANGE,
             cls.GEOLOCATION,
@@ -102,6 +104,12 @@ class TextConfig(_ScreenConfig, PublicModel):
         if values.get("correct_answer_required") and not value:
             raise CorrectAnswerRequiredError()
         return value
+
+
+class ParagraphTextConfig(_ScreenConfig, PublicModel):
+    type: Literal[ResponseType.PARAGRAPHTEXT] | None
+    max_response_length: PositiveInt = 1000
+    response_required: bool
 
 
 class _SelectionConfig(_ScreenConfig, PublicModel):
@@ -398,6 +406,7 @@ class PerformanceTaskType(str, Enum):
 
 ResponseTypeConfig = (
     TextConfig
+    | ParagraphTextConfig
     | SingleSelectionConfig
     | MultiSelectionConfig
     | SliderConfig

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -16,6 +16,7 @@ from apps.activities.domain.response_type_config import (
     MultiSelectionConfig,
     MultiSelectionRowsConfig,
     NumberSelectionConfig,
+    ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
     ResponseType,
@@ -56,6 +57,10 @@ class PhrasalTemplateDisplayMode(str, Enum):
 
 class TextValues(PublicModel):
     type: Literal[ResponseType.TEXT] | None
+
+
+class ParagraphTextValues(PublicModel):
+    type: Literal[ResponseType.PARAGRAPHTEXT] | None
 
 
 class MessageValues(PublicModel):
@@ -380,6 +385,7 @@ class PhrasalTemplateValues(PublicModel):
 
 ResponseValueConfigOptions = [
     TextValues,
+    ParagraphTextValues,
     SingleSelectionValues,
     MultiSelectionValues,
     SliderValues,
@@ -450,6 +456,7 @@ def validate_none_option_flag(options):
 
 ResponseTypeConfigOptions = [
     TextConfig,
+    ParagraphTextConfig,
     SingleSelectionConfig,
     MultiSelectionConfig,
     SliderConfig,

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -12,6 +12,7 @@ from apps.activities.domain.response_type_config import (
     MultiSelectionConfig,
     MultiSelectionRowsConfig,
     NumberSelectionConfig,
+    ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
     ResponseType,
@@ -128,6 +129,15 @@ def text_config(default_config: DefaultConfig) -> TextConfig:
         response_data_identifier=False,
         response_required=False,
         type=ResponseType.TEXT,
+    )
+
+
+@pytest.fixture
+def paragraph_text_config(default_config: DefaultConfig) -> ParagraphTextConfig:
+    return ParagraphTextConfig(
+        **default_config.dict(),
+        response_required=False,
+        type=ResponseType.PARAGRAPHTEXT,
     )
 
 

--- a/src/apps/activities/tests/fixtures/items.py
+++ b/src/apps/activities/tests/fixtures/items.py
@@ -11,6 +11,7 @@ from apps.activities.domain.response_type_config import (
     MultiSelectionConfig,
     MultiSelectionRowsConfig,
     NumberSelectionConfig,
+    ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
     ResponseType,
@@ -175,6 +176,17 @@ def text_item_create(text_config: TextConfig, base_item_data: BaseItemData) -> A
         **base_item_data.dict(),
         response_type=ResponseType.TEXT,
         config=text_config,
+    )
+
+
+@pytest.fixture
+def paragraph_text_item_create(
+    paragraph_text_config: ParagraphTextConfig, base_item_data: BaseItemData
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.PARAGRAPHTEXT,
+        config=paragraph_text_config,
     )
 
 

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -52,6 +52,11 @@ class Answer(InternalModel):
     answer_item: AnswerItem
 
 
+class ParagraphText(InternalModel):
+    value: str
+    should_identify_response: bool = False
+
+
 class Text(InternalModel):
     value: str
     should_identify_response: bool = False
@@ -72,10 +77,11 @@ class Slider(InternalModel):
     additional_text: str | None
 
 
-AnswerTypes = SingleSelection | Slider | MultipleSelection | Text
+AnswerTypes = SingleSelection | Slider | MultipleSelection | Text | ParagraphText
 
 ANSWER_TYPE_MAP: dict[ResponseType, Any] = {
     ResponseType.TEXT: Text,
+    ResponseType.PARAGRAPHTEXT: ParagraphText,
     ResponseType.SINGLESELECT: SingleSelection,
     ResponseType.MULTISELECT: MultipleSelection,
     ResponseType.SLIDER: Slider,

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -91,6 +91,7 @@ class TestActivityItems:
             "audio_item_create",
             "message_item_create",
             "audio_player_item_create",
+            "paragraph_text_item_create",
         ),
     )
     async def test_create_applet_with_each_activity_item(


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7239](https://mindlogger.atlassian.net/browse/M2-7239)
Adds support to `paragraphText` item type

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Added new ParagraphItem

### 🪤 Peer Testing

This is currently working with the latest [admin version in develop](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1863)
and a specific branch in the [web app](https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/512)

### ✏️ Notes
- I am still looking at how [Pedantic](https://docs.pydantic.dev/latest/) is being used. I had some issues with some attributes that I copied from the Text item but after removing those a correct behavior from the resources was returned.
- I am also taking a look at the way the tests in pytests have been implemented and hopefully upcoming PRs will have tests. For now this one does not seem to need automated tests but peer reviews, tests, feedbacks and comments to improve the PR are welcome!