### PR TITLE
feat: Update Subscale Lookup Table to support age ranges (M2-7586)

### DIFF
--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -1,6 +1,6 @@
 from pydantic import ValidationError
 
-from apps.activities.errors import InvalidRawScoreSubscaleError, InvalidScoreSubscaleError, InvalidAgeSubscaleError
+from apps.activities.errors import InvalidAgeSubscaleError, InvalidRawScoreSubscaleError, InvalidScoreSubscaleError
 
 
 def validate_score_subscale_table(value: str):
@@ -30,6 +30,7 @@ def validate_score_subscale_table(value: str):
             raise InvalidScoreSubscaleError()
 
     return value
+
 
 def validate_age_subscale(value: str):
     # make sure it's format is "x~y" or "x"

--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -1,4 +1,6 @@
-from apps.activities.errors import InvalidRawScoreSubscaleError, InvalidScoreSubscaleError
+from pydantic import ValidationError
+
+from apps.activities.errors import InvalidRawScoreSubscaleError, InvalidScoreSubscaleError, InvalidAgeSubscaleError
 
 
 def validate_score_subscale_table(value: str):
@@ -26,6 +28,30 @@ def validate_score_subscale_table(value: str):
                 raise InvalidScoreSubscaleError()
         except ValueError:
             raise InvalidScoreSubscaleError()
+
+    return value
+
+def validate_age_subscale(value: str):
+    # make sure it's format is "x~y" or "x"
+
+    def validate_non_negative_int(maybe_int: str):
+        try:
+            int_value = int(maybe_int)
+            if int_value < 0:
+                raise InvalidAgeSubscaleError()
+        except (ValueError, ValidationError):
+            raise InvalidAgeSubscaleError()
+
+    if "~" not in value:
+        # make sure value is a positive integer
+        validate_non_negative_int(value)
+    else:
+        # make sure x and y are positive integers
+        x: str
+        y: str
+        x, y = value.split("~")
+        validate_non_negative_int(x)
+        validate_non_negative_int(y)
 
     return value
 

--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -1,4 +1,4 @@
-from pydantic import ValidationError, PositiveInt
+from pydantic import PositiveInt, ValidationError
 
 from apps.activities.errors import InvalidAgeSubscaleError, InvalidRawScoreSubscaleError, InvalidScoreSubscaleError
 

--- a/src/apps/activities/domain/custom_validation_subscale.py
+++ b/src/apps/activities/domain/custom_validation_subscale.py
@@ -1,4 +1,4 @@
-from pydantic import ValidationError
+from pydantic import ValidationError, PositiveInt
 
 from apps.activities.errors import InvalidAgeSubscaleError, InvalidRawScoreSubscaleError, InvalidScoreSubscaleError
 
@@ -32,8 +32,8 @@ def validate_score_subscale_table(value: str):
     return value
 
 
-def validate_age_subscale(value: str):
-    # make sure it's format is "x~y" or "x"
+def validate_age_subscale(value: PositiveInt | str | None):
+    # make sure its format is "x~y" or "x"
 
     def validate_non_negative_int(maybe_int: str):
         try:
@@ -43,7 +43,12 @@ def validate_age_subscale(value: str):
         except (ValueError, ValidationError):
             raise InvalidAgeSubscaleError()
 
-    if "~" not in value:
+    if value is None:
+        return value
+    elif isinstance(value, int):
+        if value < 0:
+            raise InvalidAgeSubscaleError()
+    elif "~" not in value:
         # make sure value is a positive integer
         validate_non_negative_int(value)
     else:

--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -1,7 +1,7 @@
 import enum
 from enum import Enum
 
-from pydantic import Field, validator
+from pydantic import Field, PositiveInt, validator
 
 from apps.activities.domain.conditional_logic import Match
 from apps.activities.domain.conditions import ScoreCondition, SectionCondition
@@ -172,7 +172,7 @@ class SubscaleCalculationType(str, Enum):
 class SubScaleLookupTable(PublicModel):
     score: str
     raw_score: str
-    age: str | None = None
+    age: PositiveInt | str | None = None
     sex: str | None = Field(default=None, regex="^(M|F)$", description="M or F")
     optional_text: str | None = None
     severity: str | None = Field(default=None, regex="^(Minimal|Mild|Moderate|Severe)$")

--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -5,7 +5,8 @@ from pydantic import Field, PositiveInt, validator
 
 from apps.activities.domain.conditional_logic import Match
 from apps.activities.domain.conditions import ScoreCondition, SectionCondition
