### PR TITLE
chore: Schedules database clean up (M2-8495)

### DIFF
--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -23,7 +23,8 @@ from apps.activities.services.activity_item import ActivityItemService
 from apps.activity_assignments.service import ActivityAssignmentService
 from apps.activity_flows.crud import FlowsCRUD
 from apps.applets.crud import AppletsCRUD, UserAppletAccessCRUD
-from apps.schedule.crud.events import ActivityEventsCRUD, EventCRUD
+from apps.schedule.crud.events import EventCRUD
+from apps.schedule.domain.constants import EventType
 from apps.schedule.service.schedule import ScheduleService
 from apps.workspaces.domain.constants import Role
 
@@ -114,9 +115,9 @@ class ActivityService:
         activity_id_key_map: dict[uuid.UUID, uuid.UUID] = dict()
         prepared_activity_items = list()
 
-        all_activities = await ActivityEventsCRUD(self.session).get_by_applet_id(applet_id)
+        activity_events = await EventCRUD(self.session).get_by_type_and_applet_id(applet_id, EventType.ACTIVITY)
 
-        all_activity_ids = [activity.activity_id for activity in all_activities]
+        all_activity_ids = [activity.activity_id for activity in activity_events if activity.activity_id is not None]
 
         # Save new activity ids
         new_activities = []

--- a/src/apps/activity_flows/service/flow.py
+++ b/src/apps/activity_flows/service/flow.py
@@ -15,7 +15,8 @@ from apps.activity_flows.domain.flow_update import ActivityFlowReportConfigurati
 from apps.activity_flows.service.flow_item import FlowItemService
 from apps.applets.crud import UserAppletAccessCRUD
 from apps.applets.domain.applet_history import Version
-from apps.schedule.crud.events import EventCRUD, FlowEventsCRUD
+from apps.schedule.crud.events import EventCRUD
+from apps.schedule.domain.constants import EventType
 from apps.schedule.service.schedule import ScheduleService
 from apps.workspaces.domain.constants import Role
 
@@ -89,7 +90,9 @@ class FlowService:
         schemas = list()
         prepared_flow_items = list()
 
-        all_flows = [flow.flow_id for flow in await FlowEventsCRUD(self.session).get_by_applet_id(applet_id)]
+        flow_events = await EventCRUD(self.session).get_by_type_and_applet_id(applet_id, EventType.FLOW)
+
+        all_flows = [flow_event.activity_flow_id for flow_event in flow_events if flow_event.activity_flow_id]
 
         # Save new flow ids
         new_flows = []

--- a/src/apps/schedule/crud/events.py
+++ b/src/apps/schedule/crud/events.py
@@ -243,7 +243,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
         query: Query = select(EventSchema)
         # select only always available if requested
         if only_always_available:
-            query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
+            query = query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
         query = query.where(
             EventSchema.applet_id == applet_id,
             EventSchema.is_deleted.is_(False),
@@ -295,7 +295,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
 
         # select only always available if requested
         if only_always_available:
-            query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
+            query = query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
 
         query = query.where(
             EventSchema.applet_id == applet_id,

--- a/src/apps/schedule/crud/events.py
+++ b/src/apps/schedule/crud/events.py
@@ -318,7 +318,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
             .select_from(EventSchema)
             .where(EventSchema.user_id == user_id, EventSchema.applet_id == applet_id)
             .group_by("entity_id")
-        ).cte("ids")
+        )
 
         query: Query = select(EventSchema)
         query = query.where(
@@ -378,7 +378,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
             .select_from(EventSchema)
             .where(EventSchema.user_id == user_id, EventSchema.applet_id.in_(applet_ids))
             .group_by("entity_id")
-        ).cte("ids")
+        )
 
         query: Query = select(EventSchema)
 
@@ -459,7 +459,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
             .select_from(EventSchema)
             .where(EventSchema.user_id == user_id, EventSchema.applet_id == applet_id)
             .group_by("entity_id")
-        ).cte("ids")
+        )
 
         query: Query = select(
             func.count(EventSchema.id).label("count"),

--- a/src/apps/schedule/db/schemas.py
+++ b/src/apps/schedule/db/schemas.py
@@ -1,20 +1,10 @@
 import datetime
-import uuid
 
 from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, Interval, String, Time, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import ENUM, UUID
 
 from infrastructure.database.base import Base
 from infrastructure.database.mixins import HistoryAware
-
-
-class PeriodicitySchema(Base):
-    __tablename__ = "periodicity"
-
-    type = Column(String(10), nullable=False)  # Options: ONCE, DAILY, WEEKLY, WEEKDAYS, MONTHLY, ALWAYS
-    start_date = Column(Date, nullable=True)
-    end_date = Column(Date, nullable=True)
-    selected_date = Column(Date, nullable=True)
 
 
 class _BaseEventSchema:
@@ -44,11 +34,6 @@ class _BaseEventSchema:
 class EventSchema(_BaseEventSchema, Base):
     __tablename__ = "events"
 
-    periodicity_id = Column(
-        UUID(as_uuid=True),
-        default=lambda: uuid.uuid4(),
-        server_default=text("gen_random_uuid()"),
-    )
     applet_id = Column(ForeignKey("applets.id", ondelete="CASCADE"), nullable=False)
     user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=True)
 

