### PR TITLE
chore: Bump aws-actions/amazon-ecs-deploy-task-definition from v1 to v2

### DIFF
--- a/.github/workflows/run_build_deploy.yaml
+++ b/.github/workflows/run_build_deploy.yaml
@@ -1,9 +1,10 @@
 
 name: Build and Deploy
-on: 
+on:
   push:
     branches:
       - develop
+#      - chore/bump-amazon-ecs-deploy-task-definition-version
   workflow_dispatch: {}
 
 

--- a/.github/workflows/run_build_deploy.yaml
+++ b/.github/workflows/run_build_deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-#      - chore/bump-amazon-ecs-deploy-task-definition-version
   workflow_dispatch: {}
 
 

--- a/.github/workflows/run_deploy_dev.yaml
+++ b/.github/workflows/run_deploy_dev.yaml
@@ -61,7 +61,7 @@ jobs:
           image: ${{ inputs.IMAGE_NAME }}
 
       - name: Update Task Definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ matrix.apps.service }}


### PR DESCRIPTION
### 📝 Description

This is a quick PR to fix the [recent deployment failures](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/actions/runs/12677880597/job/35350024013) to dev. It bumps `aws-actions/amazon-ecs-deploy-task-definition` from v1 to v2.

<img width="640" src="https://github.com/user-attachments/assets/60669324-735a-4ab5-a14c-750e5932ce6b">

I did a quick search and there doesn’t appear to have been any recent changes to either the task definition in ECS or the workflow file [run_deploy_dev.yaml](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/develop/.github/workflows/run_deploy_dev.yaml) in GitHub.

I found [this GitHub issue](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/705) that also doesn’t hint at a cause, but the consensus is that upgrading `aws-actions/amazon-ecs-deploy-task-definition` from v1 to v2 fixes the issue.

### 🪤 Peer Testing

We can possibly test this by uncommenting this line, provided all the secrets and variables will be available on this branch

https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/9cd8ad1d6597968bebcb0f8e85597715e54b4983/.github/workflows/run_build_deploy.yaml#L7

### ✏️ Notes

N/A