### PR TITLE
feat(applet-duplication): add optional report server config flag (M2-7830)

### DIFF
--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -188,7 +188,9 @@ async def applet_duplicate(
         await CheckAccessService(session, user.id).check_applet_duplicate_access(applet_id)
         applet_for_duplicate = await service.get_by_id_for_duplicate(applet_id)
 
-        applet = await service.duplicate(applet_for_duplicate, schema.display_name, schema.encryption)
+        applet = await service.duplicate(
+            applet_for_duplicate, schema.display_name, schema.encryption, schema.include_report_server
+        )
     return Response(result=public_detail.Applet.from_orm(applet))
 
 

--- a/src/apps/applets/domain/applet_create_update.py
+++ b/src/apps/applets/domain/applet_create_update.py
@@ -108,3 +108,4 @@ class AppletReportConfiguration(AppletReportConfigurationBase, InternalModel):
 class AppletDuplicateRequest(InternalModel):
     display_name: str
     encryption: Encryption
+    include_report_server: bool = False

--- a/src/apps/applets/router.py
+++ b/src/apps/applets/router.py
@@ -102,7 +102,7 @@ router.get(
 
 router.post(
     "/{applet_id}/duplicate",
-    description="""This endpoint using for duplicate existing applet""",
+    description="""Duplicate an existing applet, and optionally its report server configuration""",
     response_model_by_alias=True,
     response_model=Response[public_detail.Applet],
     status_code=status.HTTP_201_CREATED,

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -25,7 +25,7 @@ from apps.applets.domain.applet_create_update import AppletCreate, AppletReportC
 from apps.applets.domain.applet_duplicate import AppletDuplicate
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.domain.applet_link import AppletLink, CreateAccessLink
-from apps.applets.domain.base import Encryption
+from apps.applets.domain.base import AppletReportConfigurationBase, Encryption
 from apps.applets.errors import (
     AccessLinkDoesNotExistError,
     AppletAlreadyExist,
@@ -219,6 +219,7 @@ class AppletService:
         applet_exist: AppletDuplicate,
         new_name: str,
         encryption: Encryption,
+        include_report_server: bool,
     ):
         activity_key_id_map = dict()
 
@@ -232,7 +233,7 @@ class AppletService:
         )
         manager_role = Role.EDITOR if has_editor else Role.MANAGER
 
-        create_data = self._prepare_duplicate(applet_exist, new_name, encryption)
+        create_data = self._prepare_duplicate(applet_exist, new_name, encryption, include_report_server)
 
         applet = await self._create(create_data, self.user_id)
 
@@ -252,7 +253,9 @@ class AppletService:
         return applet
 
     @staticmethod
-    def _prepare_duplicate(applet_exist: AppletDuplicate, new_name: str, encryption: Encryption) -> AppletCreate:
+    def _prepare_duplicate(
+        applet_exist: AppletDuplicate, new_name: str, encryption: Encryption, include_report_server: bool
+    ) -> AppletCreate:
         activities = list()
         for activity in applet_exist.activities:
             activities.append(
@@ -289,7 +292,20 @@ class AppletService:
                 )
             )
 
+        report_server_config = (
+            AppletReportConfigurationBase(
+                report_server_ip=applet_exist.report_server_ip,
+                report_public_key=applet_exist.report_public_key,
+                report_include_user_id=applet_exist.report_include_user_id,
+                report_include_case_id=applet_exist.report_include_case_id,
+                report_email_body=applet_exist.report_email_body,
+            ).dict()
+            if include_report_server
+            else {}
+        )
+
         return AppletCreate(
+            **report_server_config,
             display_name=new_name,
             description=applet_exist.description,
             about=applet_exist.about,


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-7830](https://mindlogger.atlassian.net/browse/M2-7830)

This PR updates the applet duplication endpoint to optionally include a `include_report_server` property that defaults to false (making it backwards compatible).

The following properties are duplicated:
- `reportServerIp`
- `reportPublicKey`
- `reportIncludeUserId`
- `reportIncludeCaseId`
- `reportEmailBody`

### 🪤 Peer Testing

Update the `email`, `password`, and `api_base_url` variables and then run the following shell script

```shell
email=""
password=""
api_base_url="https://localhost:8000"

login_response=$(curl "${api_base_url}/auth/login" \
  -H 'Content-Language: en-US' \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw "{\"email\":\"${email}\",\"password\":\"${password}\"}"
)

access_token=$(echo "${login_response}" | jq -r '.result.token.accessToken')
workspace_id=$(echo "${login_response}" | jq -r '.result.user.id')

# Create the applet (password is P@$$w0rd)
create_applet_response=$(curl "${api_base_url}/workspaces/${workspace_id}/applets" \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H "Authorization: bearer ${access_token}" \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw '{"displayName":"Sample Applet with Report Server Config from cURL","description":{"en":""},"themeId":null,"about":{"en":""},"image":"","watermark":"","activities":[{"name":"Sample Activity","description":{"en":""},"showAllAtOnce":false,"isSkippable":false,"responseIsEditable":true,"isHidden":false,"autoAssign":true,"isReviewable":false,"items":[{"responseType":"text","name":"Sample_Item","question":{"en":"Sample item"},"config":{"removeBackButton":false,"skippableItem":false,"maxResponseLength":72,"correctAnswerRequired":false,"correctAnswer":"","numericalResponseRequired":false,"responseDataIdentifier":false,"responseRequired":false},"isHidden":false,"allowEdit":true,"responseValues":null}],"scoresAndReports":{"generateReport":false,"reports":[],"showScoreSummary":false},"key":"7b4706a1-3f80-45a5-a30b-9dd620a6405a","reportIncludedItemName":""}],"activityFlows":[],"reportEmailBody":"Please see the report attached to this email.","streamIpAddress":null,"streamPort":null,"encryption":{"publicKey":"[101,2,39,114,14,253,138,242,226,233,170,106,82,171,74,102,159,42,40,140,82,37,46,229,206,53,94,179,139,2,231,48,185,199,75,198,236,129,202,149,121,22,155,190,183,227,126,249,209,125,200,216,208,39,190,28,163,189,100,249,192,231,21,245,161,205,142,223,234,231,226,159,232,7,105,241,106,163,176,243,114,221,224,238,151,247,88,181,12,157,217,134,154,31,250,32,243,79,158,104,112,73,2,112,5,29,74,44,93,164,45,92,165,200,216,244,102,54,95,19,124,108,219,164,33,193,68,16]","prime":"[230,27,59,105,243,69,171,168,131,232,236,243,79,126,36,61,196,211,165,189,11,97,219,28,184,125,124,87,187,235,98,133,25,243,79,9,45,21,88,231,50,238,150,58,26,52,98,177,199,72,155,255,177,165,204,130,184,191,171,70,63,249,144,234,97,91,88,155,116,120,46,149,102,181,161,146,72,138,88,17,224,53,56,188,167,108,50,220,16,195,67,248,221,43,208,223,236,97,85,200,145,125,71,18,161,242,196,210,243,167,159,216,11,36,0,115,232,210,227,230,216,2,210,29,123,77,122,11]","base":"[2]","accountId":"9e7d3792-024b-42e6-b72c-ddd6d67ce8fb"}}'
)

applet_id=$(echo "${create_applet_response}" | jq -r '.result.id')

# Configure the report server
curl "${api_base_url}/applets/${applet_id}/report_configuration" \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H "Authorization: bearer ${access_token}" \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw '{"reportServerIp":"http://localhost:3031","reportPublicKey":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvhTKM1u3tzZ54Vq3mpHg\nYeEMrG+r5myp8UrVzitSF9h2x/mUcpcXrdHMzYkSurolq+D75nwlh7SeDMGUsdUX\nzD+/sWMByXG/3aq3B9FT82Ck1bMJ8O8NG+F7RxwJQbNe+eDTw1mNOW7JgzHK6nlL\nTBA709tC7LTQkeQuGT1xJN2rBIWdMDoAGx0sW4e2Id2D8BhWR4C5YupE9e5joshr\nRWCRfNANL9XIT/qTPPXzNXDT8VdcVTDnDTl/Wcg55nIsjSfQTkMVNsQ/L2Di++4z\n1kNGInzkwehNbJ2P8xDMeeIHcUa0r+DKj2pfV/fBx/6ZLoIIRUxYPqz4eWYTmV2Y\ndRtZOhRdf2oLZDivKplqJHZTeccyz5/6oVygF9uPYf/C607wzDiQmb0EkVXLFd+z\n80b9NPJ7gXzOOY+twC+r1K6ULK3SFFiaXYAO/P2X6/mQDa0ErLjRvouxtANnMqp1\n9JH314lmX1Pc85No8vsODaF/PaGYevsx7ncljMQdtUK8l/KrqDj8RmfE3vPgSOpl\nsuPe1Yl1qWq6STAKY5YuSDaK+XKh5ilqrBEufl4bfKKh3J/KYWfaHmirBpz9ivEq\nRU9UbGWxqJeIjNMNAYfDRHgrcNjhpqSpLwfkF02fCi+14yWtxWwf0S3CmZkir31D\nyV/dUs7tYGCcxbQFtnHieekCAwEAAQ==\n-----END PUBLIC KEY-----","reportRecipients":["someone@example.com"],"reportIncludeUserId":true,"reportEmailBody":"Please see the report attached to this email."}'


# Duplicate the applet without report server config
curl "${api_base_url}/applets/${applet_id}/duplicate" \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H "Authorization: bearer ${access_token}" \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw '{"displayName":"Duplicated Sample Applet from cURL", "encryption":{"publicKey":"[217,80,109,55,244,89,80,46,119,179,7,232,136,153,55,148,56,49,60,97,252,198,204,179,49,77,219,144,99,146,43,144,167,80,145,177,148,208,151,144,0,186,152,188,218,217,30,122,12,234,75,44,155,159,8,13,0,155,121,236,195,232,152,145,252,152,5,253,98,169,196,167,233,98,30,170,31,16,252,233,243,216,13,111,73,179,38,71,131,188,36,193,89,153,50,217,162,177,163,106,230,73,4,226,138,79,245,139,11,69,108,129,120,5,71,98,150,134,78,190,208,144,142,110,169,153,157,167]","prime":"[246,25,62,57,3,211,201,60,45,201,150,1,190,238,76,102,74,251,46,148,77,29,170,58,244,105,8,98,210,151,133,169,246,23,82,120,229,35,147,74,213,4,72,145,136,233,32,137,37,224,243,5,139,4,160,166,149,244,212,219,224,247,214,181,167,166,108,86,34,111,18,209,99,87,0,176,210,79,16,216,191,44,55,132,214,25,245,124,98,228,240,133,112,89,169,47,151,247,250,57,221,161,14,109,147,162,179,95,51,145,147,18,195,48,190,74,88,26,132,25,66,236,103,148,101,136,234,195]","base":"[2]","accountId":"9e7d3792-024b-42e6-b72c-ddd6d67ce8fb"}}'

# Duplicate the applet with report server config
curl "${api_base_url}/applets/${applet_id}/duplicate" \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H "Authorization: bearer ${access_token}" \
  -H 'Content-Type: application/json' \
  -H 'Mindlogger-Content-Source: admin' \
  -s --data-raw '{"includeReportServer": true, "displayName":"Duplicated Sample Applet with Report Server Config from cURL", "encryption":{"publicKey":"[217,80,109,55,244,89,80,46,119,179,7,232,136,153,55,148,56,49,60,97,252,198,204,179,49,77,219,144,99,146,43,144,167,80,145,177,148,208,151,144,0,186,152,188,218,217,30,122,12,234,75,44,155,159,8,13,0,155,121,236,195,232,152,145,252,152,5,253,98,169,196,167,233,98,30,170,31,16,252,233,243,216,13,111,73,179,38,71,131,188,36,193,89,153,50,217,162,177,163,106,230,73,4,226,138,79,245,139,11,69,108,129,120,5,71,98,150,134,78,190,208,144,142,110,169,153,157,167]","prime":"[246,25,62,57,3,211,201,60,45,201,150,1,190,238,76,102,74,251,46,148,77,29,170,58,244,105,8,98,210,151,133,169,246,23,82,120,229,35,147,74,213,4,72,145,136,233,32,137,37,224,243,5,139,4,160,166,149,244,212,219,224,247,214,181,167,166,108,86,34,111,18,209,99,87,0,176,210,79,16,216,191,44,55,132,214,25,245,124,98,228,240,133,112,89,169,47,151,247,250,57,221,161,14,109,147,162,179,95,51,145,147,18,195,48,190,74,88,26,132,25,66,236,103,148,101,136,234,195]","base":"[2]","accountId":"9e7d3792-024b-42e6-b72c-ddd6d67ce8fb"}}'
```

Inspect the database and confirm the following:
- The _Sample Applet with Report Server Config from cURL_ applet has a report server config
- The _Duplicated Sample Applet from cURL_ does not have a report server config
- The _Duplicated Sample Applet with Report Server Config from cURL_ applet has the same report server config as the _Sample Applet with Report Server Config from cURL_ applet, except for the `reportRecipients` field

### ✏️ Notes

N/A