--- a/src/apps/schedule/db/schemas.py
+++ b/src/apps/schedule/db/schemas.py
@@ -36,6 +36,9 @@ class _BaseEventSchema:
     start_date = Column(Date, nullable=True)
     end_date = Column(Date, nullable=True)
     selected_date = Column(Date, nullable=True)
+    event_type = Column(ENUM("activity", "flow", name="event_type_enum", create_type=False), nullable=False)
+    activity_id = Column(UUID(as_uuid=True), nullable=True)
+    activity_flow_id = Column(UUID(as_uuid=True), nullable=True)
 
 
 class EventSchema(_BaseEventSchema, Base):
@@ -47,6 +50,7 @@ class EventSchema(_BaseEventSchema, Base):
         server_default=text("gen_random_uuid()"),
     )
     applet_id = Column(ForeignKey("applets.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=True)
 
 
 class EventHistorySchema(_BaseEventSchema, HistoryAware, Base):
@@ -54,9 +58,6 @@ class EventHistorySchema(_BaseEventSchema, HistoryAware, Base):
 
     id_version = Column(String(), primary_key=True)
     id = Column(UUID(as_uuid=True))
-    event_type = Column(ENUM("activity", "flow", name="event_type_enum", create_type=False), nullable=False)
-    activity_id = Column(UUID(as_uuid=True), nullable=True)
-    activity_flow_id = Column(UUID(as_uuid=True), nullable=True)
     user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=True)
 
 
@@ -72,54 +73,6 @@ class AppletEventsSchema(Base):
             "event_id",
             "is_deleted",
             name="_unique_applet_events",
-        ),
-    )
-
-
-class UserEventsSchema(Base):
-    __tablename__ = "user_events"
-
-    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
-    event_id = Column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint(
-            "user_id",
-            "event_id",
-            "is_deleted",
-            name="_unique_user_events",
-        ),
-    )
-
-
-class ActivityEventsSchema(Base):
-    __tablename__ = "activity_events"
-
-    activity_id = Column(UUID(as_uuid=True), nullable=False)
-    event_id = Column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint(
-            "activity_id",
-            "event_id",
-            "is_deleted",
-            name="_unique_activity_events",
-        ),
-    )
-
-
-class FlowEventsSchema(Base):
-    __tablename__ = "flow_events"
-
-    flow_id = Column(UUID(as_uuid=True), nullable=False)
-    event_id = Column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint(
-            "flow_id",
-            "event_id",
-            "is_deleted",
-            name="_unique_flow_events",
         ),
     )
 

--- a/src/apps/schedule/domain/schedule/internal.py
+++ b/src/apps/schedule/domain/schedule/internal.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from pydantic import Field, NonNegativeInt, root_validator
 
