### PR TITLE
fix: Hot fix for null auto-assign field in activity flow (M2-7285)

### DIFF
--- a/src/apps/activity_flows/domain/base.py
+++ b/src/apps/activity_flows/domain/base.py
@@ -14,7 +14,7 @@ class FlowBase(BaseModel):
     report_included_activity_name: str | None = None
     report_included_item_name: str | None = None
     is_hidden: bool | None = False
-    auto_assign: bool = True
+    auto_assign: bool | None = True
 
     @validator("description")
     def validate_description(cls, value):


### PR DESCRIPTION
### 📝 Description

Fixing error introduced in M2-7285 when auto-assign field is null for activity flow

🔗 [Jira Ticket M2-7285](https://mindlogger.atlassian.net/browse/M2-7285)


