### PR TITLE
feat: Update "Get target subjects by respondent" endpoint to include `teamMemberCanViewData` property (M2-8464)

### DIFF
--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -318,8 +318,9 @@ async def get_target_subjects_by_respondent(
         respondent_subject.applet_id, respondent_subject.id
     )
 
-    access = await AppletAccessService(session).get_priority_access(applet_id=respondent_subject.applet_id,
-                                                                    user_id=user.id)
+    access = await AppletAccessService(session).get_priority_access(
+        applet_id=respondent_subject.applet_id, user_id=user.id
+    )
     if not access:
         raise AccessDeniedError()
 
@@ -360,7 +361,8 @@ async def get_target_subjects_by_respondent(
     is_super_reviewer = access.role in Role.super_reviewers()
     for subject in subjects:
         can_view_data = is_super_reviewer or (
-                    access.role == Role.REVIEWER and str(subject.id) in access.meta.get("subjects", []))
+            access.role == Role.REVIEWER and str(subject.id) in access.meta.get("subjects", [])
+        )
 
         target_subject = TargetSubjectByRespondentResponse(
             secret_user_id=subject.secret_user_id,
@@ -373,7 +375,7 @@ async def get_target_subjects_by_respondent(
             last_name=subject.last_name,
             submission_count=subject_info[subject.id]["submission_count"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
-            team_member_can_view_data=can_view_data
+            team_member_can_view_data=can_view_data,
         )
 
         if subject.id == respondent_subject_id:

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -91,6 +91,7 @@ class SubjectReadResponse(SubjectUpdateRequest):
 class TargetSubjectByRespondentResponse(SubjectReadResponse):
     submission_count: int = 0
     currently_assigned: bool = False
+    team_member_can_view_data: bool = False
 
 
 class SubjectRelation(InternalModel):

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -1137,15 +1137,15 @@ class TestSubjects(BaseTest):
         assert tom_result["teamMemberCanViewData"] is True
 
     async def test_get_target_subjects_by_respondent_via_submission_as_reviewer(
-            self,
-            client,
-            tom: User,
-            pit: User,
-            tom_applet_one_subject: Subject,
-            applet_one_shell_account: Subject,
-            applet_one_pit_reviewer: AppletFull,
-            answer_create_payload: dict,
-            session: AsyncSession,
+        self,
+        client,
+        tom: User,
+        pit: User,
+        tom_applet_one_subject: Subject,
+        applet_one_shell_account: Subject,
+        applet_one_pit_reviewer: AppletFull,
+        answer_create_payload: dict,
+        session: AsyncSession,
     ):
         activity = applet_one_pit_reviewer.activities[0]
 
@@ -1163,9 +1163,9 @@ class TestSubjects(BaseTest):
         )
 
         # Assign pit as a reviewer to tom
-        await (UserAppletAccessService(session, tom.id, applet_one_pit_reviewer.id).
-               set_subjects_for_review(reviewer_id=pit.id, applet_id=applet_one_pit_reviewer.id,
-                                       subjects=[tom_applet_one_subject.id]))
+        await UserAppletAccessService(session, tom.id, applet_one_pit_reviewer.id).set_subjects_for_review(
+            reviewer_id=pit.id, applet_id=applet_one_pit_reviewer.id, subjects=[tom_applet_one_subject.id]
+        )
 
         filtered_answer_create_payload = {k: v for k, v in answer_create_payload.items() if k != "submit_id"}
 
@@ -1218,15 +1218,15 @@ class TestSubjects(BaseTest):
         assert shell_account_result["teamMemberCanViewData"] is False
 
     async def test_get_target_subjects_by_respondent_via_submission_as_coordinator(
-            self,
-            client,
-            tom: User,
-            bob: User,
-            tom_applet_one_subject: Subject,
-            applet_one_shell_account: Subject,
-            applet_one_bob_coordinator: AppletFull,
-            answer_create_payload: dict,
-            session: AsyncSession,
+        self,
+        client,
+        tom: User,
+        bob: User,
+        tom_applet_one_subject: Subject,
+        applet_one_shell_account: Subject,
+        applet_one_bob_coordinator: AppletFull,
+        answer_create_payload: dict,
+        session: AsyncSession,
     ):
         activity = applet_one_bob_coordinator.activities[0]
 

--- a/src/apps/workspaces/service/applet_access.py
+++ b/src/apps/workspaces/service/applet_access.py
@@ -1,0 +1,30 @@
+import uuid
+
+from apps.applets.domain import UserAppletAccess
+from apps.workspaces.crud.applet_access import AppletAccessCRUD
+
+__all__ = ["AppletAccessService"]
+
+
+class AppletAccessService:
+    def __init__(self, session):
+        self.session = session
+
+    async def get_priority_access(self, applet_id: uuid.UUID, user_id: uuid.UUID) -> UserAppletAccess | None:
+        """
+        Get the user's access to an applet with the most permissions. Returns accesses in this order:
+        1. Owner
+        2. Manager
+        3. Coordinator
+        4. Editor
+        5. Reviewer
+        6. Respondent
+        :param applet_id:
+        :param user_id:
+        :return:
+        """
+        schema = await AppletAccessCRUD(self.session).get_priority_access(applet_id, user_id)
+        if not schema:
+            return None
+
+        return UserAppletAccess.from_orm(schema)


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8464](https://mindlogger.atlassian.net/browse/M2-8464)

This PR updates the structure of the subjects being returned by the "Get target subjects by respondent" endpoint. Each subject now includes a `teamMemberCanViewData` property, which indicates whether the logged-in admin user calling the endpoint can view the data of that particular subject.

### 🪤 Peer Testing

Test along with https://github.com/ChildMindInstitute/mindlogger-admin/pull/2009

### ✏️ Notes

N/A