### PR TITLE
fix: Fixed ScoringType class using new python Enum syntax

### DIFF
--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -29,7 +29,7 @@ class CalculationType(enum.StrEnum):
     PERCENTAGE = "percentage"
 
 
-class ScoringType(str, enum.StrEnum):
+class ScoringType(enum.StrEnum):
     SCORE = "score"
     RAW_SCORE = "raw_score"
 

--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -29,7 +29,7 @@ class CalculationType(enum.StrEnum):
     PERCENTAGE = "percentage"
 
 
-class ScoringType(str, Enum):
+class ScoringType(str, enum.StrEnum):
     SCORE = "score"
     RAW_SCORE = "raw_score"
 

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -552,7 +552,7 @@ class TestActivityItems:
         assert resp.status_code == http.HTTPStatus.CREATED
         result = resp.json()["result"]
         assert result["activities"][0]["subscaleSetting"] == sub_setting.dict(by_alias=True)
-        assert result["activities"][0]["scoresAndReports"]["reports"][0]["scoringType"] == ScoringType.SCORE.value
+        assert result["activities"][0]["scoresAndReports"]["reports"][0]["scoringType"] == ScoringType.SCORE
         assert result["activities"][0]["scoresAndReports"]["reports"][0]["subscaleName"] == "subscale type score"
 
     async def test_create_applet__activity_with_subscale_settings_with_invalid_subscale_lookup_table_age(


### PR DESCRIPTION
- [ ] Using new enum python 11 syntax
### 📝 Description

Quick fix for ScoringType definition using enum.StrEnum instead of str, ENUM.