### PR TITLE
fix: Return assignments matching either respondent or target subject ID (M2-6223)

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -122,7 +122,9 @@ async def applet_activities_for_subject(
             applet_id, language
         )
         flows_future = FlowService(session).get_single_language_by_applet_id(applet_id, language)
-        assignments_future = ActivityAssignmentService(session).get_all_by_respondent(applet_id, subject_id)
+        assignments_future = ActivityAssignmentService(session).get_all_by_subject(
+            applet_id, subject_id, match_by="respondent_or_target"
+        )
 
         activities, flows, assignments = await asyncio.gather(activities_future, flows_future, assignments_future)
         result = ActivitiesAndFlowsWithAssignmentDetailsPublic(

--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -122,9 +122,9 @@ async def applet_activities_for_subject(
             applet_id, language
         )
         flows_future = FlowService(session).get_single_language_by_applet_id(applet_id, language)
-        assignments_future = ActivityAssignmentService(session).get_all_by_subject(
-            applet_id, subject_id, match_by="respondent_or_target"
-        )
+
+        query_params = QueryParams(filters={"respondent_subject_id": subject_id, "target_subject_id": subject_id})
+        assignments_future = ActivityAssignmentService(session).get_all_with_subject_entities(applet_id, query_params)
 
         activities, flows, assignments = await asyncio.gather(activities_future, flows_future, assignments_future)
         result = ActivitiesAndFlowsWithAssignmentDetailsPublic(

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -644,7 +644,7 @@ class TestActivities:
         result = response.json()["result"]
 
         assert result[0]["type"] == "NOT_FOUND"
-        assert result[0]["message"] == f"Respondent subject id {subject_id} not found"
+        assert result[0]["message"] == f"Subject with id {subject_id} not found"
 
     async def test_subject_assigned_activities_empty_applet(
         self, client, empty_applet_lucy_manager, lucy, lucy_empty_applet_subject
@@ -706,6 +706,7 @@ class TestActivities:
         client,
         empty_applet_lucy_manager,
         lucy,
+        lucy_empty_applet_subject,
         user_empty_applet_subject,
         activity_create_session: ActivityCreate,
     ):
@@ -730,7 +731,17 @@ class TestActivities:
                     activity_id=manual_activity.id,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
-                )
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=manual_activity.id,
+                    respondent_subject_id=user_empty_applet_subject.id,
+                    target_subject_id=lucy_empty_applet_subject.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=manual_activity.id,
+                    respondent_subject_id=lucy_empty_applet_subject.id,
+                    target_subject_id=user_empty_applet_subject.id,
+                ),
             ],
         )
 
@@ -756,7 +767,17 @@ class TestActivities:
                     activity_flow_id=manual_flow.id,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
-                )
+                ),
+                ActivityAssignmentCreate(
+                    activity_flow_id=manual_flow.id,
+                    respondent_subject_id=user_empty_applet_subject.id,
+                    target_subject_id=lucy_empty_applet_subject.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_flow_id=manual_flow.id,
+                    respondent_subject_id=lucy_empty_applet_subject.id,
+                    target_subject_id=user_empty_applet_subject.id,
+                ),
             ],
         )
 
@@ -779,7 +800,7 @@ class TestActivities:
         assert activity_result["description"] == manual_activity.description[Language.ENGLISH]
         assert activity_result["autoAssign"] is False
         assert len(activity_result["items"]) == 1
-        assert len(activity_result["assignments"]) == 1
+        assert len(activity_result["assignments"]) == 3
 
         activity_assignment = activity_result["assignments"][0]
         assert activity_assignment["activityId"] == str(manual_activity.id)
@@ -792,7 +813,7 @@ class TestActivities:
         assert flow_result["name"] == manual_flow.name
         assert flow_result["description"] == manual_flow.description[Language.ENGLISH]
         assert flow_result["autoAssign"] is False
