### PR TITLE
feature: Soft delete activity assignments on activity/flow deletion

### DIFF
--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -18,6 +18,7 @@ from apps.activities.domain.activity_update import (
 )
 from apps.activities.errors import ActivityAccessDeniedError, ActivityDoeNotExist
 from apps.activities.services.activity_item import ActivityItemService
+from apps.activity_assignments.service import ActivityAssignmentService
 from apps.applets.crud import AppletsCRUD, UserAppletAccessCRUD
 from apps.schedule.crud.events import ActivityEventsCRUD, EventCRUD
 from apps.schedule.service.schedule import ScheduleService
@@ -189,6 +190,7 @@ class ActivityService:
             await ScheduleService(self.session).delete_by_activity_ids(
                 applet_id=applet_id, activity_ids=list(deleted_activity_ids)
             )
+            await ActivityAssignmentService(self.session).delete_by_activity_or_flow_ids(list(deleted_activity_ids))
 
         # Create default events for new activities
         if new_activities:

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -332,6 +332,9 @@ class ActivityAssignmentService:
             target_subject_ids=target_subject_ids,
         )
 
+    async def delete_by_activity_or_flow_ids(self, activity_or_flow_ids: list[uuid.UUID]) -> None:
+        await ActivityAssigmentCRUD(self.session).delete_by_activity_or_flow_ids(activity_or_flow_ids)
+
     async def get_all(self, applet_id: uuid.UUID, query_params: QueryParams) -> list[ActivityAssignment]:
         """
         Returns assignments for given applet ID and matching any filters provided in query_params.

--- a/src/apps/activity_flows/service/flow.py
+++ b/src/apps/activity_flows/service/flow.py
@@ -1,5 +1,6 @@
 import uuid
 
+from apps.activity_assignments.service import ActivityAssignmentService
 from apps.activity_flows.crud import FlowItemsCRUD, FlowsCRUD, FlowsHistoryCRUD
 from apps.activity_flows.db.schemas import ActivityFlowSchema
 from apps.activity_flows.domain.flow import (
@@ -143,6 +144,7 @@ class FlowService:
         deleted_flow_ids = set(all_flows) - set(existing_flows)
         if deleted_flow_ids:
             await ScheduleService(self.session).delete_by_flow_ids(applet_id=applet_id, flow_ids=list(deleted_flow_ids))
+            await ActivityAssignmentService(self.session).delete_by_activity_or_flow_ids(list(deleted_flow_ids))
 
         # Create default events for new activities
         if new_flows:


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

On applet update, if an activity or flow got deleted, soft deleted activity assignments associates for those activites/flows


🔗 [Jira Ticket M2-7640](https://mindlogger.atlassian.net/browse/M2-7640)