-from apps.activities.domain.custom_validation_subscale import validate_raw_score_subscale, validate_score_subscale_table
+from apps.activities.domain.custom_validation_subscale import validate_raw_score_subscale, \
+    validate_score_subscale_table, validate_age_subscale
 from apps.activities.errors import (
     DuplicateScoreConditionIdError,
     DuplicateScoreConditionNameError,
@@ -168,7 +169,7 @@ class SubscaleCalculationType(str, Enum):
 class SubScaleLookupTable(PublicModel):
     score: str
     raw_score: str
-    age: PositiveInt | None = None
+    age: str | None = None
     sex: str | None = Field(default=None, regex="^(M|F)$", description="M or F")
     optional_text: str | None = None
     severity: str | None = Field(default=None, regex="^(Minimal|Mild|Moderate|Severe)$")
@@ -180,6 +181,10 @@ class SubScaleLookupTable(PublicModel):
     @validator("score")
     def validate_score_lookup(cls, value):
         return validate_score_subscale_table(value)
+
+    @validator("age")
+    def validate_age_lookup(cls, value):
+        return validate_age_subscale(value)
 
 
 class SubscaleItemType(str, Enum):

--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -1,12 +1,15 @@
 import enum
 from enum import Enum
 
-from pydantic import Field, PositiveInt, validator
+from pydantic import Field, validator
 
 from apps.activities.domain.conditional_logic import Match
 from apps.activities.domain.conditions import ScoreCondition, SectionCondition
-from apps.activities.domain.custom_validation_subscale import validate_raw_score_subscale, \
-    validate_score_subscale_table, validate_age_subscale
+from apps.activities.domain.custom_validation_subscale import (
+    validate_age_subscale,
+    validate_raw_score_subscale,
+    validate_score_subscale_table,
+)
 from apps.activities.errors import (
     DuplicateScoreConditionIdError,
     DuplicateScoreConditionNameError,

--- a/src/apps/activities/errors.py
+++ b/src/apps/activities/errors.py
@@ -219,6 +219,9 @@ class InvalidRawScoreSubscaleError(ValidationError):
 class InvalidScoreSubscaleError(ValidationError):
     message = _("Score in subscale lookup table is invalid.")
 
+class InvalidAgeSubscaleError(ValidationError):
+    message = _("Age in subscale lookup table is invalid.")
+
 
 class IncorrectSubscaleItemError(ValidationError):
     message = _("Activity item inside subscale does not exist.")

--- a/src/apps/activities/errors.py
+++ b/src/apps/activities/errors.py
@@ -219,6 +219,7 @@ class InvalidRawScoreSubscaleError(ValidationError):
 class InvalidScoreSubscaleError(ValidationError):
     message = _("Score in subscale lookup table is invalid.")
 
+
 class InvalidAgeSubscaleError(ValidationError):
     message = _("Age in subscale lookup table is invalid.")
 

--- a/src/apps/activities/tests/fixtures/scores_reports.py
+++ b/src/apps/activities/tests/fixtures/scores_reports.py
@@ -125,5 +125,5 @@ def subscale_lookup_table() -> list[SubScaleLookupTable]:
         SubScaleLookupTable(score="10", age="10", sex="M", raw_score="1", optional_text="some url", severity="Minimal"),
         SubScaleLookupTable(score="20", age="10", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
         SubScaleLookupTable(score="20", age="10~15", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
-        SubScaleLookupTable(score="20", age="0~5", sex="F", raw_score="2", optional_text="some url", severity="Mild")
+        SubScaleLookupTable(score="20", age="0~5", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
     ]

--- a/src/apps/activities/tests/fixtures/scores_reports.py
+++ b/src/apps/activities/tests/fixtures/scores_reports.py
@@ -122,6 +122,8 @@ def subscale_total_score_table() -> list[TotalScoreTable]:
 @pytest.fixture
 def subscale_lookup_table() -> list[SubScaleLookupTable]:
     return [
-        SubScaleLookupTable(score="10", age=10, sex="M", raw_score="1", optional_text="some url", severity="Minimal"),
-        SubScaleLookupTable(score="20", age=10, sex="F", raw_score="2", optional_text="some url", severity="Mild"),
+        SubScaleLookupTable(score="10", age="10", sex="M", raw_score="1", optional_text="some url", severity="Minimal"),
+        SubScaleLookupTable(score="20", age="10", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
+        SubScaleLookupTable(score="20", age="10~15", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
+        SubScaleLookupTable(score="20", age="0~5", sex="F", raw_score="2", optional_text="some url", severity="Mild")
     ]

--- a/src/apps/activities/tests/fixtures/scores_reports.py
+++ b/src/apps/activities/tests/fixtures/scores_reports.py
@@ -124,6 +124,8 @@ def subscale_lookup_table() -> list[SubScaleLookupTable]:
     return [
         SubScaleLookupTable(score="10", age="10", sex="M", raw_score="1", optional_text="some url", severity="Minimal"),
         SubScaleLookupTable(score="20", age="10", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
+        SubScaleLookupTable(score="20", age=15, sex="F", raw_score="2", optional_text="some url", severity="Mild"),
+        SubScaleLookupTable(score="20", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
         SubScaleLookupTable(score="20", age="10~15", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
         SubScaleLookupTable(score="20", age="0~5", sex="F", raw_score="2", optional_text="some url", severity="Mild"),
     ]

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -521,6 +521,36 @@ class TestActivityItems:
         result = resp.json()["result"]
         assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
 
+    async def test_create_applet__activity_with_subscale_settings_with_invalid_subscale_lookup_table_age(
+        self,
+        client: TestClient,
+        applet_minimal_data: AppletCreate,
+        single_select_item_create_with_score: ActivityItemCreate,
+        tom: User,
+        subscale_setting: SubscaleSetting,
+    ):
+        client.login(tom)
+        data = applet_minimal_data.copy(deep=True)
+        sub_setting = subscale_setting.copy(deep=True)
+        sub_setting.subscales[0].items[0].name = single_select_item_create_with_score.name  # type: ignore[index]
+        sub_setting.subscales[0].subscale_table_data = [
+            SubScaleLookupTable(
+                score="20",
+                age="-1~15",
+                sex="F",
+                raw_score="~2",
+                optional_text="some url",
+                severity="Mild"
+            )
+        ]
+        data.activities[0].items = [single_select_item_create_with_score]
+        data.activities[0].subscale_setting = sub_setting
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert resp.status_code == http.HTTPStatus.BAD_REQUEST
+        result = resp.json()["result"]
+        print(result)
+        # assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
+
     async def test_create_applet__activity_with_score_and_reports__score_and_section(
         self,
         client: TestClient,


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-7586](https://mindlogger.atlassian.net/browse/M2-7586)

This PR updates the validation for the subscale lookup table to support ranges in the `age` field using the tilde character (~), similar to the `score` and `rawScore` fields.

### 🪤 Peer Testing

Consume the create applet endpoint, where the data contains a subscale lookup table with an age range

> [!NOTE]
> Edit the `email` and `password` variables

```shell
email=""
password=""

login_response=$(curl 'https://localhost:8000/auth/login' \
  -H 'Content-Language: en-US' \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw "{\"email\":\"${email}\",\"password\":\"${password}\"}")

access_token=$(echo "${login_response}" | jq -r '.result.token.accessToken')
workspace_id=$(echo "${login_response}" | jq -r '.result.user.id')

curl "https://localhost:8000/workspaces/${workspace_id}/applets" \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H "Authorization: bearer ${access_token}" \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw '{"displayName":"Age Range Subscale Applet","description":{"en":""},"themeId":null,"about":{"en":""},"image":"","watermark":"","activities":[{"name":"Activity","description":{"en":""},"showAllAtOnce":false,"isSkippable":false,"responseIsEditable":true,"isHidden":false,"autoAssign":true,"isReviewable":false,"items":[{"responseType":"singleSelect","name":"Item","question":{"en":"Scored Item"},"config":{"removeBackButton":false,"skippableItem":false,"randomizeOptions":false,"addScores":true,"setAlerts":false,"addTooltip":false,"setPalette":false,"timer":0,"additionalResponseOption":{"textInputOption":false,"textInputRequired":false},"portraitLayout":false,"autoAdvance":false},"isHidden":false,"allowEdit":true,"responseValues":{"options":[{"id":"8081cf86-2edd-459b-baf8-9adb207a30e6","text":"The right answer","isHidden":false,"value":0,"score":1}]}},{"responseType":"singleSelect","name":"gender_screen","question":{"en":"How do you describe yourself?<br><br>*Please provide your response as accurately as possible. The information you provide is important for ensuring the accuracy of your results. If you have any concerns about how your information will be used, please refer to our Terms of Service.*"},"config":{"removeBackButton":false,"skippableItem":false,"randomizeOptions":false,"addScores":false,"setAlerts":false,"addTooltip":false,"setPalette":false,"timer":0,"additionalResponseOption":{"textInputOption":false,"textInputRequired":false},"portraitLayout":false,"autoAdvance":false},"isHidden":false,"allowEdit":false,"responseValues":{"options":[{"id":"356526cb-ba04-4349-9911-0f814f6f8086","text":"Male","isHidden":false,"value":0},{"id":"f7c7a050-4859-47b3-8e8e-48703b6a515c","text":"Female","isHidden":false,"value":1}]}},{"responseType":"text","name":"age_screen","question":{"en":"How old are you?<br><br>*Please provide your response as accurately as possible. The information you provide is important for ensuring the accuracy of your results. If you have any concerns about how your information will be used, please refer to our Terms of Service.*"},"config":{"removeBackButton":false,"skippableItem":false,"maxResponseLength":3,"correctAnswerRequired":false,"correctAnswer":"","numericalResponseRequired":true,"responseDataIdentifier":false,"responseRequired":false},"isHidden":false,"allowEdit":false,"responseValues":null}],"scoresAndReports":{"generateReport":false,"reports":[],"showScoreSummary":false},"subscaleSetting":{"subscales":[{"name":"Subscale","scoring":"sum","items":[{"name":"Item","type":"item"}],"subscaleTableData":[{"score":"10","rawScore":"1","age":"15","sex":"M","optionalText":"https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt","id":"24f30754-bf89-4bac-a599-b9df11a16c12","severity":null},{"score":"20","rawScore":"2","age":"15","sex":"M","optionalText":"https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt","id":"3f99acd7-5447-445b-9b53-3d1713b33c12","severity":null},{"score":"30","rawScore":"3","age":"15","sex":"M","optionalText":"Markdown Text Here","id":"13abe852-6cce-4859-86f6-f0fe051f30a4","severity":null},{"score":"40","rawScore":"4","age":"15","sex":"F","optionalText":"Good","id":"bdfd9e20-0fb8-44c5-bbbd-4a3c4fbba2c4","severity":null},{"score":"50","rawScore":"5","age":"15~25","sex":null,"optionalText":"","id":"8f2b853d-134f-40a5-9ab8-dcedd8072328","severity":null}]}],"calculateTotalScore":null,"totalScoresTableData":null},"key":"3ff8fa06-8265-49f6-93e0-44cdc21ea438","reportIncludedItemName":""}],"activityFlows":[],"reportEmailBody":"Please see the report attached to this email.","streamIpAddress":null,"streamPort":null,"encryption":{"publicKey":"[69,10,200,71,2,222,237,55,31,26,217,3,199,24,231,124,231,204,200,74,174,87,7,105,133,137,100,36,216,232,87,146,236,216,156,236,201,91,170,189,161,5,207,247,47,167,132,104,185,196,187,94,249,177,167,157,221,227,4,50,38,19,58,35,82,197,62,174,118,116,10,110,43,203,77,189,175,77,57,135,222,252,59,135,160,39,103,134,205,52,43,0,14,238,217,210,15,10,216,142,30,221,250,143,114,237,190,220,183,1,2,153,24,58,190,108,253,164,62,179,38,57,70,110,3,244,16,73]","prime":"[188,223,9,149,64,85,250,187,46,43,7,141,98,242,217,92,165,224,181,233,215,8,78,218,132,92,205,217,68,104,156,149,203,154,98,135,113,216,27,127,182,178,20,77,55,90,35,34,177,253,33,129,91,152,221,91,175,206,119,211,228,153,125,219,231,255,207,84,23,31,124,216,95,207,228,144,74,114,60,44,139,192,167,89,9,227,100,155,200,81,121,8,33,189,116,50,127,62,60,127,250,195,25,252,112,172,137,183,213,2,207,49,161,185,65,211,21,44,233,188,143,13,44,78,62,78,234,115]","base":"[2]","accountId":"9e7d3792-024b-42e6-b72c-ddd6d67ce8fb"}}'
```

Then check the database and confirm the presence of an age range in the `subscale_setting` JSONB column of the `activities` table

<img width="292" alt="image" src="https://github.com/user-attachments/assets/f4daf864-d523-4e70-b794-efab42dc52dc">

### ✏️ Notes

N/A