### PR TITLE
feat: Get Subjects by Respondent Subject: Submissions + Assignments (M2-7919)

### DIFF
--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -147,7 +147,7 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
 
         db_result = await self._execute(query.distinct())
 
-        return [row[0] for row in db_result.all()]
+        return db_result.scalars().all()
 
     async def delete_by_activity_or_flow_ids(self, activity_or_flow_ids: list[uuid.UUID]):
         """

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -137,7 +137,7 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
             ActivityAssigmentSchema.soft_exists(),
         )
 
-        if activity_or_flow_ids and len(activity_or_flow_ids) > 0:
+        if len(activity_or_flow_ids) > 0:
             query = query.where(
                 or_(
                     ActivityAssigmentSchema.activity_id.in_(activity_or_flow_ids),

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -301,3 +301,12 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
             updated_schema = await self._get("id", model_id)
 
         return updated_schema
+
+    async def check_if_auto_assigned(self, activity_or_flow_id: uuid.UUID) -> bool | None:
+        activities_query = select(ActivitySchema.auto_assign).where(ActivitySchema.id == activity_or_flow_id)
+        flows_query = select(ActivityFlowSchema.auto_assign).where(ActivityFlowSchema.id == activity_or_flow_id)
+
+        union_query = activities_query.union_all(flows_query).limit(1)
+
+        db_result = await self._execute(union_query)
+        return db_result.scalar_one_or_none()

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -303,6 +303,9 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
         return updated_schema
 
     async def check_if_auto_assigned(self, activity_or_flow_id: uuid.UUID) -> bool | None:
+        """
+        Checks if the activity or flow is currently set to auto-assign.
+        """
         activities_query = select(ActivitySchema.auto_assign).where(ActivitySchema.id == activity_or_flow_id)
         flows_query = select(ActivityFlowSchema.auto_assign).where(ActivityFlowSchema.id == activity_or_flow_id)
 

--- a/src/apps/activity_assignments/crud/assignments.py
+++ b/src/apps/activity_assignments/crud/assignments.py
@@ -111,6 +111,44 @@ class ActivityAssigmentCRUD(BaseCRUD[ActivityAssigmentSchema]):
         db_result = await self._execute(query)
         return db_result.scalars().first()
 
+    async def get_target_subject_ids_by_activity_or_flow_ids(
+        self,
+        respondent_subject_id: uuid.UUID,
+        activity_or_flow_ids: list[uuid.UUID] = [],
+    ) -> list[uuid.UUID]:
+        """
+        Retrieves the IDs of target subjects that have assignments to be completed by the provided respondent.
+
+        Parameters:
+        ----------
+        respondent_subject_id : uuid.UUID
+            The ID of the respondent subject to search for. This parameter is required.
+        activity_or_flow_ids : list[uuid.UUID]
+            Optional list of activity or flow IDs to narrow the search. These IDs may correspond to either
+            `activity_id` or `activity_flow_id` fields
+
+        Returns:
+        -------
+        list[uuid.UUID]
+            List of target subject IDs associated with the provided activity or flow IDs.
+        """
+        query = select(ActivityAssigmentSchema.target_subject_id).where(
+            ActivityAssigmentSchema.respondent_subject_id == respondent_subject_id,
+            ActivityAssigmentSchema.soft_exists(),
+        )
+
+        if activity_or_flow_ids and len(activity_or_flow_ids) > 0:
+            query = query.where(
+                or_(
+                    ActivityAssigmentSchema.activity_id.in_(activity_or_flow_ids),
+                    ActivityAssigmentSchema.activity_flow_id.in_(activity_or_flow_ids),
+                )
+            )
+
+        db_result = await self._execute(query.distinct())
+
+        return [row[0] for row in db_result.all()]
+
     async def delete_by_activity_or_flow_ids(self, activity_or_flow_ids: list[uuid.UUID]):
         """
         Marks the `is_deleted` field as True for all matching assignments based on the provided

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -425,6 +425,9 @@ class ActivityAssignmentService:
         )
 
     async def check_if_auto_assigned(self, activity_or_flow_id: uuid.UUID) -> bool | None:
