### PR TITLE
feat: Add new endpoint to return activity assignment for logged user (M2-7275)

### DIFF
--- a/src/apps/activities/crud/activity_history.py
+++ b/src/apps/activities/crud/activity_history.py
@@ -123,7 +123,7 @@ class ActivityHistoriesCRUD(BaseCRUD[ActivityHistorySchema]):
         db_result = await self._execute(query)
         return db_result.scalars().all()
 
-    async def update_by_id(self, id_, **values):
+    async def update_by_id(self, id_, **values) -> None:
         subquery: Query = select(ActivityHistorySchema.id_version)
         subquery = subquery.where(ActivityHistorySchema.id == id_)
         subquery = subquery.limit(1)

--- a/src/apps/activities/domain/activity.py
+++ b/src/apps/activities/domain/activity.py
@@ -99,3 +99,4 @@ class ActivityLanguageWithItemsMobileDetailPublic(PublicModel):
 class ActivityBaseInfo(ActivityMinimumInfo, InternalModel):
     contains_response_types: list[ResponseType]
     item_count: int
+    auto_assign: bool

--- a/src/apps/activities/domain/activity_create.py
+++ b/src/apps/activities/domain/activity_create.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from pydantic import Field, root_validator
 
@@ -30,7 +31,7 @@ class ActivityCreate(ActivityBase, InternalModel):
     extra_fields: dict = Field(default_factory=dict)
 
     @root_validator()
-    def validate_existing_ids_for_duplicate(cls, values):
+    def validate_existing_ids_for_duplicate(cls, values) -> list[Any]:
         items: list[ActivityItemCreate] = values.get("items", [])
 
         item_names = set()

--- a/src/apps/activities/domain/activity_update.py
+++ b/src/apps/activities/domain/activity_update.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from pydantic import root_validator
 
@@ -30,7 +31,7 @@ class ActivityUpdate(ActivityBase, PublicModel):
     items: list[ActivityItemUpdate]
 
     @root_validator()
-    def validate_existing_ids_for_duplicate(cls, values):
+    def validate_existing_ids_for_duplicate(cls, values) -> list[Any]:
         items: list[ActivityItemUpdate] = values.get("items", [])
 
         item_names = set()

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -435,6 +435,7 @@ class ActivityService:
                 is_hidden=schema.is_hidden,
                 contains_response_types=[],
                 item_count=0,
+                auto_assign=schema.auto_assign,
             )
 
             activities.append(activity)

--- a/src/apps/activity_assignments/api.py
+++ b/src/apps/activity_assignments/api.py
@@ -5,13 +5,16 @@ from fastapi import Body, Depends
 from apps.activity_assignments.domain.assignments import (
     ActivitiesAssignments,
     ActivitiesAssignmentsCreate,
+    ActivitiesAssignmentsWithSubjects,
     ActivityAssignmentsListQueryParams,
 )
 from apps.activity_assignments.service import ActivityAssignmentService
 from apps.applets.service import AppletService
 from apps.authentication.deps import get_current_user
 from apps.shared.domain import Response
+from apps.shared.exception import NotFoundError
 from apps.shared.query_params import QueryParams, parse_query_params
+from apps.subjects.services import SubjectsService
 from apps.users import User
 from apps.workspaces.service.check_access import CheckAccessService
 from infrastructure.database import atomic
