### PR TITLE
fix: Adds activity_id filter to answers dates query to fix problem with dataviz calendar (M2-8215)

### DIFF
--- a/src/apps/answers/crud/answer_items.py
+++ b/src/apps/answers/crud/answer_items.py
@@ -155,6 +155,7 @@ class AnswerItemsCRUD(BaseCRUD[AnswerItemSchema]):
         )
         query = query.where(AnswerSchema.applet_id == applet_id)
         query = query.where(AnswerSchema.activity_history_id.in_(activity_ver_ids))
+        query = query.where(AnswerSchema.flow_history_id.is_(None))
         query = query.order_by(AnswerSchema.created_at.asc())
         query = query.where(*_ActivityAnswerFilter().get_clauses(**filters))
         db_result = await self._execute(query)

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -234,7 +234,12 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) >= filters.from_date)
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
-        query = query.where(AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_id))
+        query = query.where(
+            or_(
+                AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_or_flow_id),
+                AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
+            ),
+        )
 
         if filters.respondent_id:
             query = query.where(AnswerSchema.respondent_id == filters.respondent_id)

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -234,7 +234,7 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) >= filters.from_date)
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
-        query = query.where(AnswerSchema.activity_history_id.contains(filters.activity_id))
+        query = query.where(AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_id))
 
         if filters.respondent_id:
             query = query.where(AnswerSchema.respondent_id == filters.respondent_id)

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -235,13 +235,14 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
         query = query.where(
-                case(
-                    (
-                        AnswerSchema.flow_history_id.isnot(None),
-                        AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
-                    ),
-                    else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_or_flow_id),
-                )
+            case(
+                (
+                    AnswerSchema.flow_history_id.isnot(None),
+                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
+                ),
+                else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id)
+                == str(filters.activity_or_flow_id),
+            )
         )
 
         if filters.respondent_id:

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -234,6 +234,8 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) >= filters.from_date)
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
+        query = query.where(AnswerSchema.activity_history_id.contains(filters.activity_id))
+
         if filters.respondent_id:
             query = query.where(AnswerSchema.respondent_id == filters.respondent_id)
         if filters.target_subject_id:

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -449,7 +449,7 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
 
         for _, version, created_at, flow_history_id, _ in db_result.all():
             # Filters out the activities associated with flows to display only isolated activities
-            if flow_history_id.endswith(version):
+            if flow_history_id and flow_history_id.endswith(version):
                 results.append(Version(version=version, created_at=created_at))
 
         return results

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -235,10 +235,13 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
         query = query.where(
-            or_(
-                AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_or_flow_id),
-                AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
-            ),
+                case(
+                    (
+                        AnswerSchema.flow_history_id.isnot(None),
+                        AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
+                    ),
+                    else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == str(filters.activity_or_flow_id),
+                )
         )
 
         if filters.respondent_id:

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -431,26 +431,17 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
             ActivityHistorySchema.id,
             AppletHistorySchema.version,
             AppletHistorySchema.created_at,
-            AnswerSchema.activity_history_id,
-            AnswerSchema.flow_history_id,
         )
         query = query.join(
             AppletHistorySchema,
             AppletHistorySchema.id_version == ActivityHistorySchema.applet_id,
         )
-        query = query.outerjoin(AnswerSchema, AnswerSchema.activity_history_id.ilike(f"{str(activity_id)}%"))
-        query = query.where(
-            ActivityHistorySchema.id == activity_id,
-            AnswerSchema.flow_history_id.is_(None),
-        )
+        query = query.where(ActivityHistorySchema.id == activity_id)
         query = query.order_by(AppletHistorySchema.created_at.asc())
         db_result = await self._execute(query)
         results = []
