### PR TITLE
fix: adding remaining invitation templates to the greek template files (M2-8100)

### DIFF
--- a/src/apps/mailing/static/templates/invitation_registered_user_el.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_el.html
@@ -20,9 +20,9 @@
       </a>
     </td>
   </tr>
-  {% include 'blocks/team_info_en.html' %}
+  {% include 'blocks/team_info_el.html' %}
 </table>
-{% include 'footers/footer_info_en.html' %}
+{% include 'footers/footer_info_el.html' %}
 </body>
 
 </html>

--- a/src/apps/mailing/static/templates/new_activity_assignments_el.html
+++ b/src/apps/mailing/static/templates/new_activity_assignments_el.html
@@ -31,8 +31,8 @@
       </a>
     </td>
   </tr>
-  {% include 'blocks/team_info_en.html' %}
+  {% include 'blocks/team_info_el.html' %}
 </table>
-{% include 'footers/footer_info_en.html' %}
+{% include 'footers/footer_info_el.html' %}
 </body>
 </html>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8100](https://mindlogger.atlassian.net/browse/M2-8100)

- Remaining templates from Admin invitation with footer pending to be translated to Greek

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

- Log into the admin panel
- Send an invitation to any applet
- Select Greek as invitation language
- Check if the arrived email is completely in Greek