@@ -49,6 +52,28 @@ async def applet_assignments(
 
     return Response(
         result=ActivitiesAssignments(
+            applet_id=applet_id,
+            assignments=assignments,
+        )
+    )
+
+
+async def applet_respondent_assignments(
+    applet_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    session=Depends(get_session),
+) -> Response[ActivitiesAssignmentsWithSubjects]:
+    await AppletService(session, user.id).exist_by_id(applet_id)
+    await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
+
+    respondent_subject = await SubjectsService(session, user.id).get_by_user_and_applet(user.id, applet_id)
+    if not respondent_subject:
+        raise NotFoundError(f"User don't have subject role in applet {applet_id}")
+
+    assignments = await ActivityAssignmentService(session).get_all_by_respondent(applet_id, respondent_subject.id)
+
+    return Response(
+        result=ActivitiesAssignmentsWithSubjects(
             applet_id=applet_id,
             assignments=assignments,
         )

--- a/src/apps/activity_assignments/domain/assignments.py
+++ b/src/apps/activity_assignments/domain/assignments.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, root_validator
 
 from apps.activity_assignments.errors import ActivityAssignmentActivityOrFlowError
 from apps.shared.domain import InternalModel, PublicModel
+from apps.subjects.domain import SubjectReadResponse
 
 
 class ActivityAssignmentCreate(BaseModel):
@@ -43,3 +44,15 @@ class ActivitiesAssignments(PublicModel):
 class ActivityAssignmentsListQueryParams(InternalModel):
     activities: str | None
     flows: str | None
+
+
+class ActivityAssignmentWithSubject(PublicModel):
+    activity_flow_id: UUID | None
+    activity_id: UUID | None
+    respondent_subject: SubjectReadResponse
+    target_subject: SubjectReadResponse
+
+
+class ActivitiesAssignmentsWithSubjects(PublicModel):
+    applet_id: UUID
+    assignments: list[ActivityAssignmentWithSubject]

--- a/src/apps/activity_assignments/router.py
+++ b/src/apps/activity_assignments/router.py
@@ -1,8 +1,8 @@
 from fastapi.routing import APIRouter
 from starlette import status
 
-from apps.activity_assignments.api import applet_assignments, assignments_create
-from apps.activity_assignments.domain.assignments import ActivitiesAssignments
+from apps.activity_assignments.api import applet_assignments, applet_respondent_assignments, assignments_create
+from apps.activity_assignments.domain.assignments import ActivitiesAssignments, ActivitiesAssignmentsWithSubjects
 from apps.shared.domain import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE, Response
 
 router = APIRouter(prefix="/assignments", tags=["Activity assignments"])
@@ -33,3 +33,19 @@ router.get(
         **AUTHENTICATION_ERROR_RESPONSES,
     },
 )(applet_assignments)
+
+# User endpoints
+user_router = APIRouter(prefix="/users", tags=["Users"])
+
+user_router.get(
+    "/me/assignments/{applet_id}",
+    description="""
+    Get all activity assignments for logged-in respondent for an applet.
+                """,
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {"model": Response[ActivitiesAssignmentsWithSubjects]},
+        **DEFAULT_OPENAPI_RESPONSE,
+        **AUTHENTICATION_ERROR_RESPONSES,
+    },
+)(applet_respondent_assignments)

--- a/src/apps/activity_flows/domain/flow.py
+++ b/src/apps/activity_flows/domain/flow.py
@@ -42,6 +42,7 @@ class FlowBaseInfo(InternalModel):
     order: int
     is_hidden: bool | None = False
     activity_ids: list[uuid.UUID] = Field(default_factory=list)
+    auto_assign: bool
 
 
 class FlowSingleLanguageMobileDetailPublic(FlowBaseInfo, InternalModel):

--- a/src/apps/activity_flows/service/flow.py
+++ b/src/apps/activity_flows/service/flow.py
@@ -278,6 +278,7 @@ class FlowService:
                 hide_badge=schema.hide_badge,
                 order=schema.order,
                 is_hidden=schema.is_hidden,
+                auto_assign=schema.auto_assign,
             )
             flow_map[flow.id] = flow
             flows.append(flow)

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -264,7 +264,7 @@ class ActivitySubmissionResponse(ActivitySubmission):
     summary: SubmissionSummary | None = None
 
     @validator("summary", always=True)
-    def generate_summary(cls, value, values):
+    def generate_summary(cls, value, values) -> list[Any]:
         if not value:
             answer: ActivityAnswer = values["answer"]
             if answer:
@@ -382,7 +382,7 @@ class FlowSubmissionResponse(PublicModel):
         return value
 
     @validator("summary", always=True)
-    def generate_summary(cls, value, values):
+    def generate_summary(cls, value, values) -> list[Any]:
         if not value:
             answers: list[ActivityAnswer] = values["submission"].answers
             if answers:

--- a/src/apps/applets/domain/applet_create_update.py
+++ b/src/apps/applets/domain/applet_create_update.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field, root_validator
 
 from apps.activities.domain.activity_create import ActivityCreate
@@ -23,7 +25,7 @@ class AppletCreate(AppletReportConfigurationBase, AppletBase, InternalModel):
     extra_fields: dict = Field(default_factory=dict)
 
     @root_validator()
-    def validate_existing_ids_for_duplicate(cls, values):
+    def validate_existing_ids_for_duplicate(cls, values) -> list[Any]:
         activities: list[ActivityCreate] = values.get("activities", [])
         flows: list[FlowCreate] = values.get("activity_flows", [])
 
@@ -60,7 +62,7 @@ class AppletUpdate(AppletBase, PublicModel):
     activity_flows: list[FlowUpdate]
 
     @root_validator()
