### PR TITLE
feat: Add `severity` field to subscale lookup table (M2-7586)

### DIFF
--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -171,6 +171,7 @@ class SubScaleLookupTable(PublicModel):
     age: PositiveInt | None = None
     sex: str | None = Field(default=None, regex="^(M|F)$", description="M or F")
     optional_text: str | None = None
+    severity: str | None = Field(default=None, regex="^(Minimal|Mild|Moderate|Severe)$")
 
     @validator("raw_score")
     def validate_raw_score_lookup(cls, value):


### PR DESCRIPTION
- [ ] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-7586](https://mindlogger.atlassian.net/browse/M2-7586)

This PR adds a field called `severity` to the subscale lookup table JSONB data. This allows subscale lookup tables to be saved with severity data as needed for M2-7586

### 🪤 Peer Testing

See integration tests

### ✏️ Notes

N/A