-        assert len(flow_result["assignments"]) == 1
+        assert len(flow_result["assignments"]) == 3
         assert flow_result["activityIds"][0] == str(manual_flow.items[0].activity_id)
 
         flow_assignment = flow_result["assignments"][0]

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -729,18 +729,27 @@ class TestActivities:
             [
                 ActivityAssignmentCreate(
                     activity_id=manual_activity.id,
+                    activity_flow_id=None,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
                 ),
                 ActivityAssignmentCreate(
                     activity_id=manual_activity.id,
+                    activity_flow_id=None,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=lucy_empty_applet_subject.id,
                 ),
                 ActivityAssignmentCreate(
                     activity_id=manual_activity.id,
+                    activity_flow_id=None,
                     respondent_subject_id=lucy_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=manual_activity.id,
+                    activity_flow_id=None,
+                    respondent_subject_id=lucy_empty_applet_subject.id,
+                    target_subject_id=lucy_empty_applet_subject.id,
                 ),
             ],
         )
@@ -764,19 +773,28 @@ class TestActivities:
             empty_applet_lucy_manager.id,
             [
                 ActivityAssignmentCreate(
+                    activity_id=None,
                     activity_flow_id=manual_flow.id,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
                 ),
                 ActivityAssignmentCreate(
+                    activity_id=None,
                     activity_flow_id=manual_flow.id,
                     respondent_subject_id=user_empty_applet_subject.id,
                     target_subject_id=lucy_empty_applet_subject.id,
                 ),
                 ActivityAssignmentCreate(
+                    activity_id=None,
                     activity_flow_id=manual_flow.id,
                     respondent_subject_id=lucy_empty_applet_subject.id,
                     target_subject_id=user_empty_applet_subject.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=None,
+                    activity_flow_id=manual_flow.id,
+                    respondent_subject_id=lucy_empty_applet_subject.id,
+                    target_subject_id=lucy_empty_applet_subject.id,
                 ),
             ],
         )