-from apps.schedule.domain.constants import AvailabilityType, PeriodicityType, TimerType
+from apps.schedule.domain.constants import AvailabilityType, EventType, PeriodicityType, TimerType
 from apps.schedule.domain.schedule.base import BaseEvent, BaseNotificationSetting, BaseReminderSetting
 from apps.schedule.domain.schedule.public import (
     EventAvailabilityDto,
@@ -20,14 +20,8 @@ from apps.shared.domain import InternalModel
 __all__ = [
     "Event",
     "ScheduleEvent",
-    "UserEvent",
-    "ActivityEvent",
-    "FlowEvent",
     "EventCreate",
     "EventUpdate",
-    "UserEventCreate",
-    "ActivityEventCreate",
-    "FlowEventCreate",
     "EventFull",
     "NotificationSettingCreate",
     "NotificationSetting",
@@ -45,6 +39,10 @@ class EventCreate(BaseEvent, InternalModel):
         None,
         description="If type is WEEKLY, MONTHLY or ONCE, selectedDate must be set.",
     )
+    user_id: uuid.UUID | None = None
+    activity_id: uuid.UUID | None = None
+    activity_flow_id: uuid.UUID | None = None
+    event_type: EventType
 
     @root_validator
     def validate_periodicity(cls, values):
@@ -64,39 +62,6 @@ class EventUpdate(EventCreate):
 class Event(EventCreate, InternalModel):
     id: uuid.UUID
     version: str
-
-
-class UserEventCreate(InternalModel):
-    user_id: uuid.UUID
-    event_id: uuid.UUID
-
-
-class UserEvent(UserEventCreate, InternalModel):
-    """UserEvent of a schedule"""
-
-    id: uuid.UUID
-
-
-class ActivityEventCreate(InternalModel):
-    activity_id: uuid.UUID
-    event_id: uuid.UUID
-
-
-class ActivityEvent(ActivityEventCreate, InternalModel):
-    """ActivityEvent of a schedule"""
-
-    id: uuid.UUID
-
-
-class FlowEventCreate(InternalModel):
-    flow_id: uuid.UUID
-    event_id: uuid.UUID
-
-
-class FlowEvent(FlowEventCreate, InternalModel):
-    """FlowEvent of a schedule"""
-
-    id: uuid.UUID
 
 
 class NotificationSettingCreate(BaseNotificationSetting, InternalModel):
@@ -128,6 +93,7 @@ class EventFull(InternalModel, BaseEvent):
     activity_id: uuid.UUID | None = None
     flow_id: uuid.UUID | None = None
     version: str
+    event_type: EventType
 
 
 class ScheduleEvent(EventFull):

--- a/src/apps/schedule/service/schedule.py
+++ b/src/apps/schedule/service/schedule.py
@@ -6,23 +6,20 @@ from apps.activities.crud import ActivitiesCRUD
 from apps.activity_flows.crud import FlowsCRUD
 from apps.applets.crud import AppletsCRUD, UserAppletAccessCRUD
 from apps.applets.errors import AppletNotFoundError
-from apps.schedule.crud.events import ActivityEventsCRUD, EventCRUD, FlowEventsCRUD, UserEventsCRUD
+from apps.schedule.crud.events import EventCRUD
 from apps.schedule.crud.notification import NotificationCRUD, ReminderCRUD
 from apps.schedule.db.schemas import EventSchema, NotificationSchema
-from apps.schedule.domain.constants import DefaultEvent, PeriodicityType
+from apps.schedule.domain.constants import DefaultEvent, EventType, PeriodicityType
 from apps.schedule.domain.schedule import BaseEvent
 from apps.schedule.domain.schedule.internal import (
-    ActivityEventCreate,
     Event,
     EventCreate,
     EventFull,
     EventUpdate,
-    FlowEventCreate,
     NotificationSetting,
     ReminderSetting,
     ReminderSettingCreate,
     ScheduleEvent,
-    UserEventCreate,
 )
 from apps.schedule.domain.schedule.public import (
     PublicEvent,
@@ -95,25 +92,16 @@ class ScheduleService:
                 start_date=schedule.periodicity.start_date,
                 end_date=schedule.periodicity.end_date,
                 selected_date=schedule.periodicity.selected_date,
+                user_id=schedule.respondent_id,
+                activity_id=schedule.activity_id,
+                activity_flow_id=schedule.flow_id,
+                event_type=EventType.ACTIVITY if schedule.activity_id else EventType.FLOW,
             )
         )
 
-        # Create user event
-        if schedule.respondent_id:
-            await UserEventsCRUD(self.session).save(UserEventCreate(event_id=event.id, user_id=schedule.respondent_id))
-        # Create event-activity or event-flow
-        if schedule.activity_id:
-            await ActivityEventsCRUD(self.session).save(
-                ActivityEventCreate(event_id=event.id, activity_id=schedule.activity_id)
-            )
-        else:
-            await FlowEventsCRUD(self.session).save(FlowEventCreate(event_id=event.id, flow_id=schedule.flow_id))
-
         schedule_event = ScheduleEvent(
-            **event.dict(exclude={"applet_id"}),
-            activity_id=schedule.activity_id,
-            flow_id=schedule.flow_id,
-            user_id=schedule.respondent_id,
+            **event.dict(exclude={"applet_id", "activity_flow_id"}),
+            flow_id=event.activity_flow_id,
         )
 
         # Create notification and reminder
@@ -177,7 +165,6 @@ class ScheduleService:
                 selected_date=event.selected_date,
             ),
             respondent_id=schedule.respondent_id,
-            activity_id=schedule.activity_id,
             flow_id=schedule.flow_id,
             notification=notification_public if schedule.notification else None,
         )
@@ -187,22 +174,18 @@ class ScheduleService:
         await self._validate_applet(applet_id=applet_id)
 
         event: Event = await EventCRUD(self.session).get_by_id(pk=schedule_id)
