### PR TITLE
fix: add `items` to assigned activities endpoint (M2-7475)

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -118,7 +118,9 @@ async def applet_activities_for_subject(
         # Ensure reviewers can access the subject
         await CheckAccessService(session, user.id).check_subject_subject_access(applet_id, subject_id)
 
-        activities_future = ActivityService(session, user.id).get_single_language_by_applet_id(applet_id, language)
+        activities_future = ActivityService(session, user.id).get_single_language_with_items_by_applet_id(
+            applet_id, language
+        )
         flows_future = FlowService(session).get_single_language_by_applet_id(applet_id, language)
         assignments_future = ActivityAssignmentService(session).get_all_by_respondent(applet_id, subject_id)
 

--- a/src/apps/activities/crud/activity.py
+++ b/src/apps/activities/crud/activity.py
@@ -60,6 +60,7 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
             ActivitySchema.scores_and_reports,
             ActivitySchema.performance_task_type,
             ActivitySchema.is_performance_task,
+            ActivitySchema.auto_assign,
         )
 
         query = query.where(ActivitySchema.applet_id == applet_id)

--- a/src/apps/activities/domain/activity.py
+++ b/src/apps/activities/domain/activity.py
@@ -95,9 +95,10 @@ class ActivityLanguageWithItemsMobileDetailPublic(PublicModel):
     scores_and_reports: ScoresAndReports | None = None
     performance_task_type: PerformanceTaskType | None = None
     is_performance_task: bool = False
+    auto_assign: bool | None = True
 
 
-class ActivityWithAssignmentDetailsPublic(ActivitySingleLanguageDetailPublic):
+class ActivityWithAssignmentDetailsPublic(ActivityLanguageWithItemsMobileDetailPublic):
     assignments: list[ActivityAssignmentWithSubject] = Field(default_factory=list)
 
 

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -279,6 +279,7 @@ class ActivityService:
                 scores_and_reports=schema.scores_and_reports,
                 performance_task_type=schema.performance_task_type,
                 is_performance_task=schema.is_performance_task,
+                auto_assign=schema.auto_assign,
             )
 
             activities.append(activity)

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -687,6 +687,7 @@ class TestActivities:
         assert activity_result["name"] == activity.name
         assert activity_result["description"] == activity.description[Language.ENGLISH]
         assert activity_result["autoAssign"] == activity.auto_assign
+        assert len(activity_result["items"]) == 1
         assert len(activity_result["assignments"]) == 0
 
         flow = applet_activity_flow_lucy_manager.activity_flows[0]
@@ -777,6 +778,7 @@ class TestActivities:
         assert activity_result["name"] == manual_activity.name
         assert activity_result["description"] == manual_activity.description[Language.ENGLISH]
         assert activity_result["autoAssign"] is False
+        assert len(activity_result["items"]) == 1
         assert len(activity_result["assignments"]) == 1
 
         activity_assignment = activity_result["assignments"][0]
@@ -876,6 +878,7 @@ class TestActivities:
         assert activity_result["name"] == manual_activity.name
         assert activity_result["description"] == manual_activity.description[Language.ENGLISH]
         assert activity_result["autoAssign"] is True
+        assert len(activity_result["items"]) == 1
         assert len(activity_result["assignments"]) == 1
 
         activity_assignment = activity_result["assignments"][0]


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7475](https://mindlogger.atlassian.net/browse/M2-7475)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Adds missing `items` property to activities returned by the [recently added](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1565) `/activities/applet/{applet_id}/subject/{subject_id}` endpoint. Item information is needed for every activity in the Admin App's dashboard section to determine whether the activity is eligible for Take Now (some item types are mobile-only).

### 🪤 Peer Testing

- Test the `/activities/applet/{applet_id}/subject/{subject_id}` endpoint and observe the result
    **Expected outcome:** Each activity in the `activities` array now also contains an `items` array representing the item data for that activity

### ✏️ Notes

The **OASDIFF breaking changes** check failed due to some now-missing properties returned by this endpoint's activities:

![CleanShot 2024-09-05 at 16 14 24@2x](https://github.com/user-attachments/assets/889e41e3-5007-44f7-a2b9-8da183bae5e0)

However, as my current work in the Admin App is the first to begin consuming the new endpoint, that this is a breaking change doesn't matter. None of those properties are needed by my work, and the endpoint currently consumed by the Admin App for the same screen, `/activities/applet/${appletId}`, doesn't return these properties either. It just so happens that the new endpoint had introduced a slight variation in the activity properties returned, none of which are relevant to the screen consuming this endpoint. In the end, this PR is going to align this endpoint's result more closely to what that screen is currently expecting.