### PR TITLE
Feature/m2 7358 unassign activity or flow endpoint

### DIFF
--- a/src/apps/activity_assignments/api.py
+++ b/src/apps/activity_assignments/api.py
@@ -19,6 +19,31 @@ async def assignments_create(
     schema: ActivitiesAssignmentsCreate = Body(...),
     session=Depends(get_session),
 ) -> Response[ActivitiesAssignments]:
+    """
+    Creates multiple activity assignments for a specified applet.
+
+    This endpoint allows authorized users to assign activities or flows to participants
+    by creating new assignment records in the database.
+
+    Parameters:
+    -----------
+    applet_id : uuid.UUID
+        The ID of the applet for which assignments are being created.
+    
+    user : User, optional
+        The current user making the request (automatically injected).
+    
+    schema : ActivitiesAssignmentsCreate
+        The schema containing the list of assignments to be created.
+    
+    session : Depends, optional
+        The database session (automatically injected).
+
+    Returns:
+    --------
+    Response[ActivitiesAssignments]
+        A response object containing the newly created assignments for the applet.
+    """
     async with atomic(session):
         service = AppletService(session, user.id)
         await service.exist_by_id(applet_id)
@@ -31,3 +56,49 @@ async def assignments_create(
             assignments=assignments,
         )
     )
+    
+    
+async def unassignments_create(
+    applet_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    schema: ActivitiesAssignmentsCreate = Body(...),
+    session=Depends(get_session),
+) -> Response[ActivitiesAssignments]:
+    """
+    Unassigns multiple activity assignments for a specified applet.
+
+    This endpoint allows authorized users to unassign activities or flows from
+    participants by marking the corresponding assignments as deleted.
+
+    Parameters:
+    -----------
+    applet_id : uuid.UUID
+        The ID of the applet from which assignments are being unassigned.
+    
+    user : User, optional
+        The current user making the request (automatically injected).
+    
+    schema : ActivitiesAssignmentsCreate
+        The schema containing the list of assignments to be unassigned.
+    
+    session : Depends, optional
+        The database session (automatically injected).
+
+    Returns:
+    --------
+    Response[ActivitiesAssignments]
+        A response object containing the updated list of assignments for the applet.
+    """
+    async with atomic(session):
+        service = AppletService(session, user.id)
+        await service.exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_applet_activity_assignment_access(applet_id)
+        assignments = await ActivityAssignmentService(session).unassign_many(applet_id, schema.assignments)
+
+    return Response(
+        result=ActivitiesAssignments(
+            applet_id=applet_id,
+            assignments=assignments,
+        )
+    )
+    

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -1,5 +1,6 @@
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.orm import Query
+import uuid
 
 from apps.activity_assignments.db.schemas import ActivityAssigmentSchema
 from infrastructure.database import BaseCRUD
@@ -11,9 +12,54 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
     schema_class = ActivityAssigmentSchema
 
     async def create_many(self, schemas: list[ActivityAssigmentSchema]) -> list[ActivityAssigmentSchema]:
+        """
+        Creates multiple activity assignment records in the database.
+
+        This method utilizes the `_create_many` method from the `BaseCRUD` class to insert
+        multiple `ActivityAssigmentSchema` records into the database in a single operation.
+
+        Parameters:
+        -----------
+        schemas : list[ActivityAssigmentSchema]
+            A list of activity assignment schemas to be created.
+
+        Returns:
+        --------
+        list[ActivityAssigmentSchema]
+            A list of the created `ActivityAssigmentSchema` objects.
+
+        Notes:
+        ------
+        - Inherits functionality from `BaseCRUD`, which provides the `_create_many` method for
+        bulk insertion operations.
+        - Ensures that all new assignments are created in a single database transaction.
+        """
         return await self._create_many(schemas)
 
     async def already_exists(self, schema: ActivityAssigmentSchema) -> bool:
+        """
+        Checks if an activity assignment already exists in the database.
+
+        This method builds a query to check for the existence of an assignment with the same 
+        `activity_id`, `activity_flow_id`, `respondent_subject_id`, and `target_subject_id`, 
+        while ensuring the record has not been soft-deleted.
+
+        Parameters:
+        -----------
+        schema : ActivityAssigmentSchema
+            The activity assignment schema to check for existence.
+
+        Returns:
+        --------
+        bool
+            `True` if the assignment already exists, otherwise `False`.
+
+        Notes:
+        ------
+        - This method uses the `_execute` method from the `BaseCRUD` class to run the query and 
+        check for the existence of the assignment.
+        - The existence check is based on the combination of IDs and considers soft-deleted records.
+        """
         query: Query = select(ActivityAssigmentSchema)
         query = query.where(ActivityAssigmentSchema.activity_id == schema.activity_id)
         query = query.where(ActivityAssigmentSchema.respondent_subject_id == schema.respondent_subject_id)
