### PR TITLE
fix: allow `auto_assign` field to be `None` (M2-7285)

### DIFF
--- a/src/apps/activities/domain/activity_base.py
+++ b/src/apps/activities/domain/activity_base.py
@@ -21,7 +21,7 @@ class ActivityBase(BaseModel):
     report_included_item_name: str | None = None
     performance_task_type: PerformanceTaskType | None = None
     is_performance_task: bool = False
-    auto_assign: bool = True
+    auto_assign: bool | None = True
 
     @validator("name")
     def validate_string(cls, value):


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7285](https://mindlogger.atlassian.net/browse/M2-7285)

This PR fixes a crash caused by the introduction of the `auto_assign` field on Activities (original PR #1511). The model previously didn't align with the ORM definition.

### 🪤 Peer Testing

- From the Dashboard, try to edit any Applet.
    **Expected outcome:** The Applet should load properly into the builder, and **not** cause this BE error in DevTools:
    <img width="500" src="https://github.com/user-attachments/assets/59b72641-c53e-4a92-ba88-19643c8ed4e2">