### PR TITLE
feature: paragraph ItemResponseType for phrase builder response options BE (M2-7762)

### DIFF
--- a/src/apps/activities/domain/custom_validation.py
+++ b/src/apps/activities/domain/custom_validation.py
@@ -266,6 +266,7 @@ def validate_phrasal_templates(values: dict):
                             ResponseType.DATE,
                             ResponseType.SLIDERROWS,
                             ResponseType.SINGLESELECTROWS,
+                            ResponseType.PARAGRAPHTEXT,
                             ResponseType.MULTISELECTROWS,
                         ]:
                             raise IncorrectPhrasalTemplateItemTypeError()

--- a/src/apps/activities/tests/fixtures/items.py
+++ b/src/apps/activities/tests/fixtures/items.py
@@ -298,3 +298,21 @@ def phrasal_template_with_slider_rows_create(
     )
 
     return [slider_rows_item_create, phrasal_item]
+
+
+@pytest.fixture
+def phrasal_template_with_paragraph_create(
+    phrasal_template_config: PhrasalTemplateConfig,
+    phrasal_template_with_paragraph_response_values: PhrasalTemplateValues,
+    base_item_data: BaseItemData,
+    paragraph_text_item_create,
+):
+    phrasal_item = ActivityItemCreate(
+        **base_item_data.dict(exclude={"name"}),
+        name="phrasal_template_paragraph_test",
+        response_type=ResponseType.PHRASAL_TEMPLATE,
+        config=phrasal_template_config,
+        response_values=phrasal_template_with_paragraph_response_values,
+    )
+
+    return [paragraph_text_item_create, phrasal_item]

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -12,6 +12,7 @@ from apps.activities.domain.response_values import (
     MultiSelectionRowsValues,
     MultiSelectionValues,
     NumberSelectionValues,
+    ParagraphTextValues,
     PhrasalTemplateDisplayMode,
     PhrasalTemplateField,
     PhrasalTemplatePhrase,
@@ -50,6 +51,13 @@ def single_select_response_values() -> SingleSelectionValues:
             )
         ],
         type=ResponseType.SINGLESELECT,
+    )
+
+
+@pytest.fixture
+def paragraph_response_values() -> ParagraphTextValues:
+    return ParagraphTextValues(
+        type=ResponseType.PARAGRAPHTEXT,
     )
 
 
@@ -202,6 +210,18 @@ def phrasal_template_with_slider_rows_response_fields(slider_rows_item_create) -
     ]
 
 
