### PR TITLE
fix: Add respondent subject metadata to applet base info (M2-8164, M2-8026)

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -90,7 +90,7 @@ async def applet_activities(
             activities_future,
         )
         applet_detail = AppletSingleLanguageDetailMobilePublic.from_orm(applet)
-        respondent_meta = {"nickname": subject.nickname if subject else None, "tag": subject.tag if subject else None}
+        respondent_meta = SubjectsService.to_respondent_meta(subject)
 
         if filters.has_submitted or filters.has_score:
             activities = await __filter_activities(

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -403,7 +403,8 @@ class TestActivities:
         assert result["appletDetail"]["activityFlows"] == []
 
         assert result["respondentMeta"] == {
-            "nickname": f"{tom.first_name} {tom.last_name}",
+            "subjectId": str(tom_applet_one_subject.id),
+            "nickname": tom_applet_one_subject.nickname,
             "tag": tom_applet_one_subject.tag,
         }
 

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -103,7 +103,7 @@ async def applet_retrieve(
         applet.owner_id = applet_owner.owner_id
     return AppletRetrieveResponse(
         result=AppletSingleLanguageDetailPublic.from_orm(applet),
-        respondent_meta={"nickname": subject.nickname if subject else None, "tag": subject.tag if subject else None},
+        respondent_meta=SubjectsService.to_respondent_meta(subject),
         applet_meta=AppletMeta(has_assessment=has_assessment),
     )
 

--- a/src/apps/applets/domain/applet.py
+++ b/src/apps/applets/domain/applet.py
@@ -179,3 +179,4 @@ class AppletActivitiesBaseInfo(AppletMinimumInfo, PublicModel):
     updated_at: datetime.datetime | None
     activities: list[ActivityBaseInfo]
     activity_flows: list[FlowBaseInfo]
+    respondent_meta: dict | None = None

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -766,9 +766,11 @@ class AppletService:
         )
         activities = ActivityService(self.session, self.user_id).get_info_by_applet_id(schema.id, language)
         activity_flows = FlowService(self.session).get_info_by_applet_id(schema.id, language)
-        futures = await asyncio.gather(activities, activity_flows)
+        subject = SubjectsService(self.session, self.user_id).get_by_user_and_applet(self.user_id, schema.id)
+        futures = await asyncio.gather(activities, activity_flows, subject)
         applet.activities = futures[0]
         applet.activity_flows = futures[1]
+        applet.respondent_meta = SubjectsService.to_respondent_meta(futures[2])
         return applet
 
     async def has_assessment(self, applet_id: uuid.UUID) -> bool:

--- a/src/apps/subjects/services/subjects.py
+++ b/src/apps/subjects/services/subjects.py
@@ -35,6 +35,14 @@ class SubjectsService:
             tag=schema.tag,
         )
 
+    @staticmethod
+    def to_respondent_meta(subject: Subject | None):
+        return {
+            "subjectId": subject.id if subject else None,
+            "nickname": subject.nickname if subject else None,
+            "tag": subject.tag if subject else None,
+        }
+
     async def create(self, schema: SubjectCreate) -> Subject:
         subject_with_secret = await self.get_by_secret_id(schema.applet_id, schema.secret_user_id)
         if subject_with_secret and not subject_with_secret.is_deleted:


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8164](https://mindlogger.atlassian.net/browse/M2-8164)
🔗 [Jira Ticket M2-8026](https://mindlogger.atlassian.net/browse/M2-8026)

This change adds `respondentMeta` to the response for `GET /applets/{applet_id}/base-info` to provide the Web App with the current respondent's subject ID, which is required to determine if a previous submission is a self-report in order to fix the bug reported by M2-8164.

To note: `respondentMeta` is already provided in two other existing endpoints, but not by ones consumed by the Web App. To ensure uniformity of this data structure across all three endpoints, created a function `SubjectsService.to_respondent_meta` and reused it in all 3 places.

<details>
<summary>Example response</summary>

```json
{
    "result": {
        "displayName": "Applet 3",
        "version": "1.2.1",
        "description": "",
        "about": "",
        "image": "",
        "watermark": "",
        "id": "57c19b5c-bff9-4687-8961-6d8c66288a2c",
        "createdAt": "2024-10-23T17:50:18.212814",
        "updatedAt": "2024-10-31T21:10:41.214624",
        "activities": [
            {
                "id": "f53141c3-7a70-4c4f-b5f9-adbe17154959",
                "name": "Activity With Paragraph Phrase",
                "description": "",
                "image": "",
                "isHidden": false,
                "order": 1,
                "containsResponseTypes": [
                    "paragraphText",
                    "singleSelect",
                    "phrasalTemplate"
                ],
                "itemCount": 3,
                "autoAssign": true
            }
        ],
        "activityFlows": [],
        "respondentMeta": {
            "subjectId": "fc222d53-eaa0-4e5a-bf1b-8d3b1fb53e57",
            "nickname": "Paul HH",
            "tag": "Team"
        }
    }
}
```
</details>

### 🪤 Peer Testing

1. Log into the Web App
2. While having DevTools open to the Network tab, navigate to an applet
3. Inspect the response of the `/applets/{applet_id}/base_info` request:
    **Expected outcome:** The response should include a `respondentMeta` object containing `subjectId`, `nickname`, and `tag`.