### PR TITLE
feat: Add arbitrary command to check-delete copied applet data (M2-7674)

### DIFF
--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -926,3 +926,8 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         res = await self._execute(query)
         user_ids = res.scalars().all()
         return user_ids
+
+    async def delete_by_ids(self, ids: list[uuid.UUID]):
+        query: Query = delete(AnswerSchema)
+        query = query.where(AnswerSchema.id.in_(ids))
+        await self._execute(query)

--- a/src/apps/answers/db/schemas.py
+++ b/src/apps/answers/db/schemas.py
@@ -52,15 +52,6 @@ class AnswerSchema(HistoryAware, Base):
         lazy="noload",
     )
 
-    assessments = relationship(
-        "AnswerItemSchema",
-        order_by=lambda: asc(AnswerItemSchema.created_at),
-        primaryjoin=(
-            lambda: and_(AnswerSchema.id == AnswerItemSchema.answer_id, AnswerItemSchema.is_assessment.is_(True))  # type: ignore[has-type]
-        ),
-        lazy="noload",
-    )
-
 
 class AnswerNoteSchema(Base):
     __tablename__ = "answer_notes"

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -686,3 +686,17 @@ class PublicSubmissionsResponse(PublicModel):
     submissions: list[AppletSubmission] = Field(default_factory=list)
     submissions_count: int = 0
     participants_count: int = 0
+
+
+class AnswersCopyCheckResult(InternalModel):
+    total_answers: int
+    not_copied_answers: set[uuid.UUID]
+    answers_to_remove: set[uuid.UUID]
+    total_answer_items: int
+    not_copied_answer_items: set[uuid.UUID]
+
+
+class FilesCopyCheckResult(InternalModel):
+    total_files: int
+    not_copied_files: set[str]
+    files_to_remove: set[str]


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7674](https://mindlogger.atlassian.net/browse/M2-7674)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- CLI command to check (/remove) copied from one server to another one  applet data
```
python src/cli.py arbitrary check-copied-applet-answers -s <source arbitrary server owner email> -t <target arbitrary server owner email> <applet_id_1> <applet_id_2> ... <applet_id_n> --delete
```