-
-        for _, version, created_at, flow_history_id, _ in db_result.all():
-            # Filters out the activities associated with flows to display only isolated activities
-            if flow_history_id and flow_history_id.endswith(version):
-                results.append(Version(version=version, created_at=created_at))
+        for _, version, created_at in db_result.all():
+            results.append(Version(version=version, created_at=created_at))
 
         return results
 

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -238,9 +238,9 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
             case(
                 (
                     AnswerSchema.flow_history_id.isnot(None),
-                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),
+                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == str(filters.activity_or_flow_id),  # noqa: E501
                 ),
-                else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id)
+                else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id)  # noqa: E501
                 == str(filters.activity_or_flow_id),
             )
         )

--- a/src/apps/answers/filters.py
+++ b/src/apps/answers/filters.py
@@ -34,7 +34,7 @@ class AppletSubmissionsFilter(BaseQueryParams):
 class AppletSubmitDateFilter(BaseQueryParams):
     respondent_id: uuid.UUID | None
     target_subject_id: uuid.UUID | None
-    activity_or_flow_id: uuid.UUID | None
+    activity_or_flow_id: str | None
     from_date: datetime.date
     to_date: datetime.date
 

--- a/src/apps/answers/filters.py
+++ b/src/apps/answers/filters.py
@@ -17,6 +17,7 @@ class SummaryActivityFilter(BaseQueryParams):
 class ReviewAppletItemFilter(BaseQueryParams):
     target_subject_id: uuid.UUID
     created_date: datetime.date
+    flow_id: uuid.UUID | None
 
 
 class AppletSubmissionsFilter(BaseQueryParams):

--- a/src/apps/answers/filters.py
+++ b/src/apps/answers/filters.py
@@ -34,7 +34,7 @@ class AppletSubmissionsFilter(BaseQueryParams):
 class AppletSubmitDateFilter(BaseQueryParams):
     respondent_id: uuid.UUID | None
     target_subject_id: uuid.UUID | None
-    activity_id: str | None
+    activity_or_flow_id: uuid.UUID | None
     from_date: datetime.date
     to_date: datetime.date
 

--- a/src/apps/answers/filters.py
+++ b/src/apps/answers/filters.py
@@ -34,6 +34,7 @@ class AppletSubmissionsFilter(BaseQueryParams):
 class AppletSubmitDateFilter(BaseQueryParams):
     respondent_id: uuid.UUID | None
     target_subject_id: uuid.UUID | None
+    activity_id: str | None
     from_date: datetime.date
     to_date: datetime.date
 

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -504,6 +504,12 @@ class AnswerService:
             old_activity_answer_dates: dict[uuid.UUID, list[AnswerDate]] = defaultdict(list)
             activity_history_ids = set()
             for answer in answers:
