### PR TITLE
fix: Allow number select item type to be printed (M2-8147)

### DIFF
--- a/src/apps/activities/domain/custom_validation.py
+++ b/src/apps/activities/domain/custom_validation.py
@@ -127,17 +127,20 @@ def validate_score_and_sections(values: dict):  # noqa: C901
                     if not items[score_item_index].config.add_scores:
                         raise IncorrectScoreItemConfigError()
 
+            print_item_types = [
+                ResponseType.SINGLESELECT,
+                ResponseType.MULTISELECT,
+                ResponseType.SLIDER,
+                ResponseType.TEXT,
+                ResponseType.PARAGRAPHTEXT,
+                ResponseType.NUMBERSELECT,
+            ]
+
             for item in report.items_print:
                 if item not in item_names:
                     raise IncorrectScorePrintItemError()
                 else:
-                    if items[item_names.index(item)].response_type not in [
-                        ResponseType.SINGLESELECT,
-                        ResponseType.MULTISELECT,
-                        ResponseType.SLIDER,
-                        ResponseType.TEXT,
-                        ResponseType.PARAGRAPHTEXT,
-                    ]:
+                    if items[item_names.index(item)].response_type not in print_item_types:
                         raise IncorrectScorePrintItemTypeError()
 
             if report.conditional_logic:
@@ -147,13 +150,7 @@ def validate_score_and_sections(values: dict):  # noqa: C901
                         if item not in item_names:
                             raise IncorrectScorePrintItemError()
                         else:
-                            if items[item_names.index(item)].response_type not in [
-                                ResponseType.SINGLESELECT,
-                                ResponseType.MULTISELECT,
-                                ResponseType.SLIDER,
-                                ResponseType.TEXT,
-                                ResponseType.PARAGRAPHTEXT,
-                            ]:
+                            if items[item_names.index(item)].response_type not in print_item_types:
                                 raise IncorrectScorePrintItemTypeError()
 
         for report in list(sections):


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8147](https://mindlogger.atlassian.net/browse/M2-8147)

This PR updates the applet validation logic to allow items of type `NUMBERSELECT` to be included in the report or section printed items.

### 🪤 Peer Testing

- Follow the steps in https://github.com/ChildMindInstitute/mindlogger-admin/pull/1966 and save the applet again at the end
- Confirm that the applet is saved successfully, and check the `activities.scores_and_reports` column in the database to confirm the presence of the `age_screen` item

<img width="330" alt="image" src="https://github.com/user-attachments/assets/26ec6cf3-5939-463c-8936-0c5b28ca8505">

### ✏️ Notes

N/A