+@pytest.fixture()
+def phrasal_template_wiht_paragraph_response_fields(paragraph_text_item_create) -> List[PhrasalTemplateField]:
+    return [
+        _PhrasalTemplateSentenceField(text="test sentence"),
+        _PhrasalTemplateItemResponseField(
+            item_name=paragraph_text_item_create.name, display_mode=PhrasalTemplateDisplayMode.SENTENCE, item_index=0
+        ),
+        _PhrasalTemplateLineBreakField(),
+        _PhrasalTemplateSentenceField(text="test sentence 2"),
+    ]
+
+
 @pytest.fixture
 def phrasal_template_with_slider_rows_response_values(
     phrasal_template_with_slider_rows_response_fields,
@@ -209,5 +229,16 @@ def phrasal_template_with_slider_rows_response_values(
     return PhrasalTemplateValues(
         phrases=[PhrasalTemplatePhrase(image=None, fields=phrasal_template_with_slider_rows_response_fields)],
         card_title="test card title",
+        type=ResponseType.PHRASAL_TEMPLATE,
+    )
+
+
+@pytest.fixture
+def phrasal_template_with_paragraph_response_values(
+    phrasal_template_wiht_paragraph_response_fields,
+) -> PhrasalTemplateValues:
+    return PhrasalTemplateValues(
+        phrases=[PhrasalTemplatePhrase(image=None, fields=phrasal_template_wiht_paragraph_response_fields)],
+        card_title="test paragraph card title",
         type=ResponseType.PHRASAL_TEMPLATE,
     )

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -129,7 +129,12 @@ class TestActivityItems:
             assert item["responseValues"] == item_create.response_values.dict(by_alias=True)
 
     @pytest.mark.parametrize(
-        "item_fixture", ("phrasal_template_with_text_create", "phrasal_template_with_slider_rows_create")
+        "item_fixture",
+        (
+            "phrasal_template_with_text_create",
+            "phrasal_template_with_slider_rows_create",
+            "phrasal_template_with_paragraph_create",
+        ),
     )
     async def test_create_applet_with_phrasal_template(
         self,
@@ -245,6 +250,25 @@ class TestActivityItems:
         assert result[0]["message"] == activity_errors.IncorrectConditionItemIndexError.message
 
     async def test_create_applet__activity_with_conditional_logic(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        activity_create_with_conditional_logic: ActivityCreate,
+    ):
+        client.login(tom)
+        data = applet_minimal_data.copy(deep=True)
+        data.activities = [activity_create_with_conditional_logic]
+        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+        result = response.json()["result"]
+        item_create_with_logic = activity_create_with_conditional_logic.items[1]
+        assert item_create_with_logic.conditional_logic is not None
+        assert result["activities"][0]["items"][1]["conditionalLogic"] == item_create_with_logic.conditional_logic.dict(
+            by_alias=True
+        )
+
+    async def test_create_applet__activity_with_paragraph_and_phrase_builder(
         self,
         client: TestClient,
         tom: User,

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -268,25 +268,6 @@ class TestActivityItems:
             by_alias=True
         )
 
-    async def test_create_applet__activity_with_paragraph_and_phrase_builder(
-        self,
-        client: TestClient,
-        tom: User,
-        applet_minimal_data: AppletCreate,
-        activity_create_with_conditional_logic: ActivityCreate,
-    ):
-        client.login(tom)
-        data = applet_minimal_data.copy(deep=True)
-        data.activities = [activity_create_with_conditional_logic]
-        response = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data)
-        assert response.status_code == http.HTTPStatus.CREATED
-        result = response.json()["result"]
-        item_create_with_logic = activity_create_with_conditional_logic.items[1]
-        assert item_create_with_logic.conditional_logic is not None
-        assert result["activities"][0]["items"][1]["conditionalLogic"] == item_create_with_logic.conditional_logic.dict(
-            by_alias=True
-        )
-
     @pytest.mark.parametrize(
         "item_fixture_name",
         (


### PR DESCRIPTION
- [ ] Create a new activity with one pragraph item and one phrase builder item
- [ ] Paragraph item should be a valid option to select from the PhraseBuilder select options. 

### 📝 Description
As an Admin, I want to choose the paragraph item type as a response phrase field so that I can include its contents in my Action Plan. By adding paragraph option to the allowed types on validate_phrasal_templates, the backend can store Activities with PhrasalBuilder Items that contain Parragraph items as elements of the PhraseBuilder item. 
 
🔗 [Jira Ticket M2-7762](https://mindlogger.atlassian.net/browse/M2-7762)

Changes include:
- [Allow new item_type (paragraph) to phrase-builder response options]


### 📸 Screenshots

ADMIN PANEL - CONFIGURATION
Creating Activity with paragraph type on Phrase Builder
![image](https://github.com/user-attachments/assets/e159f3cd-29aa-4fbf-ba1f-8c948e6c5dbe)

WEB APPLICATION: 
![image](https://github.com/user-attachments/assets/1f02faf2-7fe7-4483-a3cf-e678a0388161)

ADMIN PANEL -  RESULTS
![image](https://github.com/user-attachments/assets/8b08e601-d337-40b3-9d99-461d51697aff)


### 🪤 Peer Testing
* Create an activity
* Create and item  of type parragraph inside your activity
* In the same activity create a new item of type phrase builder
* Phrase builder should allow you to choose the newly created paragraph item inside the “Select Item (Response)” dropdown menu.
* Complete an activity from the web application and validate that the parragraph can be selected on the Phrase Builder section. 


### Notes:
I verified that the information is being passed from the backend to the web app. I did this by debugging the apliucation. First I tried with a single-entry and phrase-builder items and I the information is accurately passed as an activity, we can look at result.items[1].response_values.phrases[0] that contains the phrase builer text and the single-selection element.
![image](https://github.com/user-attachments/assets/9e2a1e66-e585-41b1-81bd-f5139b67526c)

I compared that result with the paragraph-text and phrase-builder items and the result is the same but with different attributes for  result.items[1].response_values.phrases[1]
 
![image](https://github.com/user-attachments/assets/36a11e50-241d-48ac-8c0c-324e17c005b8)
This is being tested on the new unittest created for this featute.