### PR TITLE
set auto_assign variable to true for all entries on activities and fl…

### DIFF
--- a/src/apps/shared/commands/patch_commands.py
+++ b/src/apps/shared/commands/patch_commands.py
@@ -109,6 +109,13 @@ PatchRegister.register(
     description="[Migration] Migrate missed secret ids",
 )
 
+PatchRegister.register(
+    file_path="m2_7366_set_auto_assign_to_true_for_activities_and_flows.py",
+    task_id="M2-7366",
+    description="Set auto_assign to true for existing activities and flows",
+    manage_session=False,
+)
+
 app = typer.Typer()
 
 

--- a/src/apps/shared/commands/patches/m2_7366_set_auto_assign_to_true_for_activities_and_flows.py
+++ b/src/apps/shared/commands/patches/m2_7366_set_auto_assign_to_true_for_activities_and_flows.py
@@ -1,0 +1,37 @@
+# patches/m2_7285_set_auto_assign.py
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# SQL Queries
+SET_DEFAULT_AUTO_ASSIGN_ACTIVITIES_SQL = """
+    ALTER TABLE activities ALTER COLUMN auto_assign SET DEFAULT true;
+"""
+
+SET_DEFAULT_AUTO_ASSIGN_FLOWS_SQL = """
+    ALTER TABLE flows ALTER COLUMN auto_assign SET DEFAULT true;
+"""
+
+UPDATE_EXISTING_ACTIVITIES_SQL = """
+    UPDATE activities SET auto_assign = true WHERE auto_assign IS NULL;
+"""
+
+UPDATE_EXISTING_FLOWS_SQL = """
+    UPDATE flows SET auto_assign = true WHERE auto_assign IS NULL;
+"""
+
+async def main(session: AsyncSession, *args, **kwargs):
+    try:
+        # Set the default value of auto_assign to true for new records
+        await session.execute(SET_DEFAULT_AUTO_ASSIGN_ACTIVITIES_SQL)
+        await session.execute(SET_DEFAULT_AUTO_ASSIGN_FLOWS_SQL)
+
+        # Update existing records to set auto_assign to true
+        await session.execute(UPDATE_EXISTING_ACTIVITIES_SQL)
+        await session.execute(UPDATE_EXISTING_FLOWS_SQL)
+
+        # Commit the transaction
+        await session.commit()
+    except Exception as ex:
+        # Rollback the transaction in case of error
+        await session.rollback()
+        raise ex

--- a/src/apps/shared/commands/patches/m2_7366_set_auto_assign_to_true_for_activities_and_flows.py
+++ b/src/apps/shared/commands/patches/m2_7366_set_auto_assign_to_true_for_activities_and_flows.py
@@ -2,15 +2,7 @@
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# SQL Queries
-SET_DEFAULT_AUTO_ASSIGN_ACTIVITIES_SQL = """
-    ALTER TABLE activities ALTER COLUMN auto_assign SET DEFAULT true;
-"""
-
-SET_DEFAULT_AUTO_ASSIGN_FLOWS_SQL = """
-    ALTER TABLE flows ALTER COLUMN auto_assign SET DEFAULT true;
-"""
-
+# SQL Queries to update existing records
 UPDATE_EXISTING_ACTIVITIES_SQL = """
     UPDATE activities SET auto_assign = true WHERE auto_assign IS NULL;
 """
@@ -19,12 +11,9 @@ UPDATE_EXISTING_FLOWS_SQL = """
     UPDATE flows SET auto_assign = true WHERE auto_assign IS NULL;
 """
 
+
 async def main(session: AsyncSession, *args, **kwargs):
     try:
-        # Set the default value of auto_assign to true for new records
-        await session.execute(SET_DEFAULT_AUTO_ASSIGN_ACTIVITIES_SQL)
-        await session.execute(SET_DEFAULT_AUTO_ASSIGN_FLOWS_SQL)
-
         # Update existing records to set auto_assign to true
         await session.execute(UPDATE_EXISTING_ACTIVITIES_SQL)
         await session.execute(UPDATE_EXISTING_FLOWS_SQL)


### PR DESCRIPTION
📝 Description

🔗 [Jira Ticket M2-7366](https://mindlogger.atlassian.net/browse/M2-7366)
Changes include:

Created a Python patch to set the auto_assign field to true for existing records in the activities and flows tables.
Registered the patch in cli.py for execution via the CLI.
🪤 Peer Testing
<!-- Uncomment out any of the following as needed:           -->
Requires pipenv shell
Requires pipenv sync --dev

Test steps:

Run the patch: Execute the patch using the CLI command python src/cli.py patch exec M2-7366.

Expected outcome: The auto_assign field in existing activities and flows records is set to true, and the default value for new records is also set to true.

Verify database changes: Check the activities and flows tables to ensure that the auto_assign field is updated correctly for both existing and new records.

Expected outcome: All existing records have auto_assign set to true, and the default for new records is set to true.

✏️ Notes
No additional notes.