-        user_id = await UserEventsCRUD(self.session).get_by_event_id(event_id=event.id)
-        activity_id = await ActivityEventsCRUD(self.session).get_by_event_id(event_id=event.id)
-        flow_id = await FlowEventsCRUD(self.session).get_by_event_id(event_id=event.id)
         notification = await self._get_notifications_and_reminder(event.id)
 
         return PublicEvent(
-            **event.dict(exclude={"periodicity"}),
+            **event.dict(exclude={"periodicity", "user_id", "activity_flow_id"}),
             periodicity=PublicPeriodicity(
                 type=event.periodicity,
                 start_date=event.start_date,
                 end_date=event.end_date,
                 selected_date=event.selected_date,
             ),
-            respondent_id=user_id,
-            activity_id=activity_id,
-            flow_id=flow_id,
+            respondent_id=event.user_id,
+            flow_id=event.activity_flow_id,
             notification=notification,
         )
 
@@ -224,24 +207,19 @@ class ScheduleService:
 
         for event_schema in event_schemas:
             event: Event = Event.from_orm(event_schema)
-
-            user_id = await UserEventsCRUD(self.session).get_by_event_id(event_id=event.id)
-            activity_id = await ActivityEventsCRUD(self.session).get_by_event_id(event_id=event.id)
-            flow_id = await FlowEventsCRUD(self.session).get_by_event_id(event_id=event.id)
             notification = await self._get_notifications_and_reminder(event.id)
 
             events.append(
                 PublicEvent(
-                    **event.dict(exclude={"periodicity"}),
+                    **event.dict(exclude={"periodicity", "user_id", "activity_flow_id"}),
                     periodicity=PublicPeriodicity(
                         type=event.periodicity,
                         start_date=event.start_date,
                         end_date=event.end_date,
                         selected_date=event.selected_date,
                     ),
-                    respondent_id=user_id,
-                    activity_id=activity_id,
-                    flow_id=flow_id,
+                    respondent_id=event.user_id,
+                    flow_id=event.activity_flow_id,
                     notification=notification,
                 )
             )
@@ -257,8 +235,6 @@ class ScheduleService:
         full_events: list[EventFull] = []
         for event_schema in event_schemas:
             event: Event = Event.from_orm(event_schema)
-            activity_id = await ActivityEventsCRUD(self.session).get_by_event_id(event_id=event.id)
-            flow_id = await FlowEventsCRUD(self.session).get_by_event_id(event_id=event.id)
             base_event = BaseEvent(**event.dict())
 
             full_events.append(
@@ -269,9 +245,11 @@ class ScheduleService:
                     start_date=event.start_date,
                     end_date=event.end_date,
                     selected_date=event.selected_date,
-                    activity_id=activity_id,
-                    flow_id=flow_id,
+                    activity_id=event.activity_id,
+                    flow_id=event.activity_flow_id,
+                    user_id=event.user_id,
                     version=event.version,
+                    event_type=event.event_type,
                 )
             )
 
@@ -298,10 +276,6 @@ class ScheduleService:
         event_schemas: list[EventSchema] = await EventCRUD(self.session).get_all_by_applet_id_with_filter(applet_id)
         event_ids = [event_schema.id for event_schema in event_schemas]
 
-        # Get all activity_ids and flow_ids
-        activity_ids = await ActivityEventsCRUD(self.session).get_by_event_ids(event_ids)
-        flow_ids = await FlowEventsCRUD(self.session).get_by_event_ids(event_ids)
-
         await self._delete_by_ids(event_ids)
 
         await ScheduleHistoryService(self.session).mark_as_deleted(
@@ -309,50 +283,54 @@ class ScheduleService:
         )
 
         # Create default events for activities and flows
-        for activity_id in activity_ids:
-            await self._create_default_event(applet_id=applet_id, activity_id=activity_id, is_activity=True)
-
-        for flow_id in flow_ids:
-            await self._create_default_event(applet_id=applet_id, activity_id=flow_id, is_activity=False)
+        processed_activities_and_flows: dict[uuid.UUID, bool] = {}
+        for event in event_schemas:
+            if event.activity_id and event.activity_id not in processed_activities_and_flows:
+                await self._create_default_event(
+                    applet_id=applet_id,
+                    activity_id=event.activity_id,
+                    is_activity=True,
+                    respondent_id=event.user_id,
+                )
+                processed_activities_and_flows[event.activity_id] = True
+            if event.activity_flow_id and event.activity_flow_id not in processed_activities_and_flows:
+                await self._create_default_event(
+                    applet_id=applet_id,
+                    activity_id=event.activity_flow_id,
+                    is_activity=False,
+                    respondent_id=event.user_id,
+                )
+                processed_activities_and_flows[event.activity_flow_id] = True
 
     async def delete_schedule_by_id(self, schedule_id: uuid.UUID) -> uuid.UUID | None:
-        event: Event = await EventCRUD(self.session).get_by_id(pk=schedule_id)
-        respondent_id = await UserEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
+        crud = EventCRUD(self.session)
+        event: Event = await crud.get_by_id(pk=schedule_id)
 