-    def validate_existing_ids_for_duplicate(cls, values):
+    def validate_existing_ids_for_duplicate(cls, values) -> list[Any]:
         activities: list[ActivityUpdate] = values.get("activities", [])
         flows: list[FlowUpdate] = values.get("activity_flows", [])
 

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -176,6 +176,8 @@ async def update_subject(
                 tag=subject.tag,
                 applet_id=subject.applet_id,
                 user_id=subject.user_id,
+                first_name=subject.first_name,
+                last_name=subject.last_name,
             )
         )
 
@@ -256,6 +258,8 @@ async def get_subject(
             tag=subject.tag,
             applet_id=subject.applet_id,
             user_id=subject.user_id,
+            first_name=subject.first_name,
+            last_name=subject.last_name,
         )
     )
 
@@ -288,5 +292,7 @@ async def get_my_subject(
             tag=subject.tag,
             applet_id=subject.applet_id,
             user_id=subject.user_id,
+            first_name=subject.first_name,
+            last_name=subject.last_name,
         )
     )

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -84,6 +84,8 @@ class SubjectReadResponse(SubjectUpdateRequest):
     last_seen: datetime.datetime | None
     applet_id: uuid.UUID
     user_id: uuid.UUID | None
+    first_name: str
+    last_name: str
 
 
 class SubjectRelation(InternalModel):

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -540,7 +540,17 @@ class TestSubjects(BaseTest):
         data = response.json()
         assert data
         res = data["result"]
-        assert set(res.keys()) == {"id", "secretUserId", "nickname", "lastSeen", "tag", "appletId", "userId"}
+        assert set(res.keys()) == {
+            "id",
+            "secretUserId",
+            "nickname",
+            "lastSeen",
+            "tag",
+            "appletId",
+            "firstName",
+            "lastName",
+            "userId",
+        }
         assert uuid.UUID(res["id"]) == tom_applet_one_subject.id
         assert res["secretUserId"] == tom_applet_one_subject.secret_user_id
         assert res["nickname"] == tom_applet_one_subject.nickname
@@ -631,7 +641,17 @@ class TestSubjects(BaseTest):
         data = response.json()
         assert data
         res = data["result"]
-        assert set(res.keys()) == {"id", "secretUserId", "nickname", "lastSeen", "tag", "appletId", "userId"}
+        assert set(res.keys()) == {
+            "id",
+            "secretUserId",
+            "nickname",
+            "lastSeen",
+            "tag",
+            "appletId",
+            "firstName",
+            "lastName",
+            "userId",
+        }
         assert uuid.UUID(res["id"]) == tom_applet_one_subject.id
         assert res["secretUserId"] == tom_applet_one_subject.secret_user_id
         assert res["nickname"] == tom_applet_one_subject.nickname
@@ -657,7 +677,17 @@ class TestSubjects(BaseTest):
         data = response.json()
         assert data
         res = data["result"]
-        assert set(res.keys()) == {"id", "secretUserId", "nickname", "lastSeen", "tag", "appletId", "userId"}
+        assert set(res.keys()) == {
+            "id",
+            "secretUserId",
+            "nickname",
+            "lastSeen",
+            "tag",
+            "appletId",
+            "firstName",
+            "lastName",
+            "userId",
+        }
         assert uuid.UUID(res["id"]) == applet_one_shell_account.id
         assert res["secretUserId"] == applet_one_shell_account.secret_user_id
         assert res["nickname"] == applet_one_shell_account.nickname

--- a/src/infrastructure/app.py
+++ b/src/infrastructure/app.py
@@ -63,6 +63,7 @@ routers: Iterable[APIRouter] = (
     ws_alerts.router,
     subject_router.router,
     activity_assignments.router,
+    activity_assignments.user_router,
 )
 
 # Declare your middlewares here

--- a/src/middlewares/content_length.py
+++ b/src/middlewares/content_length.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from fastapi import HTTPException
 from starlette import status
 from starlette.types import ASGIApp
@@ -28,10 +30,10 @@ class ContentLengthLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        def _receiver():
+        def _receiver() -> Callable:
             read_length: int = 0
 
-            async def _receive():
+            async def __receive():
                 nonlocal read_length, receive
 
                 message = await receive()
@@ -43,7 +45,7 @@ class ContentLengthLimitMiddleware:
                         )
                 return message
 
-            return _receive
+            return __receive
 
         _receive = _receiver()
         await self.app(scope, _receive, send)


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [x] For new features, QA automation engineers have been tagged

### 📝 Description
Added new GET endpoint `/users/me/assignments/applet/{applet_id}` to return all activity assigned as respondent for logged user
 - Also removed some mypy warnings

🔗 [Jira Ticket M2-7275](https://mindlogger.atlassian.net/browse/M2-7275)


