### PR TITLE
fix: incorrect relation value when non admin is source and respondent but not target (M2-7517)

### DIFF
--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -286,7 +286,7 @@ class AnswerService:
 
         if is_take_now_relation(relation) and is_valid_take_now_relation(relation):
             return Relation.other
- 
+
         return relation.relation
 
     async def _create_answer(self, applet_answer: AppletAnswerCreate) -> AnswerSchema:

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -286,7 +286,7 @@ class AnswerService:
 
         if is_take_now_relation(relation) and is_valid_take_now_relation(relation):
             return Relation.other
-
+ 
         return relation.relation
 
     async def _create_answer(self, applet_answer: AppletAnswerCreate) -> AnswerSchema:

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -284,7 +284,7 @@ class AnswerService:
 
             return Relation.other
 
-        if is_take_now_relation(relation):
+        if is_take_now_relation(relation) and is_valid_take_now_relation(relation):
             return Relation.other
 
         return relation.relation

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -284,6 +284,9 @@ class AnswerService:
 
             return Relation.other
 
+        if is_take_now_relation(relation):
+            return Relation.other
+
         return relation.relation
 
     async def _create_answer(self, applet_answer: AppletAnswerCreate) -> AnswerSchema:

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1184,11 +1184,7 @@ class TestAnswerActivityItems(BaseTest):
 
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
-        answers, _ = await AnswersCRUD(session).get_applet_answers(
-            applet_id=applet_one.id,
-            page=1,
-            limit=5
-        )
+        answers, _ = await AnswersCRUD(session).get_applet_answers(applet_id=applet_one.id, page=1, limit=5)
 
         assert answers[0].relation == Relation.other
 
@@ -1233,11 +1229,7 @@ class TestAnswerActivityItems(BaseTest):
 
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
-        answers, _ = await AnswersCRUD(session).get_applet_answers(
-            applet_id=applet_one.id,
-            page=1,
-            limit=5
-        )
+        answers, _ = await AnswersCRUD(session).get_applet_answers(applet_id=applet_one.id, page=1, limit=5)
 
         assert answers[0].relation == "father"
 

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -25,6 +25,7 @@ from apps.applets.service import AppletService
 from apps.mailing.services import TestMail
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.subjects.constants import Relation
 from apps.subjects.db.schemas import SubjectSchema
 from apps.subjects.domain import Subject, SubjectCreate
 from apps.subjects.services import SubjectsService
@@ -1138,6 +1139,107 @@ class TestAnswerActivityItems(BaseTest):
         # after submitting make sure that the relation has been deleted
         relation_exists = await subject_service.get_relation(applet_one_sam_subject.id, target_subject.id)
         assert not relation_exists
+
+    async def test_answer_activity_items_relation_equal_other_when_relation_is_temp(
+        self,
+        tom: User,
+        answer_create_applet_one: AppletAnswerCreate,
+        client: TestClient,
+        session: AsyncSession,
+        sam: User,
+        applet_one: AppletFull,
+        applet_one_sam_respondent,
+        applet_one_sam_subject,
+    ) -> None:
+        client.login(tom)
+        subject_service = SubjectsService(session, tom.id)
+
+        data = answer_create_applet_one.copy(deep=True)
+
+        client.login(sam)
+        subject_service = SubjectsService(session, sam.id)
+        target_subject = await subject_service.create(
+            SubjectCreate(
+                applet_id=applet_one.id,
+                creator_id=tom.id,
+                first_name="target",
+                last_name="subject",
+                secret_user_id=f"{uuid.uuid4()}",
+            )
+        )
+        await subject_service.create_relation(
+            relation="take-now",
+            source_subject_id=applet_one_sam_subject.id,
+            subject_id=target_subject.id,
+            meta={
+                "expiresAt": (datetime.datetime.now() + datetime.timedelta(days=1)).isoformat(),
+            },
+        )
+
+        data.source_subject_id = applet_one_sam_subject.id
+        data.target_subject_id = target_subject.id
+        data.input_subject_id = applet_one_sam_subject.id
+
+        response = await client.post(self.answer_url, data=data)
+
+        assert response.status_code == http.HTTPStatus.CREATED, response.json()
+
+        answers, _ = await AnswersCRUD(session).get_applet_answers(
+            applet_id=applet_one.id,
+            page=1,
+            limit=5
+        )
+
+        assert answers[0].relation == Relation.other
+
+    async def test_answer_activity_items_relation_equal_other_when_relation_is_permanent(
+        self,
+        tom: User,
+        answer_create_applet_one: AppletAnswerCreate,
+        client: TestClient,
+        session: AsyncSession,
+        sam: User,
+        applet_one: AppletFull,
+        applet_one_sam_respondent,
+        applet_one_sam_subject,
+    ) -> None:
+        client.login(tom)
+        subject_service = SubjectsService(session, tom.id)
+
+        data = answer_create_applet_one.copy(deep=True)
+
+        client.login(sam)
+        subject_service = SubjectsService(session, sam.id)
+        target_subject = await subject_service.create(
+            SubjectCreate(
+                applet_id=applet_one.id,
+                creator_id=tom.id,
+                first_name="target",
+                last_name="subject",
+                secret_user_id=f"{uuid.uuid4()}",
+            )
+        )
+        await subject_service.create_relation(
+            relation="father",
+            source_subject_id=applet_one_sam_subject.id,
+            subject_id=target_subject.id,
+        )
+
+        data.source_subject_id = applet_one_sam_subject.id
+        data.target_subject_id = target_subject.id
+        data.input_subject_id = applet_one_sam_subject.id
+
+        response = await client.post(self.answer_url, data=data)
+
+        assert response.status_code == http.HTTPStatus.CREATED, response.json()
+
+        answers, _ = await AnswersCRUD(session).get_applet_answers(
+            applet_id=applet_one.id,
+            page=1,
+            limit=5
+        )
+
+        assert answers[0].relation == "father"
 
     async def test_answer_activity_items_create_permanent_relation_success(
         self,


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-7517](https://mindlogger.atlassian.net/browse/M2-7517)

Changes include:

- add an additional check for the get_answer_relation function to check for a temp relation if it is a temp relation we return "other"
- other than that we keep going with our code execution

### 🪤 Peer Testing

- Jira ticket include the testing steps make sure to follow them and check for the final output

### ✏️ Notes