-        # Get activity_id or flow_id if exists
-        activity_id = await ActivityEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
-        flow_id = await FlowEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
-
-        # Delete event-user, event-activity, event-flow
         await self._delete_by_ids(event_ids=[schedule_id])
 
         await ScheduleHistoryService(self.session).mark_as_deleted([(event.id, event.version)])
 
-        # Create default event for activity or flow if another event doesn't exist # noqa: E501
-        if activity_id:
-            count_events = await ActivityEventsCRUD(self.session).count_by_activity(
-                activity_id=activity_id, respondent_id=respondent_id
-            )
+        # Create default event for activity or flow if another event doesn't exist
+        if event.activity_id:
+            count_events = await crud.count_by_activity(activity_id=event.activity_id, respondent_id=event.user_id)
             if count_events == 0:
                 await self._create_default_event(
                     applet_id=event.applet_id,
-                    activity_id=activity_id,
+                    activity_id=event.activity_id,
                     is_activity=True,
-                    respondent_id=respondent_id,
+                    respondent_id=event.user_id,
                 )
 
-        elif flow_id:
-            count_events = await FlowEventsCRUD(self.session).count_by_flow(
-                flow_id=flow_id, respondent_id=respondent_id
-            )
+        elif event.activity_flow_id:
+            count_events = await crud.count_by_flow(flow_id=event.activity_flow_id, respondent_id=event.user_id)
             if count_events == 0:
                 await self._create_default_event(
                     applet_id=event.applet_id,
-                    activity_id=flow_id,
+                    activity_id=event.activity_flow_id,
                     is_activity=False,
-                    respondent_id=respondent_id,
+                    respondent_id=event.user_id,
                 )
-        return respondent_id
+        return event.user_id
 
     async def update_schedule(
         self,
@@ -364,18 +342,15 @@ class ScheduleService:
         await self._validate_applet(applet_id=applet_id)
 
         event: Event = await EventCRUD(self.session).get_by_id(pk=schedule_id)
-        activity_id = await ActivityEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
-        flow_id = await FlowEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
-        respondent_id = await UserEventsCRUD(self.session).get_by_event_id(event_id=schedule_id)
 
         # Delete all events of this activity or flow
-        # if new periodicity type is "always" and old periodicity type is not "always" # noqa: E501
-        if schedule.periodicity.type == PeriodicityType.ALWAYS and event.periodicity != PeriodicityType.ALWAYS:  # noqa: E501
+        # if new periodicity type is "always" and old periodicity type is not "always"
+        if schedule.periodicity.type == PeriodicityType.ALWAYS and event.periodicity != PeriodicityType.ALWAYS:
             await self._delete_by_activity_or_flow(
                 applet_id=applet_id,
-                activity_id=activity_id,
-                flow_id=flow_id,
-                respondent_id=respondent_id,
+                activity_id=event.activity_id,
+                flow_id=event.activity_flow_id,
+                respondent_id=event.user_id,
                 only_always_available=False,
                 except_event_id=schedule_id,
             )
@@ -395,14 +370,16 @@ class ScheduleService:
                 start_date=schedule.periodicity.start_date,
                 end_date=schedule.periodicity.end_date,
                 selected_date=schedule.periodicity.selected_date,
+                event_type=event.event_type,
+                activity_id=event.activity_id,
+                activity_flow_id=event.activity_flow_id,
+                user_id=event.user_id,
             ),
         )
 
         schedule_event = ScheduleEvent(
-            **event.dict(exclude={"applet_id"}),
-            activity_id=activity_id,
-            flow_id=flow_id,
-            user_id=respondent_id,
+            **event.dict(exclude={"applet_id", "activity_flow_id"}),
+            flow_id=event.activity_flow_id,
         )
 
         # Update notification
@@ -461,16 +438,15 @@ class ScheduleService:
         )
 
         return PublicEvent(
-            **event.dict(exclude={"periodicity"}),
+            **event.dict(exclude={"periodicity", "user_id", "activity_flow_id"}),
             periodicity=PublicPeriodicity(
                 type=event.periodicity,
                 start_date=event.start_date,
                 end_date=event.end_date,
                 selected_date=event.selected_date,
             ),
-            respondent_id=respondent_id,
-            activity_id=activity_id,
-            flow_id=flow_id,
+            respondent_id=event.user_id,
+            flow_id=event.activity_flow_id,
             notification=notification_public,
         )
 
@@ -507,46 +483,43 @@ class ScheduleService:
         event_count = PublicEventCount(activity_events=[], flow_events=[])
 
         # Get list of activity-event ids
-        activity_counts = await ActivityEventsCRUD(self.session).count_by_applet(applet_id=applet_id)
-
-        # Get list of flow-event ids
-        flow_counts = await FlowEventsCRUD(self.session).count_by_applet(applet_id=applet_id)
+        activity_counts, flow_counts = await EventCRUD(self.session).count_by_applet(applet_id=applet_id)
 
         event_count.activity_events = activity_counts if activity_counts else []
         event_count.flow_events = flow_counts if flow_counts else []
 
         return event_count
 