--- a/src/apps/activity_assignments/api.py
+++ b/src/apps/activity_assignments/api.py
@@ -129,9 +129,8 @@ async def applet_respondent_assignments(
     if not respondent_subject:
         raise NotFoundError(f"User doesn't have subject role in applet {applet_id}")
 
-    assignments = await ActivityAssignmentService(session).get_all_by_subject(
-        applet_id, respondent_subject.id, match_by="respondent"
-    )
+    query_params = QueryParams(filters={"respondent_subject_id": respondent_subject.id})
+    assignments = await ActivityAssignmentService(session).get_all_with_subject_entities(applet_id, query_params)
 
     return Response(
         result=ActivitiesAssignmentsWithSubjects(

--- a/src/apps/activity_assignments/api.py
+++ b/src/apps/activity_assignments/api.py
@@ -127,9 +127,11 @@ async def applet_respondent_assignments(
 
     respondent_subject = await SubjectsService(session, user.id).get_by_user_and_applet(user.id, applet_id)
     if not respondent_subject:
-        raise NotFoundError(f"User don't have subject role in applet {applet_id}")
+        raise NotFoundError(f"User doesn't have subject role in applet {applet_id}")
 
-    assignments = await ActivityAssignmentService(session).get_all_by_respondent(applet_id, respondent_subject.id)
+    assignments = await ActivityAssignmentService(session).get_all_by_subject(
+        applet_id, respondent_subject.id, match_by="respondent"
+    )
 
     return Response(
         result=ActivitiesAssignmentsWithSubjects(

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -158,13 +158,6 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
         )
         await self._execute(query)
 
-    async def get_by_respondent_subject_id(self, respondent_subject_id) -> list[ActivityAssigmentSchema]:
-        query: Query = select(ActivityAssigmentSchema)
-        query = query.where(ActivityAssigmentSchema.respondent_subject_id == respondent_subject_id)
-        db_result = await self._execute(query)
-
-        return db_result.scalars().all()
-
     async def get_by_applet(self, applet_id: uuid.UUID, query_params: QueryParams) -> list[ActivityAssigmentSchema]:
         respondent_schema = aliased(SubjectSchema)
         target_schema = aliased(SubjectSchema)

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -120,7 +120,9 @@ class ActivityAssignmentService:
         ]
 
     async def check_for_assignment_and_notify(self, applet_id: uuid.UUID, respondent_subject_id: uuid.UUID) -> None:
-        assignments = await ActivityAssigmentCRUD(self.session).get_by_respondent_subject_id(respondent_subject_id)
+        assignments = await ActivityAssigmentCRUD(self.session).get_by_applet_and_subject(
+            applet_id, respondent_subject_id, match_by="respondent"
+        )
         if not assignments:
             return
 

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -371,7 +371,7 @@ class ActivityAssignmentService:
             applet_id, subject_id, match_by
         )
 
-        subject_ids: set[uuid] = set()
+        subject_ids: set[uuid.UUID] = set()
         for assignment in assignments:
             subject_ids.add(assignment.respondent_subject_id)
             subject_ids.add(assignment.target_subject_id)
@@ -388,7 +388,7 @@ class ActivityAssignmentService:
                 tag=subject.tag,
                 applet_id=subject.applet_id,
             )
-            for subject in await SubjectsCrud(self.session).get_by_ids(subject_ids)
+            for subject in await SubjectsCrud(self.session).get_by_ids(list(subject_ids))
         }
 
         return [

--- a/src/apps/shared/query_params.py
+++ b/src/apps/shared/query_params.py
@@ -25,7 +25,7 @@ class QueryParams(InternalModel):
     """
 
     filters: dict[str, Any] = Field(default_factory=dict)
-    search: str | None
+    search: str | None = None
     page: int = Field(gt=0, default=1)
     limit: int = Field(gt=0, default=10, le=settings.service.result_limit)
     ordering: list[str] = Field(default_factory=list)


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6223](https://mindlogger.atlassian.net/browse/M2-6223)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Assignments being returned by the recently added `/activities/applet/{applet_id}/subject/{subject_id}` endpoint were only matching by respondent subject, but the AC for M2-6223 states to return assignments matching either by respondent _or_ target subject. Fixed this behaviour and updated tests to verify this is working as intended.

In addition, the `check_for_assignment_and_notify` function was using a CRUD function `get_by_respondent_subject_id` to return assignments matching a given respondent subject, which did not perform soft-delete integrity checks. This caused email notifications sent to pending full accounts after they've accepted the invitation to include unassigned activities. A better function to use is `get_by_applet_and_subject`, which has soft-delete integrity checks, and fixes this issue. So removed the old function in favour of this one.

### 🪤 Peer Testing

#### Test `/activities/applet/{applet_id}/subject/{subject_id}` endpoint:
1. Create 3 assignments on an activity for a given subject where:
    - the subject is only the respondent
    - the subject is only the target subject
    - the subject is both the respondent and the target subject
    - the subject is neither the respondent nor the target subject
2. Call the endpoint `/activities/applet/{applet_id}/subject/{subject_id}` for that subject and check the list of returned assignments.
    **Expected outcome:** The 1st three assignments created above should be returned, and the 4th one should not be.

#### Test fix to email notifications:
1. Create an assignment for a pending invited full account on an activity using the POST `/assignments` endpoint. (There's a bug in the Admin Panel that prevents you from assigning activities to pending invitations, so this needs to be tested via the API directly.)
    **Expected outcome:** That assignment should be created successfully, but no email about the assignment should be sent to the respondent yet because their account is pending.
2. Unassign the assignment created in step 1 using the DELETE `/assignments` endpoint.
3. Accept the pending invitation to create the full account.
    **Expected outcome:** No email should be sent to notify the respondent about the now-unassigned activity.