+                if filters.flow_id:
+                    if not answer.flow_history_id or not answer.flow_history_id.startswith(str(filters.flow_id)):
+                        continue
+                elif answer.flow_history_id:
+                    continue
+
                 activity_id, _ = HistoryAware.split_id_version(answer.activity_history_id)
                 if _activity := activity_map.get(activity_id):
                     _activity.answer_dates.append(

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -307,19 +307,19 @@ def public_answer_create(
 
 @pytest.fixture
 def answer_with_flow_create(
-    applet: AppletFull,
+    applet_with_flow: AppletFull,
     answer_item_create: ItemAnswerCreate,
     client_meta: ClientMeta,
 ) -> AppletAnswerCreate:
     return AppletAnswerCreate(
-        applet_id=applet.id,
-        version=applet.version,
+        applet_id=applet_with_flow.id,
+        version=applet_with_flow.version,
         submit_id=uuid.uuid4(),
-        activity_id=applet.activities[0].id,
+        activity_id=applet_with_flow.activities[0].id,
         answer=answer_item_create,
         created_at=datetime.datetime.utcnow().replace(microsecond=0),
         client=client_meta,
-        flow_id=applet.activity_flows[0].id,
+        flow_id=applet_with_flow.activity_flows[0].id,
         is_flow_completed=True,
     )
 

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1001,6 +1001,7 @@ class TestAnswerActivityItems(BaseTest):
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1008,11 +1008,11 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_answer_skippable_activity_items_create_for_respondent_with_flow_id(
-        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_with_flow: AppletFull
+        self, client: TestClient, tom: User, answer_with_flow_create: AppletAnswerCreate, applet_with_flow: AppletFull
     ):
         client.login(tom)
 
-        response = await client.post(self.answer_url, data=answer_create)
+        response = await client.post(self.answer_url, data=answer_with_flow_create)
 
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
@@ -1049,11 +1049,11 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_list_submit_dates_with_flow_id(
-        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_with_flow: AppletFull
+        self, client: TestClient, tom: User, answer_with_flow_create: AppletAnswerCreate, applet_with_flow: AppletFull
     ):
         client.login(tom)
 
-        response = await client.post(self.answer_url, data=answer_create)
+        response = await client.post(self.answer_url, data=answer_with_flow_create)
         assert response.status_code == http.HTTPStatus.CREATED
 
         response = await client.get(

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1008,7 +1008,7 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_answer_skippable_activity_items_create_for_respondent_with_flow_id(
-        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_with_flow: AppletFull
     ):
         client.login(tom)
 
@@ -1017,12 +1017,12 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
         response = await client.get(
-            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
             dict(
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
-                activityOrFlowId=applet.activity_flows[0].id,
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK
@@ -1049,7 +1049,7 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
 
     async def test_list_submit_dates_with_flow_id(
-        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_with_flow: AppletFull
     ):
         client.login(tom)
 
@@ -1057,12 +1057,12 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.CREATED
 
         response = await client.get(
-            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
             dict(
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
-                activityOrFlowId=applet.activity_flows[0].id,
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1021,6 +1021,7 @@ class TestAnswerActivityItems(BaseTest):
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1007,6 +1007,27 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         assert len(response.json()["result"]["dates"]) == 1
 
+    async def test_answer_skippable_activity_items_create_for_respondent_with_flow_id(
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
+    ):
+        client.login(tom)
+
+        response = await client.post(self.answer_url, data=answer_create)
+
+        assert response.status_code == http.HTTPStatus.CREATED, response.json()
+
+        response = await client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+
     async def test_list_submit_dates(
         self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
     ):
@@ -1022,6 +1043,26 @@ class TestAnswerActivityItems(BaseTest):
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
                 activityOrFlowId=applet.activities[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+
+    async def test_list_submit_dates_with_flow_id(
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
+    ):
+        client.login(tom)
+
+        response = await client.post(self.answer_url, data=answer_create)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activity_flows[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -271,7 +271,7 @@ class TestAnswerActivityItems(BaseTest):
         arbitrary_client: TestClient,
         tom: User,
         answer_create: AppletAnswerCreate,
-        applet: AppletFull,
+        applet_with_flow: AppletFull,
     ):
         arbitrary_client.login(tom)
 
@@ -280,12 +280,12 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
         response = await arbitrary_client.get(
-            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
             dict(
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
-                activityOrFlowId=applet.activity_flows[0].id,
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK
@@ -298,7 +298,7 @@ class TestAnswerActivityItems(BaseTest):
         arbitrary_client: TestClient,
         tom: User,
         answer_create: AppletAnswerCreate,
-        applet: AppletFull,
+        applet_with_flow: AppletFull,
     ):
         arbitrary_client.login(tom)
 
@@ -306,12 +306,12 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.CREATED
 
         response = await arbitrary_client.get(
-            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
             dict(
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
-                activityOrFlowId=applet.activity_flows[0].id,
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK
@@ -319,12 +319,12 @@ class TestAnswerActivityItems(BaseTest):
         await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
 
         response = await arbitrary_client.get(
-            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
             dict(
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
-                activityOrFlowId=applet.activity_flows[0].id,
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
             ),
         )
         assert response.status_code == 200

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -265,6 +265,71 @@ class TestAnswerActivityItems(BaseTest):
         assert len(response.json()["result"]["dates"]) == 1
         await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
 
+    async def test_answer_skippable_activity_items_create_for_respondent_with_flow_id(
+        self,
+        arbitrary_session: AsyncSession,
+        arbitrary_client: TestClient,
+        tom: User,
+        answer_create: AppletAnswerCreate,
+        applet: AppletFull,
+    ):
+        arbitrary_client.login(tom)
+
+        response = await arbitrary_client.post(self.answer_url, data=answer_create)
+
+        assert response.status_code == http.HTTPStatus.CREATED, response.json()
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+
+    async def test_list_submit_dates_with_flow_id(
+        self,
+        arbitrary_session: AsyncSession,
+        arbitrary_client: TestClient,
+        tom: User,
+        answer_create: AppletAnswerCreate,
+        applet: AppletFull,
+    ):
+        arbitrary_client.login(tom)
+
+        response = await arbitrary_client.post(self.answer_url, data=answer_create)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == 200
+        assert len(response.json()["result"]["dates"]) == 1
+
     async def test_list_submit_dates(
         self,
         arbitrary_session: AsyncSession,

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -258,6 +258,7 @@ class TestAnswerActivityItems(BaseTest):
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK
@@ -283,6 +284,7 @@ class TestAnswerActivityItems(BaseTest):
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
             ),
         )
         assert response.status_code == http.HTTPStatus.OK
@@ -295,6 +297,7 @@ class TestAnswerActivityItems(BaseTest):
                 respondentId=tom.id,
                 fromDate=datetime.date.today() - datetime.timedelta(days=10),
                 toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
             ),
         )
         assert response.status_code == 200

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -270,12 +270,12 @@ class TestAnswerActivityItems(BaseTest):
         arbitrary_session: AsyncSession,
         arbitrary_client: TestClient,
         tom: User,
-        answer_create: AppletAnswerCreate,
+        answer_with_flow_create: AppletAnswerCreate,
         applet_with_flow: AppletFull,
     ):
         arbitrary_client.login(tom)
 
-        response = await arbitrary_client.post(self.answer_url, data=answer_create)
+        response = await arbitrary_client.post(self.answer_url, data=answer_with_flow_create)
 
         assert response.status_code == http.HTTPStatus.CREATED, response.json()
 
@@ -290,19 +290,19 @@ class TestAnswerActivityItems(BaseTest):
         )
         assert response.status_code == http.HTTPStatus.OK
         assert len(response.json()["result"]["dates"]) == 1
-        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+        await assert_answer_exist_on_arbitrary(str(answer_with_flow_create.submit_id), arbitrary_session)
 
     async def test_list_submit_dates_with_flow_id(
         self,
         arbitrary_session: AsyncSession,
         arbitrary_client: TestClient,
         tom: User,
-        answer_create: AppletAnswerCreate,
+        answer_with_flow_create: AppletAnswerCreate,
         applet_with_flow: AppletFull,
     ):
         arbitrary_client.login(tom)
 
-        response = await arbitrary_client.post(self.answer_url, data=answer_create)
+        response = await arbitrary_client.post(self.answer_url, data=answer_with_flow_create)
         assert response.status_code == http.HTTPStatus.CREATED
 
         response = await arbitrary_client.get(
@@ -316,7 +316,7 @@ class TestAnswerActivityItems(BaseTest):
         )
         assert response.status_code == http.HTTPStatus.OK
         assert len(response.json()["result"]["dates"]) == 1
-        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+        await assert_answer_exist_on_arbitrary(str(answer_with_flow_create.submit_id), arbitrary_session)
 
         response = await arbitrary_client.get(
             self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8215](https://mindlogger.atlassian.net/browse/M2-8215)

This change introduces a new (optional) field to the answers dates endpoint, which includes an additional filter to the query and removes incorrectly retrieved answers.


### 🪤 Peer Testing

- Access Dataviz for Limited users, and search for activities with answers from *limited* users on different dates.
- Only the answers for the user within that activity should be seen in the correct days.

### ✏️ Notes

- As an optional field, this change shall not cause any incompatibility issues.