### PR TITLE
feat: update applet activities auto_assign (M2-7391)

### DIFF
--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -148,6 +148,7 @@ class ActivityService:
                     order=index + 1,
                     report_included_item_name=(activity_data.report_included_item_name),
                     performance_task_type=activity_data.performance_task_type,
+                    auto_assign=activity_data.auto_assign,
                 )
             )
 

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -251,6 +251,7 @@ class ActivityService:
                     report_included_item_name=schema.report_included_item_name,
                     performance_task_type=schema.performance_task_type,
                     is_performance_task=schema.is_performance_task,
+                    auto_assign=schema.auto_assign,
                 )
             )
         return activities

--- a/src/apps/activity_flows/service/flow.py
+++ b/src/apps/activity_flows/service/flow.py
@@ -196,6 +196,7 @@ class FlowService:
                 created_at=schema.created_at,
                 report_included_activity_name=schema.report_included_activity_name,  # noqa: E501
                 report_included_item_name=schema.report_included_item_name,
+                auto_assign=schema.auto_assign,
             )
             flow_map[flow.id] = flow
             flows.append(flow)

--- a/src/apps/activity_flows/service/flow.py
+++ b/src/apps/activity_flows/service/flow.py
@@ -107,6 +107,7 @@ class FlowService:
                     hide_badge=flow_update.hide_badge,
                     is_hidden=flow_update.is_hidden,
                     order=index + 1,
+                    auto_assign=flow_update.auto_assign,
                     report_included_activity_name=(flow_update.report_included_activity_name),
                     report_included_item_name=(flow_update.report_included_item_name),
                 )

--- a/src/apps/applets/domain/applets/public_detail.py
+++ b/src/apps/applets/domain/applets/public_detail.py
@@ -40,6 +40,7 @@ class Activity(PublicModel):
     performance_task_type: PerformanceTaskType | None = None
     report_included_item_name: str | None = None
     is_performance_task: bool = False
+    auto_assign: bool | None = True
 
 
 class ActivityFlowItem(PublicModel):

--- a/src/apps/applets/domain/applets/public_detail.py
+++ b/src/apps/applets/domain/applets/public_detail.py
@@ -61,6 +61,7 @@ class ActivityFlow(PublicModel):
     items: list[ActivityFlowItem] = Field(default_factory=list)
     report_included_activity_name: str | None = None
     report_included_item_name: str | None = None
+    auto_assign: bool | None = True
 
 
 class Encryption(PublicModel):


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [x] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-7391](https://mindlogger.atlassian.net/browse/M2-7391)

This PR updates the applet update endpoint `PUT /applets/{applet_id}` to update the `auto_assign` flag on the activities in the applet, if that flag is present in the update payload.

Changes include:

- Update `ActivityService#update_create` to update activities' `auto_assign` flag.

### 🪤 Peer Testing

There is no UI yet, so this has to be tested via Postman:

1. Create an applet with some activities (This will create activities with `auto_assign` defaulted to `true`)
2. Update the applet and set `auto_assign` on some activities to `false`

The change to that applet's activities' `auto_assign` should now be properly persisted.

### ✏️ Notes

N/A