@@ -23,3 +69,80 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
         query = query.exists()
         db_result = await self._execute(select(query))
         return db_result.scalars().first() or False
+    
+    
+    async def unassign_many(self, schemas: list[ActivityAssigmentSchema]) -> list[ActivityAssigmentSchema]:
+        """
+        Unassigns multiple assignments by marking them as deleted.
+
+        This method updates the `is_deleted` field for multiple assignment records
+        based on their `id`.
+
+        Parameters:
+        ----------
+        schemas : list[ActivityAssigmentSchema]
+            A list of schemas that need to be updated (unassigned).
+
+        Returns:
+        -------
+        list[ActivityAssigmentSchema]
+            A list of updated assignment schemas.
+        """
+        updated_schemas = []
+        for schema in schemas:
+            updated_schemas.extend(
+                await self._update(
+                    lookup='id',
+                    value=schema.id,
+                    schema=schema
+                )
+            )
+        return updated_schemas
+    
+    
+    async def get_assignments_by_activity_or_flow_id_and_subject_id(
+        self,
+        search_id: uuid.UUID,
+        respondent_subject_id: uuid.UUID,
+        target_subject_id: uuid.UUID,
+    ) -> uuid.UUID | None:
+        """
+        Retrieves the assignment ID from the activity_assignment table that matches
+        the given activity ID or flow ID and the respondent subject ID or target subject ID.
+
+        Parameters:
+        ----------
+        search_id : uuid.UUID
+            The ID to search for, either an activity ID or a flow ID.
+        respondent_subject_id : uuid.UUID
+            The ID of the respondent subject to match.
+        
+        target_subject_id : uuid.UUID
+            The ID of the target subject to match.
+
+        Returns:
+        -------
+        uuid.UUID | None
+            The ID of the matching assignment, or None if no match is found.
+        """
+
+        # Construct the query to match either activity_id or activity_flow_id and either subject ID
+        query: Query = select(ActivityAssigmentSchema)
+        query= query.where(
+            or_(
+                ActivityAssigmentSchema.activity_id == search_id,
+                ActivityAssigmentSchema.activity_flow_id == search_id
+            )
+        )
+        query = query.where(
+            or_(
+                ActivityAssigmentSchema.respondent_subject_id == respondent_subject_id,
+                ActivityAssigmentSchema.target_subject_id == target_subject_id
+            )
+        )
+        # Execute the query
+        result = await self._execute(query)
+
+        # Fetch the first matching assignment and return its ID, or None if no match is found
+        assignment = result.scalars().first()
+        return assignment.id if assignment else None

--- a/src/apps/activity_assignments/router.py
+++ b/src/apps/activity_assignments/router.py
@@ -1,7 +1,7 @@
 from fastapi.routing import APIRouter
 from starlette import status
 
-from apps.activity_assignments.api import assignments_create
+from apps.activity_assignments.api import assignments_create, unassignments_create  # Import the new unassignment function
 from apps.activity_assignments.domain.assignments import ActivitiesAssignments
 from apps.shared.domain import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE, Response
 
@@ -12,7 +12,7 @@ router.post(
     description="""Create a set of activity assignments. For each
                 assignment, provide respondent ID (or if pending
                 invite, then invitation ID), activity or activity
-                flow ID, and optionally, target subject ID.
+                flow ID, and target subject ID.
                 """,
     status_code=status.HTTP_201_CREATED,
     responses={
@@ -21,3 +21,18 @@ router.post(
         **AUTHENTICATION_ERROR_RESPONSES,
     },
 )(assignments_create)
+
+router.delete(
+    "/applet/{applet_id}/unassigns",
+    description="""Unassign a set of activity assignments. For each
+                assignment, provide respondent ID (or if pending
+                invite, then invitation ID), activity or activity
+                flow ID, and target subject ID.
+                """,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"model": Response[ActivitiesAssignments]},
+        **DEFAULT_OPENAPI_RESPONSE,
+        **AUTHENTICATION_ERROR_RESPONSES,
+    },
+)(unassignments_create)