+        """
+        Checks if the activity or flow is currently set to auto-assign.
+        """
         return await ActivityAssigmentCRUD(self.session).check_if_auto_assigned(activity_or_flow_id)
 
     @staticmethod

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -399,6 +399,31 @@ class ActivityAssignmentService:
             for assignment in assignments
         ]
 
+    async def get_target_subject_ids_by_respondent(
+        self,
+        respondent_subject_id: uuid.UUID,
+        activity_or_flow_ids: list[uuid.UUID] = [],
+    ) -> list[uuid.UUID]:
+        """
+        Retrieves the IDs of target subjects that have assignments to be completed by the provided respondent.
+
+        Parameters:
+        ----------
+        respondent_subject_id : uuid.UUID
+            The ID of the respondent subject to search for. This parameter is required.
+        activity_or_flow_ids : list[uuid.UUID]
+            Optional list of activity or flow IDs to narrow the search. These IDs may correspond to either
+            `activity_id` or `activity_flow_id` fields
+
+        Returns:
+        -------
+        list[uuid.UUID]
+            List of target subject IDs associated with the provided activity or flow IDs.
+        """
+        return await ActivityAssigmentCRUD(self.session).get_target_subject_ids_by_activity_or_flow_ids(
+            respondent_subject_id, activity_or_flow_ids
+        )
+
     @staticmethod
     def _get_email_template_name(language: str) -> str:
         return f"new_activity_assignments_{language}"

--- a/src/apps/activity_assignments/service.py
+++ b/src/apps/activity_assignments/service.py
@@ -424,6 +424,9 @@ class ActivityAssignmentService:
             respondent_subject_id, activity_or_flow_ids
         )
 