-    async def delete_by_user_id(self, applet_id, user_id):
+    async def delete_by_user_id(self, applet_id: uuid.UUID, user_id: uuid.UUID) -> None:
         # Check if applet exists
         await self._validate_applet(applet_id=applet_id)
 
         # Check if user exists
         await self._validate_user(user_id=user_id)
 
-        # Get list of activity-event ids and flow-event ids for user to create default events  # noqa: E501
-        activities = await ActivityEventsCRUD(self.session).get_by_applet_and_user_id(applet_id, user_id)
-
-        activity_ids = {activity.activity_id for activity in activities}
-
-        flows = await FlowEventsCRUD(self.session).get_by_applet_and_user_id(applet_id, user_id)
-        flow_ids = {flow.flow_id for flow in flows}
-
-        # Get list of event_ids for user and delete them all
         event_schemas = await EventCRUD(self.session).get_all_by_applet_and_user(applet_id, user_id)
-        event_ids = [event_schema.id for event_schema in event_schemas]
+
+        # List of event_ids for user for deletion
+        event_ids: list[uuid.UUID] = []
+        activity_ids: set[uuid.UUID] = set()
+        flow_ids: set[uuid.UUID] = set()
+
+        for event in event_schemas:
+            event_ids.append(event.id)
+            if event.activity_id:
+                activity_ids.add(event.activity_id)
+            if event.flow_id:
+                flow_ids.add(event.flow_id)
+
         if not event_ids:
             raise ScheduleNotFoundError()
-        await self._delete_by_ids(
-            event_ids=event_ids,
-            user_id=user_id,
-        )
+        await self._delete_by_ids(event_ids=event_ids)
 
         await ScheduleHistoryService(self.session).mark_as_deleted(
             [(event.id, event.version) for event in event_schemas]
         )
 
-        # Create AA events for all activities and flows
+        # Create always available events for all activities and flows
         await self.create_default_schedules(
             applet_id=applet_id,
             activity_ids=list(activity_ids),
@@ -608,8 +581,7 @@ class ScheduleService:
                 only_always_available,
             )
 
-        clean_events = [event for event in event_schemas if event.id != except_event_id]
-        event_ids = [event.id for event in clean_events]
+        event_ids = [event.id for event in event_schemas if event.id != except_event_id]
 
         if event_ids:
             await self._delete_by_ids(event_ids=event_ids)
@@ -620,18 +592,7 @@ class ScheduleService:
     async def _delete_by_ids(
         self,
         event_ids: list[uuid.UUID],
-        user_id: uuid.UUID | None = None,
     ):
-        if user_id:
-            await UserEventsCRUD(self.session).delete_all_by_events_and_user(
-                event_ids,
-                user_id,
-            )
-        else:
-            await UserEventsCRUD(self.session).delete_all_by_event_ids(event_ids)
-
-        await ActivityEventsCRUD(self.session).delete_all_by_event_ids(event_ids)
-        await FlowEventsCRUD(self.session).delete_all_by_event_ids(event_ids)
         await NotificationCRUD(self.session).delete_by_event_ids(event_ids)
         await ReminderCRUD(self.session).delete_by_event_ids(event_ids)
         await EventCRUD(self.session).delete_by_ids(event_ids)
@@ -882,10 +843,7 @@ class ScheduleService:
         if not event_ids:
             raise ScheduleNotFoundError()
 
-        await self._delete_by_ids(
-            event_ids=event_ids,
-            user_id=user_id,
-        )
+        await self._delete_by_ids(event_ids=event_ids)
 
         await ScheduleHistoryService(self.session).mark_as_deleted(
             [(event.id, event.version) for event in event_schemas]
@@ -947,7 +905,7 @@ class ScheduleService:
         activity_ids: list[uuid.UUID],
     ) -> None:
         """Create default schedules for applet."""