--- a/src/apps/activity_assignments/tests/test_unassignments.py
+++ b/src/apps/activity_assignments/tests/test_unassignments.py
@@ -1,0 +1,160 @@
+
+import http
+import uuid
+
+import pytest
+from pydantic import EmailStr
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.activity_assignments.db.schemas import ActivityAssigmentSchema
+from apps.activity_assignments.domain.assignments import ActivitiesAssignmentsCreate, ActivityAssignmentCreate
+from apps.activity_flows.domain.flow_update import ActivityFlowItemUpdate, FlowUpdate
+from apps.applets.domain.applet_create_update import AppletUpdate
+from apps.applets.domain.applet_full import AppletFull
+from apps.applets.service import AppletService
+from apps.invitations.domain import InvitationRespondentRequest
+from apps.shared.enums import Language
+from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
+from apps.subjects.db.schemas import SubjectSchema
+from apps.subjects.domain import Subject, SubjectCreate, SubjectFull
+from apps.subjects.services import SubjectsService
+from apps.users import User
+
+#TODO: remove fixtures and import them from shared_fixtures.py
+@pytest.fixture
+def invitation_respondent_data() -> InvitationRespondentRequest:
+    return InvitationRespondentRequest(
+        email=EmailStr("pending@example.com"),
+        first_name="User",
+        last_name="pending",
+        language="en",
+        secret_user_id=str(uuid.uuid4()),
+        nickname=str(uuid.uuid4()),
+        tag="respondentTag",
+    )
+
+
+@pytest.fixture
+async def lucy_applet_one_subject(session: AsyncSession, lucy: User, applet_one_lucy_respondent: AppletFull) -> Subject:
+    applet_id = applet_one_lucy_respondent.id
+    query = select(SubjectSchema).where(SubjectSchema.user_id == lucy.id, SubjectSchema.applet_id == applet_id)
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    model = res.scalars().one()
+    return Subject.from_orm(model)
+
+
+@pytest.fixture
+async def lucy_applet_two_subject(session: AsyncSession, lucy: User, applet_two_lucy_respondent: AppletFull) -> Subject:
+    applet_id = applet_two_lucy_respondent.id
+    query = select(SubjectSchema).where(SubjectSchema.user_id == lucy.id, SubjectSchema.applet_id == applet_id)
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    model = res.scalars().one()
+    return Subject.from_orm(model)
+
+
+@pytest.fixture
+async def applet_one_pending_subject(
+    client, tom: User, invitation_respondent_data, applet_one: AppletFull, session: AsyncSession
+) -> Subject:
+    # invite a new respondent
+    client.login(tom)
+    response = await client.post(
+        "/invitations/{applet_id}/respondent".format(applet_id=str(applet_one.id)),
+        invitation_respondent_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    query = select(SubjectSchema).where(
+        SubjectSchema.applet_id == applet_one.id, SubjectSchema.email == invitation_respondent_data.email
+    )
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    model = res.scalars().one()
+    return Subject.from_orm(model)
+
+
+@pytest.fixture
+async def applet_one_with_flow(
+    session: AsyncSession, applet_one: AppletFull, applet_minimal_data: AppletFull, tom: User
+):
+    data = AppletUpdate(**applet_minimal_data.dict())
+    flow = FlowUpdate(
+        name="flow",
+        items=[ActivityFlowItemUpdate(id=None, activity_key=data.activities[0].key)],
+        description={Language.ENGLISH: "description"},
+        id=None,
+    )
+    data.activity_flows = [flow]
+    srv = AppletService(session, tom.id)
+    await srv.update(applet_one.id, data)
+    applet = await srv.get_full_applet(applet_one.id)
+    return applet
+
+
+@pytest.fixture
+async def applet_one_shell_account(session: AsyncSession, applet_one: AppletFull, tom: User) -> Subject:
+    return await SubjectsService(session, tom.id).create(
+        SubjectCreate(
+            applet_id=applet_one.id,
+            creator_id=tom.id,
+            first_name="Shell",
+            last_name="Account",
+            nickname="shell-account-0",
+            tag="shell-account-0-tag",
+            secret_user_id=f"{uuid.uuid4()}",
+        )
+    )
+
+
+class TestActivityUnassignments(BaseTest):
+    activities_unassignments_applet = "/assignments/applet/{applet_id}/unassigns"
+    activities_assignments_applet = "/assignments/applet/{applet_id}"
+
+    async def test_create_one_unassignment(
+        self,
+        client: TestClient,
+        applet_one: AppletFull,
+        tom: User,
+        lucy_applet_one_subject: SubjectFull,
+        tom_applet_one_subject,
+        session: AsyncSession,
+        ):
+        client.login(tom)
+
+        # Use the same details as the existing assignment
+        assignments_create = ActivitiesAssignmentsCreate(
+            assignments=[
+                ActivityAssignmentCreate(
+                    activity_id=applet_one.activities[0].id,
+                    respondent_subject_id=tom_applet_one_subject.id,
+                    target_subject_id=lucy_applet_one_subject.id,
+                )
+            ]
+        )
+        
+        assignment_response = await client.post(
+            self.activities_assignments_applet.format(applet_id=applet_one.id), data=assignments_create
+        )
+        
+        unassign_response = await client.delete(
+            self.activities_unassignments_applet.format(applet_id=applet_one.id), data=assignments_create
+        )
+
+        assert unassign_response.status_code == http.HTTPStatus.CREATED, unassign_response.json()
+        assignments = unassign_response.json()["result"]["assignments"]
+        assert len(assignments) == 1
+        assignment = assignments[0]
+        assert assignment["activityId"] == str(applet_one.activities[0].id)
+        assert assignment["respondentSubjectId"] == str(tom_applet_one_subject.id)
+        assert assignment["targetSubjectId"] == str(lucy_applet_one_subject.id)
+        assert assignment["activityFlowId"] is None
+        assert assignment["id"] is not None
+
+        query = select(ActivityAssigmentSchema).where(ActivityAssigmentSchema.id == assignment["id"])
+        res = await session.execute(query, execution_options={"synchronize_session": False})
+        model = res.scalars().one()
+
+        assert str(model.id) == assignment["id"]
+        assert model.activity_id == applet_one.activities[0].id
+        assert model.is_deleted is True


### PR DESCRIPTION
This pull request introduces the unassign endpoint for activity assignments. The unassign functionality allows authorized users to mark assignments as deleted. It ensures that previously assigned activities or flows can be unassigned, effectively updating the database to reflect the unassignment.

Implementation of the unassignments_create endpoint.
-[ ] Logic to mark assignments as is_deleted=True.
-[ ] Unassignment route, api, service and CRUD layers.
-[ ] Validation to ensure that the assignments exist before unassigning.
-[ ] Documentation for assignments and unassignments
-[ ] Tests for unassigning activities, including edge cases such as wrong IDs, missing IDs, and ensuring the correct state transition.

🪤 Peer Testing

To test the application you will need to:
- [ ] Create an applet and at least two activities. 
- [ ] Then create at least one user-subject. 
- [ ] Click on the validation mail form mailhog and delete any extra https:// on that link.  
- [ ] Log into the admin panel and invite the user to activity1 and activity2. 
- [ ] As a user-subject accept the invite using mailhog.  
- [] If you try to assign the activity 1 or two from the FE you the records will not be stored in the DB. You need to use the backend assignment endpoint (/assignments/applet/{applet_id}) on port 8000 to create the record on the activity_assignment table. 
-[ ] Once the record is created you can test the unassign endpoint (/assignments/applet/{applet_id}/unassigns") 

You can also use the test_unassignment as it creates assignments and the it uses the unassign feature. 


Test steps:

Assign an activity or flow to a subject using the existing assignment endpoint.
Expected outcome: The activity/flow should be successfully assigned, and visible in the database with is_deleted=False.
Unassign the same activity or flow using the new unassign endpoint.
Expected outcome: The corresponding record should be marked as is_deleted=True.

### ✏️ Notes

* The unassign endpoint mirrors the assignment endpoint, meaning it expects the same JSON format and body as the assignment endpoint. Initially, I created the unassign endpoint using the assignment_id, but according to the acceptance criteria (AC), the endpoint should operate with either the activity_id or flow_id along with the subject_id. To support this, I added a function in assignments.py (get_assignments_by_activity_or_flow_id_and_subject_id) that retrieves the assignment_id based on the provided activity/flow_id and subject_id.
* The base CRUD _update function is used to update the assignment entries by assignment_id. This function is utilized within the unassign_many method of the ActivityAssigmentCRUD class.
* In test_unassign.py, I first call the assignment endpoint to create an assignment, and then I unassign it using the unassign endpoint. Ideally, the assignment function should be a @pytest.fixture, but I encountered asynchronous issues when attempting to test the code this way.