+    async def check_if_auto_assigned(self, activity_or_flow_id: uuid.UUID) -> bool | None:
+        return await ActivityAssigmentCRUD(self.session).check_if_auto_assigned(activity_or_flow_id)
+
     @staticmethod
     def _get_email_template_name(language: str) -> str:
         return f"new_activity_assignments_{language}"

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -944,7 +944,7 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query: Query = (
             select(
                 AnswerSchema.target_subject_id,
-                func.count(func.distinct(AnswerSchema.submit_id)).label("number_of_submissions"),
+                func.count(func.distinct(AnswerSchema.submit_id)).label("submission_count"),
             )
             .where(
                 AnswerSchema.source_subject_id == respondent_subject_id,

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -937,3 +937,24 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query: Query = delete(AnswerSchema)
         query = query.where(AnswerSchema.id.in_(ids))
         await self._execute(query)
+
+    async def get_target_subject_ids_by_respondent(
+        self, respondent_subject_id: uuid.UUID, activity_or_flow_id: uuid.UUID
+    ):
+        query: Query = (
+            select(
+                AnswerSchema.target_subject_id,
+                func.count(func.distinct(AnswerSchema.submit_id)).label("number_of_submissions"),
+            )
+            .where(
+                AnswerSchema.source_subject_id == respondent_subject_id,
+                or_(
+                    AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(activity_or_flow_id),
+                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(activity_or_flow_id),
+                ),
+            )
+            .group_by(AnswerSchema.target_subject_id)
+        )
+
+        res = await self._execute(query)
+        return res.all()

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1853,6 +1853,13 @@ class AnswerService:
             )
         return results
 
+    async def get_target_subject_ids_by_respondent_and_activity_or_flow(
+        self, respondent_subject_id: uuid.UUID, activity_or_flow_id: uuid.UUID
+    ) -> list[tuple[uuid.UUID, int]]:
+        return await AnswersCRUD(self.answer_session).get_target_subject_ids_by_respondent(
+            respondent_subject_id, activity_or_flow_id
+        )
+
 
 class ReportServerService:
     def __init__(self, session, arbitrary_session=None):

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -352,8 +352,12 @@ async def get_target_subjects_by_respondent(
             subject_info[subject_id]["currently_assigned"] = True
 
     subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
-    result = [
-        TargetSubjectByRespondentResponse(
+    result: list[TargetSubjectByRespondentResponse] = []
+
+    # Find the respondent subject in the list of subjects
+    respondent_target_subject: TargetSubjectByRespondentResponse | None = None
+    for subject in subjects:
+        target_subject = TargetSubjectByRespondentResponse(
             secret_user_id=subject.secret_user_id,
             nickname=subject.nickname,
             tag=subject.tag,
@@ -365,7 +369,14 @@ async def get_target_subjects_by_respondent(
             submission_count=subject_info[subject.id]["submission_count"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
         )
-        for subject in subjects
-    ]
+
+        if subject.id == respondent_subject_id:
+            respondent_target_subject = target_subject
+        else:
+            result.append(target_subject)
+
+    if respondent_target_subject:
+        # TODO: If this endpoint is ever paginated, this logic will need to be moved to the query level
+        result.insert(0, respondent_target_subject)
 
     return ResponseMulti(result=result, count=len(result))

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -322,9 +322,14 @@ async def get_target_subjects_by_respondent(
         respondent_subject.applet_id, respondent_subject.id
     )
 
-    assignment_subject_ids = await ActivityAssignmentService(session).get_target_subject_ids_by_respondent(
+    assignment_service = ActivityAssignmentService(session)
+    assignment_subject_ids = await assignment_service.get_target_subject_ids_by_respondent(
         respondent_subject_id=respondent_subject_id, activity_or_flow_ids=[activity_or_flow_id]
     )
+
+    is_auto_assigned = await assignment_service.check_if_auto_assigned(activity_or_flow_id)
+    if is_auto_assigned:
+        assignment_subject_ids.append(respondent_subject_id)
 
     submission_data: list[tuple[uuid.UUID, int]] = await AnswerService(
         user_id=user.id, session=session, arbitrary_session=answer_session

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -346,11 +346,7 @@ async def get_target_subjects_by_respondent(
         else:
             subject_info[subject_id]["currently_assigned"] = True
 
-    subject_ids = list(subject_info.keys())
-    subjects: list[Subject] = await subjects_service.get_by_ids(subject_ids)
-    answer_dates = await AnswerService(
-        user_id=user.id, session=session, arbitrary_session=answer_session
-    ).get_last_answer_dates(subject_ids, respondent_subject.applet_id)
+    subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
     result = [
         TargetSubjectByRespondentResponse(
             secret_user_id=subject.secret_user_id,
@@ -363,7 +359,6 @@ async def get_target_subjects_by_respondent(
             last_name=subject.last_name,
             submission_count=subject_info[subject.id]["submission_count"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
-            last_seen=answer_dates.get(subject.id),
         )
         for subject in subjects
     ]

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -307,7 +307,7 @@ async def get_target_subjects_by_respondent(
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     answer_session=Depends(get_answer_session),
-) -> ResponseMulti[list[TargetSubjectByRespondentResponse]]:
+) -> ResponseMulti[TargetSubjectByRespondentResponse]:
     subjects_service = SubjectsService(session, user.id)
     respondent_subject = await subjects_service.get(respondent_subject_id)
     if not respondent_subject:

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -346,8 +346,11 @@ async def get_target_subjects_by_respondent(
         else:
             subject_info[subject_id]["currently_assigned"] = True
 
-    # Fetch the rest of the subject data
-    subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
+    subject_ids = list(subject_info.keys())
+    subjects: list[Subject] = await subjects_service.get_by_ids(subject_ids)
+    answer_dates = await AnswerService(
+        user_id=user.id, session=session, arbitrary_session=answer_session
+    ).get_last_answer_dates(subject_ids, respondent_subject.applet_id)
     result = [
         TargetSubjectByRespondentResponse(
             secret_user_id=subject.secret_user_id,
@@ -360,6 +363,7 @@ async def get_target_subjects_by_respondent(
             last_name=subject.last_name,
             number_of_submissions=subject_info[subject.id]["number_of_submissions"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
+            last_seen=answer_dates.get(subject.id),
         )
         for subject in subjects
     ]

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -334,15 +334,15 @@ async def get_target_subjects_by_respondent(
 
     class SubjectInfo(TypedDict):
         currently_assigned: bool
-        number_of_submissions: int
+        submission_count: int
 
     subject_info: dict[uuid.UUID, SubjectInfo] = {}
-    for subject_id, number_of_submissions in submission_data:
-        subject_info[subject_id] = {"currently_assigned": False, "number_of_submissions": number_of_submissions}
+    for subject_id, submission_count in submission_data:
+        subject_info[subject_id] = {"currently_assigned": False, "submission_count": submission_count}
 
     for subject_id in assignment_subject_ids:
         if subject_id not in subject_info:
-            subject_info[subject_id] = {"currently_assigned": True, "number_of_submissions": 0}
+            subject_info[subject_id] = {"currently_assigned": True, "submission_count": 0}
         else:
             subject_info[subject_id]["currently_assigned"] = True
 
@@ -361,7 +361,7 @@ async def get_target_subjects_by_respondent(
             user_id=subject.user_id,
             first_name=subject.first_name,
             last_name=subject.last_name,
-            number_of_submissions=subject_info[subject.id]["number_of_submissions"],
+            submission_count=subject_info[subject.id]["submission_count"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
             last_seen=answer_dates.get(subject.id),
         )

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -89,7 +89,7 @@ class SubjectReadResponse(SubjectUpdateRequest):
 
 
 class TargetSubjectByRespondentResponse(SubjectReadResponse):
-    number_of_submissions: int = 0
+    submission_count: int = 0
     currently_assigned: bool = False
 
 

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -87,9 +87,11 @@ class SubjectReadResponse(SubjectUpdateRequest):
     first_name: str
     last_name: str
 
+
 class TargetSubjectByRespondentResponse(SubjectReadResponse):
     number_of_submissions: int = 0
     currently_assigned: bool = False
+
 
 class SubjectRelation(InternalModel):
     source_subject_id: uuid.UUID

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -87,6 +87,9 @@ class SubjectReadResponse(SubjectUpdateRequest):
     first_name: str
     last_name: str
 
+class TargetSubjectByRespondentResponse(SubjectReadResponse):
+    number_of_submissions: int = 0
+    currently_assigned: bool = False
 
 class SubjectRelation(InternalModel):
     source_subject_id: uuid.UUID

--- a/src/apps/subjects/router.py
+++ b/src/apps/subjects/router.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from apps.authentication.deps import get_current_user
-from apps.shared.domain import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE, Response
+from apps.shared.domain import AUTHENTICATION_ERROR_RESPONSES, DEFAULT_OPENAPI_RESPONSE, Response, ResponseMulti
 from apps.subjects.api import (
     create_relation,
     create_subject,
@@ -12,9 +12,17 @@ from apps.subjects.api import (
     delete_relation,
     delete_subject,
     get_subject,
+    get_target_subjects_by_respondent,
     update_subject,
 )
-from apps.subjects.domain import Subject, SubjectCreateRequest, SubjectCreateResponse, SubjectFull, SubjectReadResponse
+from apps.subjects.domain import (
+    Subject,
+    SubjectCreateRequest,
+    SubjectCreateResponse,
+    SubjectFull,
+    SubjectReadResponse,
+    TargetSubjectByRespondentResponse,
+)
 from apps.users import User
 from infrastructure.database.deps import get_session
 
@@ -104,3 +112,14 @@ router.delete(
         **AUTHENTICATION_ERROR_RESPONSES,
     },
 )(delete_relation)
+
+router.get(
+    "/respondent/{respondent_subject_id}/activity-or-flow/{activity_or_flow_id}",
+    response_model=ResponseMulti[TargetSubjectByRespondentResponse],
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {"model": ResponseMulti[TargetSubjectByRespondentResponse]},
+        **DEFAULT_OPENAPI_RESPONSE,
+        **AUTHENTICATION_ERROR_RESPONSES,
+    },
+)(get_target_subjects_by_respondent)

--- a/src/apps/subjects/services/subjects.py
+++ b/src/apps/subjects/services/subjects.py
@@ -69,6 +69,10 @@ class SubjectsService:
         schema = await SubjectsCrud(self.session).get_by_id(id_)
         return Subject.from_orm(schema) if schema else None
 
+    async def get_by_ids(self, ids: list[uuid.UUID], include_deleted=False) -> list[Subject]:
+        subjects = await SubjectsCrud(self.session).get_by_ids(ids, include_deleted)
+        return [Subject.from_orm(subject) for subject in subjects]
+
     async def get_if_soft_exist(self, id_: uuid.UUID) -> Subject | None:
         schema = await SubjectsCrud(self.session).get_by_id(id_)
         if schema and schema.soft_exists():

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -927,6 +927,8 @@ class TestSubjects(BaseTest):
             ],
         )
 
+        client.login(tom)
+
         url = self.subject_target_by_respondent_url.format(
             respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=str(activity.id)
         )

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -9,7 +9,13 @@ from asyncpg import UniqueViolationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.activities.domain.activity_update import ActivityUpdate
+from apps.activities.services.activity import ActivityService
+from apps.activity_assignments.domain.assignments import ActivityAssignmentCreate, ActivityAssignmentDelete
+from apps.activity_assignments.service import ActivityAssignmentService
 from apps.answers.crud.answers import AnswersCRUD
+from apps.answers.domain import AppletAnswerCreate
+from apps.answers.service import AnswerService
 from apps.applets.domain.applet_full import AppletFull
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
@@ -202,9 +208,25 @@ async def applet_one_lucy_respondent(session: AsyncSession, applet_one: AppletFu
 
 
 @pytest.fixture
+async def applet_one_pit_respondent(session: AsyncSession, applet_one: AppletFull, tom: User, pit: User) -> AppletFull:
+    await UserAppletAccessService(session, tom.id, applet_one.id).add_role(pit.id, Role.RESPONDENT)
+    return applet_one
+
+
+@pytest.fixture
 async def lucy_applet_one_subject(session: AsyncSession, lucy: User, applet_one_lucy_respondent: AppletFull) -> Subject:
     applet_id = applet_one_lucy_respondent.id
     user_id = lucy.id
+    query = select(SubjectSchema).where(SubjectSchema.user_id == user_id, SubjectSchema.applet_id == applet_id)
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    model = res.scalars().one()
+    return Subject.from_orm(model)
+
+
+@pytest.fixture
+async def pit_applet_one_subject(session: AsyncSession, pit: User, applet_one_pit_respondent: AppletFull) -> Subject:
+    applet_id = applet_one_pit_respondent.id
+    user_id = pit.id
     query = select(SubjectSchema).where(SubjectSchema.user_id == user_id, SubjectSchema.applet_id == applet_id)
     res = await session.execute(query, execution_options={"synchronize_session": False})
     model = res.scalars().one()
@@ -266,6 +288,9 @@ class TestSubjects(BaseTest):
     subject_relation_url = "/subjects/{subject_id}/relations/{source_subject_id}"
     subject_temporary_multiinformant_relation_url = (
         "/subjects/{subject_id}/relations/{source_subject_id}/multiinformant-assessment"
+    )
+    subject_target_by_respondent_url = (
+        "/subjects/respondent/{respondent_subject_id}/activity-or-flow/{activity_or_flow_id}"
     )
     answer_url = "/answers"
 
@@ -770,3 +795,332 @@ class TestSubjects(BaseTest):
         client.login(request.getfixturevalue(user_fixture))
         res = await client.get(self.subject_detail_url.format(subject_id=subject_id))
         assert res.status_code == expected
+
+    async def test_get_target_subjects_by_respondent_invalid_respondent(
+        self, client, tom: User, applet_one: AppletFull
+    ):
+        invalid_respondent_subject_id = str(uuid.uuid4())
+        activity_or_flow_id = str(applet_one.activities[0].id)
+        client.login(tom)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=invalid_respondent_subject_id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+
+    async def test_get_target_subjects_by_respondent_limited_account_respondent(
+        self, client, tom: User, applet_one: AppletFull, applet_one_shell_account: Subject
+    ):
+        activity_or_flow_id = str(applet_one.activities[0].id)
+        client.login(tom)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=applet_one_shell_account.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+
+    async def test_get_target_subjects_by_respondent_editor_user(
+        self, client, applet_one_pit_editor: AppletFull, pit: User, tom_applet_one_subject: Subject
+    ):
+        activity_or_flow_id = str(applet_one_pit_editor.activities[0].id)
+        client.login(pit)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=tom_applet_one_subject.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_get_target_subjects_by_respondent_respondent_user(
+        self, client, lucy: User, tom_applet_one_subject: Subject, applet_one_lucy_respondent: AppletFull
+    ):
+        activity_or_flow_id = str(applet_one_lucy_respondent.activities[0].id)
+        client.login(lucy)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=tom_applet_one_subject.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_get_target_subjects_by_respondent_reviewer_without_assignment(
+        self, client, lucy: User, tom_applet_one_subject: Subject, applet_one_pit_reviewer: AppletFull
+    ):
+        activity_or_flow_id = str(applet_one_pit_reviewer.activities[0].id)
+        client.login(lucy)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=tom_applet_one_subject.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_get_target_subjects_by_respondent_reviewer_with_assignment(
+        self, client, lucy: User, tom_applet_one_subject: Subject, applet_one_lucy_reviewer_with_subject: AppletFull
+    ):
+        activity_or_flow_id = str(applet_one_lucy_reviewer_with_subject.activities[0].id)
+        client.login(lucy)
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=tom_applet_one_subject.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+    async def test_get_target_subjects_by_respondent_no_assignments_or_submissions(
+        self,
+        client,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        lucy_applet_one_subject: Subject,
+        applet_one_lucy_respondent: AppletFull,
+        session,
+    ):
+        activity_or_flow_id = str(applet_one_lucy_respondent.activities[0].id)
+        client.login(tom)
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=activity_or_flow_id
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+        result = response.json()["result"]
+
+        assert len(result) == 1
+
+        subject_result = result[0]
+
+        assert subject_result["id"] == str(lucy_applet_one_subject.id)
+        assert subject_result["submissionCount"] == 0
+        assert subject_result["currentlyAssigned"] is True
+
+    async def test_get_target_subjects_by_respondent_manual_assignment(
+        self,
+        client,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        lucy_applet_one_subject: Subject,
+        applet_one_lucy_respondent: AppletFull,
+        session,
+    ):
+        activity = applet_one_lucy_respondent.activities[0]
+
+        # Turn off auto-assignment
+        activity_service = ActivityService(session, tom.id)
+        await activity_service.remove_applet_activities(applet_one_lucy_respondent.id)
+        await activity_service.update_create(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityUpdate(
+                    **activity.dict(exclude={"auto_assign"}),
+                    auto_assign=False,
+                )
+            ],
+        )
+
+        # Create a manual assignment
+        await ActivityAssignmentService(session).create_many(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityAssignmentCreate(
+                    activity_id=activity.id,
+                    respondent_subject_id=lucy_applet_one_subject.id,
+                    target_subject_id=tom_applet_one_subject.id,
+                ),
+            ],
+        )
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=str(activity.id)
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+        result = response.json()["result"]
+
+        assert len(result) == 1
+
+        subject_result = result[0]
+
+        assert subject_result["id"] == str(tom_applet_one_subject.id)
+        assert subject_result["submissionCount"] == 0
+        assert subject_result["currentlyAssigned"] is True
+
+    async def test_get_target_subjects_by_respondent_excludes_deleted_assignment(
+        self,
+        client,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        lucy_applet_one_subject: Subject,
+        applet_one_lucy_respondent: AppletFull,
+        session,
+    ):
+        activity = applet_one_lucy_respondent.activities[0]
+
+        # Turn off auto-assignment
+        activity_service = ActivityService(session, tom.id)
+        await activity_service.remove_applet_activities(applet_one_lucy_respondent.id)
+        await activity_service.update_create(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityUpdate(
+                    **activity.dict(exclude={"auto_assign"}),
+                    auto_assign=False,
+                )
+            ],
+        )
+
+        # Create a deleted assignment
+        assignment_service = ActivityAssignmentService(session)
+        await assignment_service.create_many(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityAssignmentCreate(
+                    activity_id=activity.id,
+                    respondent_subject_id=lucy_applet_one_subject.id,
+                    target_subject_id=tom_applet_one_subject.id,
+                ),
+            ],
+        )
+        await assignment_service.unassign_many(
+            [
+                ActivityAssignmentDelete(
+                    activity_id=activity.id,
+                    respondent_subject_id=lucy_applet_one_subject.id,
+                    target_subject_id=tom_applet_one_subject.id,
+                )
+            ]
+        )
+
+        client.login(tom)
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=str(activity.id)
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+        assert response.json()["result"] == []
+
+    async def test_get_target_subjects_by_respondent_multiple_assignments(
+        self,
+        client,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        lucy_applet_one_subject: Subject,
+        pit_applet_one_subject: Subject,
+        applet_one_shell_account: Subject,
+        applet_one_lucy_respondent: AppletFull,
+        applet_one_pit_respondent: AppletFull,
+        session,
+    ):
+        activity = applet_one_lucy_respondent.activities[0]
+
+        # Turn off auto-assignment
+        activity_service = ActivityService(session, tom.id)
+        await activity_service.remove_applet_activities(applet_one_lucy_respondent.id)
+        await activity_service.update_create(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityUpdate(
+                    **activity.dict(exclude={"auto_assign"}),
+                    auto_assign=False,
+                )
+            ],
+        )
+
+        # Create a manual assignment
+        await ActivityAssignmentService(session).create_many(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityAssignmentCreate(
+                    activity_id=activity.id,
+                    respondent_subject_id=lucy_applet_one_subject.id,
+                    target_subject_id=tom_applet_one_subject.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=activity.id,
+                    respondent_subject_id=lucy_applet_one_subject.id,
+                    target_subject_id=applet_one_shell_account.id,
+                ),
+                ActivityAssignmentCreate(
+                    activity_id=activity.id,
+                    respondent_subject_id=tom_applet_one_subject.id,
+                    target_subject_id=pit_applet_one_subject.id,
+                ),
+            ],
+        )
+
+        client.login(tom)
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=str(activity.id)
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+        result = response.json()["result"]
+
+        assert len(result) == 2
+
+        tom_result = result[0]
+
+        assert tom_result["id"] == str(tom_applet_one_subject.id)
+        assert tom_result["submissionCount"] == 0
+        assert tom_result["currentlyAssigned"] is True
+
+        shell_account_result = result[1]
+
+        assert shell_account_result["id"] == str(applet_one_shell_account.id)
+        assert shell_account_result["submissionCount"] == 0
+        assert shell_account_result["currentlyAssigned"] is True
+
+    async def test_get_target_subjects_by_respondent_via_submission(
+        self,
+        client,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        lucy_applet_one_subject: Subject,
+        applet_one_lucy_respondent: AppletFull,
+        answer_create_payload: dict,
+        session: AsyncSession,
+    ):
+        activity = applet_one_lucy_respondent.activities[0]
+
+        # Turn off auto-assignment
+        activity_service = ActivityService(session, tom.id)
+        await activity_service.remove_applet_activities(applet_one_lucy_respondent.id)
+        await activity_service.update_create(
+            applet_one_lucy_respondent.id,
+            [
+                ActivityUpdate(
+                    **activity.dict(exclude={"auto_assign"}),
+                    auto_assign=False,
+                )
+            ],
+        )
+
+        # Create an answer
+        await AnswerService(session, tom.id).create_answer(
+            AppletAnswerCreate(
+                **answer_create_payload,
+                input_subject_id=lucy_applet_one_subject.id,
+                source_subject_id=lucy_applet_one_subject.id,
+                target_subject_id=tom_applet_one_subject.id,
+            )
+        )
+
+        client.login(tom)
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=lucy_applet_one_subject.id, activity_or_flow_id=str(activity.id)
+        )
+        response = await client.get(url)
+        assert response.status_code == http.HTTPStatus.OK
+
+        result = response.json()["result"]
+
+        assert len(result) == 1
+
+        tom_result = result[0]
+
+        assert tom_result["id"] == str(tom_applet_one_subject.id)
+        assert tom_result["submissionCount"] == 1
+        assert tom_result["currentlyAssigned"] is False

--- a/src/apps/workspaces/service/check_access.py
+++ b/src/apps/workspaces/service/check_access.py
@@ -234,6 +234,10 @@ class CheckAccessService:
             await self.check_answer_review_access(applet_id)
 
     async def check_subject_subject_access(self, applet_id: uuid.UUID, subject_id: uuid.UUID | None):
+        """
+        Check if the current authenticated user has access to the subject within this applet. The user must be an
+        owner, manager, coordinator, or a reviewer who was assigned the subject.
+        """
         access = await AppletAccessCRUD(self.session).get_priority_access(applet_id, self.user_id)
         role = getattr(access, "role", None)
         if not access:


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-7919](https://mindlogger.atlassian.net/browse/M2-7919)

This PR creates the new endpoint `/subjects/respondent/{respondent_subject_id}/activity-or-flow/{activity_or_flow_id}`, which returns a list of subjects based on an association with the respondent subject and activity/flow specified. The endpoint is accessible by users with the following applet roles:
- Owner
- Manager
- Coordinator
- Reviewer (who is assigned the `respondent_subject_id` subject)

Each subject in the list returned will be the target subject of at least one:
- Assignment where `respondent_subject_id` is the respondent subject (including auto-assigned activities/flows)
- Submission where `respondent_subject_id` is the source subject

The return type is `TargetSubjectByRespondentResponse`, and here's a sample of the data returned:

```json
{
  "result": [
    {
      "secretUserId": "participant1",
      "nickname": "participant1",
      "tag": "",
      "id": "bc61e04e-b1e0-4bef-8e86-1c4e249d8b3d",
      "lastSeen": "2024-09-25T03:10:11.153000",
      "appletId": "fe4ab554-6270-44ed-bc4a-0bbcdfa17f25",
      "userId": "0ecf89dd-5e2c-4911-988f-913acf6b4c83",
      "firstName": "Someone",
      "lastName": "Participant1",
      "submissionCount": 2,
      "currentlyAssigned": true
    }
  ],
  "count": 1
}
```

In addition to the usual `SubjectReadResponse` properties, there are two extra ones that I'd like to highlight:
- `submissionCount`: This is the number of answers that the respondent has submitted for a given subject and activity/flow
- `currentlyAssigned`: Whether the activity/flow is currently assigned for the respondent to complete about a given subject

> [!NOTE]
> Activities/flows that have been unassigned and don't have any submissions aren't included



### 🪤 Peer Testing

-  Create some assignments in the admin panel (or using the [API docs](http://localhost:8000/docs#/Activity%20assignments/assignments_create_assignments_applet__applet_id__post)) to one or more participant account
- Submit some self report activities in the respondent web app using a participant account
- Complete some take now activities using a participant account
- Complete some of the assigned activities from above using a participant account
- Consume the endpoint using the [API docs](http://localhost:8000/docs#/Subjects/get_target_subjects_by_respondent_subjects_respondent__respondent_subject_id__activity_or_flow__activity_or_flow_id__get) and validate the response matches what you expect

### ✏️ Notes

1. Tests are in-progress
2. For this PR I've assumed that the association between respondent subject and target subject via submission should be made by the `source_subject_id` on that submission. It may need to be changed to the `input_subject_id`, but I'm getting clarity on this
    - I got clarity on this and confirmed that we should be using `source_subject_id`
3. I've decided to stick with the convention and use the `id_from_history_id` function when comparing activity or flow ID with the `activity_history_id` and `flow_history_id` in the answers table. This function uses the `split_part` function in the database which seems to perform reasonably well based on the output of `EXPLAIN ANALYSE`. My initial hunch was to make `LIKE` comparisons which I know will make good use of the index on these columns, especially since the variable part of the string is at the end.
4. ~I've decided to populate the `last_seen` property on each subject, which costs an extra query. I'm not sure if it is needed, so I'm open to feedback on this and potentially removing it~