### PR TITLE
fix: Add PDP support for limited account respondents (M2-8092)

### DIFF
--- a/src/apps/activities/crud/activity.py
+++ b/src/apps/activities/crud/activity.py
@@ -108,7 +108,7 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
         return result.scalars().all()
 
     async def get_activity_and_flow_basic_info_by_ids_or_auto(
-        self, applet_id: uuid.UUID, ids: list[uuid.UUID], language: str
+        self, applet_id: uuid.UUID, ids: list[uuid.UUID], include_auto: bool, language: str
     ) -> list[ActivityOrFlowBasicInfoInternal]:
         activities_query: Query = select(
             ActivitySchema.id,
@@ -126,7 +126,7 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
             ActivitySchema.applet_id == applet_id,
             or_(
                 ActivitySchema.id.in_(ids),
-                ActivitySchema.auto_assign.is_(True),
+                include_auto and ActivitySchema.auto_assign.is_(True),
             ),
         )
 
@@ -159,7 +159,7 @@ class ActivitiesCRUD(BaseCRUD[ActivitySchema]):
                 flow_alias.applet_id == applet_id,
                 or_(
                     flow_alias.id.in_(ids),
-                    flow_alias.auto_assign.is_(True),
+                    include_auto and flow_alias.auto_assign.is_(True),
                 ),
             )
             .group_by(flow_alias.id, flow_alias.name, flow_alias.description, flow_alias.auto_assign)

--- a/src/apps/activities/domain/activity.py
+++ b/src/apps/activities/domain/activity.py
@@ -49,13 +49,13 @@ class ActivityOrFlowBasicInfoInternal(InternalModel):
     performance_task_type: PerformanceTaskType | None = None
     is_performance_task: bool | None = None
 
-    def set_status(self, assignments: list[ActivityAssignmentWithSubject]):
+    def set_status(self, assignments: list[ActivityAssignmentWithSubject], include_auto: bool):
         """
         Determine and set the value of the status field
         """
         if self.is_hidden:
             self.status = ActivityOrFlowStatusEnum.HIDDEN
-        elif assignments or self.auto_assign:
+        elif assignments or (include_auto and self.auto_assign):
             self.status = ActivityOrFlowStatusEnum.ACTIVE
         else:
             self.status = ActivityOrFlowStatusEnum.INACTIVE

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -456,8 +456,8 @@ class ActivityService:
         return activities
 
     async def get_activity_and_flow_basic_info_by_ids_or_auto(
-        self, applet_id: uuid.UUID, ids: list[uuid.UUID], language: str
+        self, applet_id: uuid.UUID, ids: list[uuid.UUID], include_auto: bool, language: str
     ) -> list[ActivityOrFlowBasicInfoInternal]:
         return await ActivitiesCRUD(self.session).get_activity_and_flow_basic_info_by_ids_or_auto(
-            applet_id, ids, language
+            applet_id, ids, include_auto, language
         )

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -1222,11 +1222,10 @@ class TestActivities:
             )
         )
 
-        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert response.status_code == http.HTTPStatus.OK
         result = response.json()["result"]
 
-        assert result[0]["type"] == "BAD_REQUEST"
-        assert result[0]["message"] == f"Subject {applet_one_shell_account.id} is not a valid respondent"
+        assert result == []
 
     @pytest.mark.parametrize("subject_type", ["target", "respondent"])
     async def test_assigned_activities_auto_assigned(

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -817,7 +817,7 @@ class TestSubjects(BaseTest):
             respondent_subject_id=applet_one_shell_account.id, activity_or_flow_id=activity_or_flow_id
         )
         response = await client.get(url)
-        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert response.status_code == http.HTTPStatus.OK
 
     async def test_get_target_subjects_by_respondent_editor_user(
         self, client, applet_one_pit_editor: AppletFull, pit: User, tom_applet_one_subject: Subject


### PR DESCRIPTION

- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8092](https://mindlogger.atlassian.net/browse/M2-8092)

Fixes responses to the below endpoints consumed by PDP By Participant tab to account for limited accounts possibly having submissions in the database done on their behalf via Take Now:
- `GET /activities/applet/{applet_id}/respondent/{subject_id}`
- `GET /subjects/respondent/{subject_id}/activity-or-flow/{activity_or_flow_id}`

### 🪤 Peer Testing

1. Connect your Admin App connected to this branch of the BE
2. Create an applet with an activity and/or flow, and add a limited account from the Participants tab.
3. For any activity or flow, perform Take Now, providing the limited account for the **Who will be providing the responses?** dropdown, and any participants for the **Who will be inputting the responses?** and **Who are the responses about?** dropdowns.
4. Complete the assessment in the Web App so that there is at least one submission by the limited account as the respondent.
5. In the Admin App, use DevTools to figure out the applet ID, subject ID of the limited account, and the activity/flow ID of the activity/flow for which you performed take now.
6. Open your local [Swagger UI](http://127.0.0.1:8000/docs) and authenticate your session as an admin account.
7. In the Admin, call these endpoints providing the above IDs:
    - `GET /activities/applet/{applet_id}/respondent/{subject_id}`
    - `GET /subjects/respondent/{subject_id}/activity-or-flow/{activity_or_flow_id}`
    **Expected outcome:** Each endpoint succeeds with a valid response, and each resulting array contains at least one entry.