-        activities_without_events = await ActivityEventsCRUD(self.session).get_missing_events(activity_ids)
+        activities_without_events = await EventCRUD(self.session).get_activities_without_events(activity_ids)
         await self.create_default_schedules(
             applet_id=applet_id,
             activity_ids=activities_without_events,

--- a/src/apps/schedule/service/schedule_history.py
+++ b/src/apps/schedule/service/schedule_history.py
@@ -27,6 +27,9 @@ class ScheduleHistoryService:
     async def add_history(self, applet_id: uuid.UUID, event: ScheduleEvent):
         applet = await AppletsCRUD(self.session).get_by_id(applet_id)
 
+        # Refresh the applet so we don't get the old version number, in case the version has changed
+        await self.session.refresh(applet)
+
         event_history = await ScheduleHistoryCRUD(self.session).add(
             EventHistorySchema(
                 start_time=event.start_time,

--- a/src/apps/workspaces/crud/user_applet_access.py
+++ b/src/apps/workspaces/crud/user_applet_access.py
@@ -29,7 +29,7 @@ from sqlalchemy_utils import StringEncryptedType
 from apps.applets.db.schemas import AppletSchema
 from apps.invitations.constants import InvitationStatus
 from apps.invitations.db import InvitationSchema
-from apps.schedule.db.schemas import EventSchema, UserEventsSchema
+from apps.schedule.db.schemas import EventSchema
 from apps.shared.encryption import get_key
 from apps.shared.filtering import FilterField, Filtering
 from apps.shared.ordering import Ordering
@@ -402,10 +402,9 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
         workspace_applets_sq = self.workspace_applets_subquery(owner_id, applet_id)
 
         schedule_exists = (
-            select(UserEventsSchema)
-            .join(EventSchema, EventSchema.id == UserEventsSchema.event_id)
+            select(EventSchema)
             .where(
-                UserEventsSchema.user_id == UserAppletAccessSchema.user_id,
+                EventSchema.user_id == UserAppletAccessSchema.user_id,
                 EventSchema.applet_id == UserAppletAccessSchema.applet_id,
             )
             .exists()
@@ -1047,12 +1046,11 @@ class UserAppletAccessCRUD(BaseCRUD[UserAppletAccessSchema]):
         page: int,
         limit: int,
     ) -> list[RespondentAppletAccess]:
-        individual_event_query: Query = select(UserEventsSchema.id)
-        individual_event_query = individual_event_query.join(EventSchema, EventSchema.id == UserEventsSchema.event_id)
+        individual_event_query: Query = select(EventSchema.id)
         individual_event_query = individual_event_query.where(
-            UserEventsSchema.user_id == UserAppletAccessSchema.user_id
+            EventSchema.user_id == UserAppletAccessSchema.user_id,
+            EventSchema.applet_id == UserAppletAccessSchema.applet_id,
         )
-        individual_event_query = individual_event_query.where(EventSchema.applet_id == UserAppletAccessSchema.applet_id)
 
         query: Query = select(
             SubjectSchema.secret_user_id,

--- a/src/infrastructure/database/migrations/versions/2025_02_02_18_39-clean_up_schedule_tables.py
+++ b/src/infrastructure/database/migrations/versions/2025_02_02_18_39-clean_up_schedule_tables.py
@@ -1,0 +1,174 @@
+"""Clean up schedule tables
+
+Revision ID: 3059a8ad6ec5
+Revises: 7c7e30fa96a4
+Create Date: 2025-02-02 18:39:01.011295
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "3059a8ad6ec5"
+down_revision = "7c7e30fa96a4"
+branch_labels = None
+depends_on = None
+
+EVENT_TYPE_ENUM = 'event_type_enum'
+EVENT_TYPE_ENUM_VALUES = ['activity', 'flow']
+
+
+def upgrade() -> None:
+    # Add columns `event_type`, `activity_id`, `activity_flow_id`, and `user_id` to `events`
+    op.add_column("events", sa.Column("activity_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("events", sa.Column("activity_flow_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("events", sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="RESTRICT"), nullable=True))
+    op.add_column("events", sa.Column("event_type", postgresql.ENUM(*EVENT_TYPE_ENUM_VALUES, name=EVENT_TYPE_ENUM, create_type=False), nullable=True))
+
+    # Migrate data from `activity_events`, `flow_events`, and `user_events` to `events`
+    op.execute("""
+    UPDATE events dst
+    SET activity_id=ae.activity_id,
+    activity_flow_id = fe.flow_id,
+    user_id=ue.user_id,
+    event_type=(CASE WHEN ae.activity_id IS NOT NULL THEN 'activity' ELSE 'flow' END)::event_type_enum
+    FROM events e
+    LEFT JOIN activity_events ae ON e.id = ae.event_id
+    LEFT JOIN flow_events fe ON e.id = fe.event_id
+    LEFT JOIN user_events ue ON e.id = ue.event_id
+    WHERE dst.id = e.id
+    """)
+
+    # Make sure that the `event_type` column is not null
+    op.alter_column("events", "event_type", nullable=False)
+
+    # Drop the `periodicity_id` column from the `events` table
+    op.drop_column("events", "periodicity_id")
+
+    # Drop tables
+    op.drop_table("activity_events")
+    op.drop_table("flow_events")
+    op.drop_table("user_events")
+    op.drop_table("periodicity")
+
+
+def downgrade() -> None:
+    # Recreate the dropped tables
+    op.create_table(
+        "activity_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("migrated_date", sa.DateTime(), nullable=True),
+        sa.Column("migrated_updated", sa.DateTime(), nullable=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("activity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_activity_events")),
+        sa.UniqueConstraint("activity_id", "event_id", "is_deleted", name="_unique_activity_events"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], name=op.f("fk_activity_events_event_id_events"), ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "flow_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("migrated_date", sa.DateTime(), nullable=True),
+        sa.Column("migrated_updated", sa.DateTime(), nullable=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("flow_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_flow_events")),
+        sa.UniqueConstraint("flow_id", "event_id", "is_deleted", name="_unique_flow_events"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], name=op.f("fk_flow_events_event_id_events"), ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "user_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("migrated_date", sa.DateTime(), nullable=True),
+        sa.Column("migrated_updated", sa.DateTime(), nullable=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_events")),
+        sa.UniqueConstraint("user_id", "event_id", "is_deleted", name="_unique_user_events"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], name=op.f("fk_user_events_event_id_events"), ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_user_events_user_id_users"), ondelete="RESTRICT"),
+    )
+
+    op.create_table(
+        "periodicity",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("timezone('utc', now())"), nullable=True),
+        sa.Column("migrated_date", sa.DateTime(), nullable=True),
+        sa.Column("migrated_updated", sa.DateTime(), nullable=True),
+        sa.Column("type", sa.String(10), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=True),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column("selected_date", sa.Date(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_periodicity")),
+    )
+
+    # Add the `periodicity_id` column back to the `events` table
+    op.add_column(
+        "events",
+        sa.Column(
+            "periodicity_id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False
+        )
+    )
+
+    # Generate periodicity IDs for existing events
+    op.execute("""
+    UPDATE events
+    SET periodicity_id = gen_random_uuid()
+    WHERE periodicity_id IS NULL
+    """)
+
+    # Repopulate the `activity_events`, `flow_events`, `user_events`, and `periodicity` tables
+    # We do lose some data here (e.g. the original `id`, `created_at`, `updated_at`, `migrated_date`, `migrated_updated`),
+    # because we can't recover that data from the `events` table
+    op.execute("""
+    INSERT INTO activity_events (id, is_deleted, activity_id, event_id)
+    SELECT gen_random_uuid(), e.is_deleted, e.activity_id, e.id
+    FROM events e
+    WHERE e.activity_id IS NOT NULL
+    AND e.event_type = 'activity'
+    """)
+
+    op.execute("""
+    INSERT INTO flow_events (id, is_deleted, flow_id, event_id)
+    SELECT gen_random_uuid(), e.is_deleted, e.activity_flow_id, e.id
+    FROM events e
+    WHERE e.activity_flow_id IS NOT NULL
+    AND e.event_type = 'flow'
+    """)
+
+    op.execute("""
+    INSERT INTO user_events (id, is_deleted, user_id, event_id)
+    SELECT gen_random_uuid(), e.is_deleted, e.user_id, e.id
+    FROM events e
+    WHERE e.user_id IS NOT NULL
+    """)
+
+    op.execute("""
+    INSERT INTO periodicity (id, is_deleted, type, start_date, end_date, selected_date)
+    SELECT e.periodicity_id, e.is_deleted, e.periodicity, e.start_date, e.end_date, e.selected_date
+    FROM events e
+    """)
+
+    # Drop the new columns from the `events` table
+    op.drop_column("events", "activity_id")
+    op.drop_column("events", "activity_flow_id")
+    op.drop_column("events", "user_id")
+    op.drop_column("events", "event_type")


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8495](https://mindlogger.atlassian.net/browse/M2-8495)

> [!NOTE]
> This PR is based on #1733. If it is still open, please review that one first

This PR implements the following cleanup operations:
- Adds four new columns to the `events` table:
    - `activity_id`: taken from the `activity_events` table
    - `activity_flow_id`: taken from the `flow_events` table
    - `user_id`: taken from the `user_events` table
    - `event_type`: Enum with value `activity` or `flow`
- Removes the `periodicity_id` column from the `events` table
- Migrates all the data from the `activity_events`, `flow_events`, and `user_events` tables into the `events` table
- Drops the `activity_events`, `flow_events`, `user_events`, and `periodicity` tables
- Updates the API code to account for these changes, which mostly included rewriting queries to select only from the `events` table where multiple joins (and sometimes multiple queries) were previously being done

These changes are intended to be 100% backwards compatible and should introduce no new features from the client perspective. As such, no new tests have been introduced.

### 🪤 Peer Testing

Run the migration on your local database and confirm no errors are reported

```shell
alembic upgrade head
```

Run the down migration on your local database and confirm no errors are reported

```shell
alembic downgrade 3059a8ad6ec5 && alembic downgrade -1
```

Run the migration again and perform the same tests as in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1719. Then confirm that there are no unexpected errors.

### ✏️ Notes

N/A