### PR TITLE
feat: Update the workspace applet respondents list endpoint to include each respondent's role (M2-8465)

### DIFF
--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -24,10 +24,10 @@ from apps.subjects.domain import (
     SubjectCreateRequest,
     SubjectDeleteRequest,
     SubjectReadResponse,
+    SubjectReadResponseWithRoles,
     SubjectRelationCreate,
     SubjectUpdateRequest,
     TargetSubjectByRespondentResponse,
-    SubjectReadResponseWithRoles,
 )
 from apps.subjects.errors import SecretIDUniqueViolationError
 from apps.subjects.services import SubjectsService
@@ -360,11 +360,10 @@ async def get_target_subjects_by_respondent(
             subject_info[subject_id]["currently_assigned"] = True
 
     subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
-    roles: dict[uuid.UUID, list[Role]] = await (
-        UserAppletAccessService(session, user.id, respondent_subject.applet_id)
-        .get_applet_roles_by_priority_for_users(
-            respondent_subject.applet_id, [subject.user_id for subject in subjects if subject.user_id]
-        )
+    roles: dict[uuid.UUID, list[Role]] = await UserAppletAccessService(
+        session, user.id, respondent_subject.applet_id
+    ).get_applet_roles_by_priority_for_users(
+        respondent_subject.applet_id, [subject.user_id for subject in subjects if subject.user_id]
     )
 
     result: list[TargetSubjectByRespondentResponse] = []

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -360,6 +360,13 @@ async def get_target_subjects_by_respondent(
             subject_info[subject_id]["currently_assigned"] = True
 
     subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
+    roles: dict[uuid.UUID, list[Role]] = await (
+        UserAppletAccessService(session, user.id, respondent_subject.applet_id)
+        .get_applet_roles_by_priority_for_users(
+            respondent_subject.applet_id, [subject.user_id for subject in subjects if subject.user_id]
+        )
+    )
+
     result: list[TargetSubjectByRespondentResponse] = []
 
     # Find the respondent subject in the list of subjects
@@ -382,6 +389,7 @@ async def get_target_subjects_by_respondent(
             submission_count=subject_info[subject.id]["submission_count"],
             currently_assigned=subject_info[subject.id]["currently_assigned"],
             team_member_can_view_data=can_view_data,
+            roles=roles[subject.user_id] if subject.user_id else [],
         )
 
         if subject.id == respondent_subject_id:

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -5,6 +5,7 @@ from pydantic import EmailStr, validator
 
 from apps.shared.domain import InternalModel, PublicModel
 from apps.shared.domain.custom_validations import lowercase
+from apps.workspaces.domain.constants import Role
 
 
 class SubjectCreate(InternalModel):
@@ -86,6 +87,9 @@ class SubjectReadResponse(SubjectUpdateRequest):
     user_id: uuid.UUID | None
     first_name: str
     last_name: str
+
+class SubjectReadResponseWithRoles(SubjectReadResponse):
+    roles: list[Role]
 
 
 class TargetSubjectByRespondentResponse(SubjectReadResponse):

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -92,7 +92,7 @@ class SubjectReadResponseWithRoles(SubjectReadResponse):
     roles: list[Role]
 
 
-class TargetSubjectByRespondentResponse(SubjectReadResponse):
+class TargetSubjectByRespondentResponse(SubjectReadResponseWithRoles):
     submission_count: int = 0
     currently_assigned: bool = False
     team_member_can_view_data: bool = False

--- a/src/apps/subjects/domain.py
+++ b/src/apps/subjects/domain.py
@@ -88,6 +88,7 @@ class SubjectReadResponse(SubjectUpdateRequest):
     first_name: str
     last_name: str
 
+
 class SubjectReadResponseWithRoles(SubjectReadResponse):
     roles: list[Role]
 

--- a/src/apps/subjects/router.py
+++ b/src/apps/subjects/router.py
@@ -21,8 +21,8 @@ from apps.subjects.domain import (
     SubjectCreateResponse,
     SubjectFull,
     SubjectReadResponse,
-    TargetSubjectByRespondentResponse,
     SubjectReadResponseWithRoles,
+    TargetSubjectByRespondentResponse,
 )
 from apps.users import User
 from infrastructure.database.deps import get_session

--- a/src/apps/subjects/router.py
+++ b/src/apps/subjects/router.py
@@ -22,6 +22,7 @@ from apps.subjects.domain import (
     SubjectFull,
     SubjectReadResponse,
     TargetSubjectByRespondentResponse,
+    SubjectReadResponseWithRoles,
 )
 from apps.users import User
 from infrastructure.database.deps import get_session
@@ -70,10 +71,10 @@ router.delete(
 
 router.get(
     "/{subject_id}",
-    response_model=Response[SubjectReadResponse],
+    response_model=Response[SubjectReadResponseWithRoles],
     status_code=status.HTTP_200_OK,
     responses={
-        status.HTTP_200_OK: {"model": Response[SubjectReadResponse]},
+        status.HTTP_200_OK: {"model": Response[SubjectReadResponseWithRoles]},
         **DEFAULT_OPENAPI_RESPONSE,
         **AUTHENTICATION_ERROR_RESPONSES,
     },

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -575,11 +575,13 @@ class TestSubjects(BaseTest):
             "firstName",
             "lastName",
             "userId",
+            "roles",
         }
         assert uuid.UUID(res["id"]) == tom_applet_one_subject.id
         assert res["secretUserId"] == tom_applet_one_subject.secret_user_id
         assert res["nickname"] == tom_applet_one_subject.nickname
         assert res["tag"] == tom_applet_one_subject.tag
+        assert res["roles"] == [Role.OWNER, Role.RESPONDENT]
         assert uuid.UUID(res["appletId"]) == tom_applet_one_subject.applet_id
         assert uuid.UUID(res["userId"]) == tom.id
 
@@ -712,11 +714,13 @@ class TestSubjects(BaseTest):
             "firstName",
             "lastName",
             "userId",
+            "roles",
         }
         assert uuid.UUID(res["id"]) == applet_one_shell_account.id
         assert res["secretUserId"] == applet_one_shell_account.secret_user_id
         assert res["nickname"] == applet_one_shell_account.nickname
         assert res["tag"] == applet_one_shell_account.tag
+        assert res["roles"] == []
         assert uuid.UUID(res["appletId"]) == applet_one_shell_account.applet_id
         assert res["userId"] is None
 

--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -1168,7 +1168,7 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
         return dict(db_result.all())
 
     async def get_applet_roles_by_priority_for_users(
-            self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]
+        self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]
     ) -> dict[uuid.UUID, list[Role]]:
         """
         Get a map of user ID to their roles in the given applet

--- a/src/apps/workspaces/domain/workspace.py
+++ b/src/apps/workspaces/domain/workspace.py
@@ -89,6 +89,7 @@ class WorkspaceRespondentDetails(InternalModel):
     subject_last_name: str
     subject_created_at: datetime.datetime
     invitation: InvitationDetail | None = None
+    roles: list[Role]
 
     @validator("respondent_nickname", "subject_first_name", "subject_last_name", pre=True)
     def decrypt_fields(cls, value):
@@ -202,6 +203,7 @@ class PublicWorkspaceRespondentDetails(PublicModel):
     subject_last_name: str
     subject_created_at: datetime.datetime
     invitation: InvitationResponse | None = None
+    roles: list[Role]
 
 
 class PublicWorkspaceRespondent(PublicModel):

--- a/src/apps/workspaces/service/check_access.py
+++ b/src/apps/workspaces/service/check_access.py
@@ -94,7 +94,7 @@ class CheckAccessService:
         await self._check_applet_roles(applet_id, roles)
 
     async def check_applet_activity_assignment_access(self, applet_id: uuid.UUID):
-        await self._check_applet_roles(applet_id, [Role.OWNER, Role.MANAGER])
+        await self._check_applet_roles(applet_id, [Role.OWNER, Role.MANAGER, Role.COORDINATOR])
 
     async def check_workspace_folder_access(self, owner_id: uuid.UUID):
         await self._check_workspace_roles(

--- a/src/apps/workspaces/service/user_applet_access.py
+++ b/src/apps/workspaces/service/user_applet_access.py
@@ -237,7 +237,7 @@ class UserAppletAccessService:
         return roles
 
     async def get_applet_roles_by_priority_for_users(
-            self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]
+        self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]
     ) -> dict[uuid.UUID, list[Role]]:
         return await UserAppletAccessCRUD(self.session).get_applet_roles_by_priority_for_users(applet_id, user_ids)
 

--- a/src/apps/workspaces/service/user_applet_access.py
+++ b/src/apps/workspaces/service/user_applet_access.py
@@ -236,6 +236,11 @@ class UserAppletAccessService:
         roles = await UserAppletAccessCRUD(self.session).get_user_roles_to_applet(self._user_id, self._applet_id)
         return roles
 
+    async def get_applet_roles_by_priority_for_users(
+            self, applet_id: uuid.UUID, user_ids: list[uuid.UUID]
+    ) -> dict[uuid.UUID, list[Role]]:
+        return await UserAppletAccessCRUD(self.session).get_applet_roles_by_priority_for_users(applet_id, user_ids)
+
     async def _validate_secret_user_id(self, exclude_id: uuid.UUID, secret_id: str):
         access = await UserAppletAccessCRUD(self.session).get_by_secret_user_id_for_applet(
             self._applet_id, secret_id, exclude_id

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -1,6 +1,7 @@
 import datetime
 import http
 import uuid
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -411,7 +412,9 @@ class TestWorkspaces(BaseTest):
         assert lucy_result["details"]
         assert tom_result["details"]
 
-        sorting_function = lambda x: x["appletDisplayName"]
+        def sorting_function(x: Any):
+            return x["appletDisplayName"]
+
         lucy_result_details = sorted(lucy_result["details"], key=sorting_function)
         shell_account_result_details = sorted(shell_account_result["details"], key=sorting_function)
         tom_result_details = sorted(tom_result["details"], key=sorting_function)
@@ -445,7 +448,7 @@ class TestWorkspaces(BaseTest):
         assert tom_result_details[1]["roles"] == [Role.OWNER, Role.RESPONDENT]
 
         # Check for the roles of the other participants
-        assert shell_account_result_details[0]["roles"] == [] # Limited accounts have no roles
+        assert shell_account_result_details[0]["roles"] == []  # Limited accounts have no roles
         assert user_result_details[0]["roles"] == [Role.RESPONDENT]
 
         # test manual, case-insensitive ordering by encrypted nicknames field

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -411,8 +411,11 @@ class TestWorkspaces(BaseTest):
         assert lucy_result["details"]
         assert tom_result["details"]
 
-        lucy_result_details = lucy_result["details"]
-        tom_result_details = sorted(tom_result["details"], key=lambda x: x["appletDisplayName"])
+        sorting_function = lambda x: x["appletDisplayName"]
+        lucy_result_details = sorted(lucy_result["details"], key=sorting_function)
+        shell_account_result_details = sorted(shell_account_result["details"], key=sorting_function)
+        tom_result_details = sorted(tom_result["details"], key=sorting_function)
+        user_result_details = sorted(user_result["details"], key=sorting_function)
 
         # Lucy has a pending invitation to Applet 1
         assert lucy_result_details[0]["invitation"]  # Applet 1
@@ -421,6 +424,7 @@ class TestWorkspaces(BaseTest):
         assert lucy_result_details[0]["subjectFirstName"] == lucy.first_name
         assert lucy_result_details[0]["subjectLastName"] == lucy.last_name
         assert lucy_result_details[0]["subjectCreatedAt"]
+        assert lucy_result_details[0]["roles"] == [Role.RESPONDENT]
 
         # Tom has an approved invitation to Applet 1
         assert tom_result_details[0]["invitation"]  # Applet 1
@@ -429,6 +433,7 @@ class TestWorkspaces(BaseTest):
         assert tom_result_details[0]["subjectFirstName"] == tom.first_name
         assert tom_result_details[0]["subjectLastName"] == tom.last_name
         assert tom_result_details[0]["subjectCreatedAt"]
+        assert tom_result_details[0]["roles"] == [Role.OWNER, Role.RESPONDENT]
 
         # Tom has a pending invitation to Applet 2
         assert tom_result_details[1]["invitation"]  # Applet 2
@@ -437,6 +442,11 @@ class TestWorkspaces(BaseTest):
         assert tom_result_details[1]["subjectFirstName"] == tom.first_name
         assert tom_result_details[1]["subjectLastName"] == tom.last_name
         assert tom_result_details[1]["subjectCreatedAt"]
+        assert tom_result_details[1]["roles"] == [Role.OWNER, Role.RESPONDENT]
+
+        # Check for the roles of the other participants
+        assert shell_account_result_details[0]["roles"] == [] # Limited accounts have no roles
+        assert user_result_details[0]["roles"] == [Role.RESPONDENT]
 
         # test manual, case-insensitive ordering by encrypted nicknames field
         assert set(data.keys()) == {"count", "result", "orderingFields"}
@@ -517,6 +527,7 @@ class TestWorkspaces(BaseTest):
         assert lucy_result_details[0]["subjectFirstName"] == lucy.first_name
         assert lucy_result_details[0]["subjectLastName"] == lucy.last_name
         assert lucy_result_details[0]["subjectCreatedAt"]
+        assert lucy_result_details[0]["roles"] == [Role.RESPONDENT]
 
         # Tom has an approved invitation to Applet 1
         assert tom_result_details[0]["invitation"]  # Applet 1
@@ -525,6 +536,7 @@ class TestWorkspaces(BaseTest):
         assert tom_result_details[0]["subjectFirstName"] == tom.first_name
         assert tom_result_details[0]["subjectLastName"] == tom.last_name
         assert tom_result_details[0]["subjectCreatedAt"]
+        assert tom_result_details[0]["roles"] == [Role.OWNER, Role.RESPONDENT]
 
         # test search
         access_id = lucy_result_details[0]["accessId"]


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8465](https://mindlogger.atlassian.net/browse/M2-8465)

This PR updates the get workspace respondents endpoints to add a `roles` property to each object in the `details` array. The `roles` property contains a list of roles the user has in a particular applet. This affects these endpoints:
- Workspace respondents list - `/workspaces/{owner_id}/respondents`
- Workspace applet respondents list -  `/workspaces/{owner_id}/applets/{applet_id}/respondents`

I've also added a `roles` property to each subject returned from these endpoints:
- Get subject - `/subjects/{subject_id}`
- Get target subjects by respondent - `/subjects/respondent/{respondent_subject_id}/activity-or-flow/{activity_or_flow_id}`

### 🪤 Peer Testing

Use the `/docs` endpoint to call each endpoint and confirm that the roles being returned match what you expect. Alternatively, you could use the admin panel and the dev tools network tab

### ✏️ Notes

I initially started out this implementation by attempting to update all endpoints that return subjects to include roles, but the changelog was getting too large and resulted in other unintentional changes to satisfy mypy. So, I landed on this compromise instead