### PR TITLE
feature: Activity/Flow id dates filtering (M2-8215)(M2-7348)

### DIFF
--- a/src/apps/answers/crud/answer_items.py
+++ b/src/apps/answers/crud/answer_items.py
@@ -155,6 +155,7 @@ class AnswerItemsCRUD(BaseCRUD[AnswerItemSchema]):
         )
         query = query.where(AnswerSchema.applet_id == applet_id)
         query = query.where(AnswerSchema.activity_history_id.in_(activity_ver_ids))
+        query = query.where(AnswerSchema.flow_history_id.is_(None))
         query = query.order_by(AnswerSchema.created_at.asc())
         query = query.where(*_ActivityAnswerFilter().get_clauses(**filters))
         db_result = await self._execute(query)

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -234,10 +234,25 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
         query = query.where(func.date(AnswerSchema.created_at) >= filters.from_date)
         query = query.where(func.date(AnswerSchema.created_at) <= filters.to_date)
         query = query.where(AnswerSchema.applet_id == applet_id)
+
         if filters.respondent_id:
             query = query.where(AnswerSchema.respondent_id == filters.respondent_id)
         if filters.target_subject_id:
             query = query.where(AnswerSchema.target_subject_id == filters.target_subject_id)
+
+        if filters.activity_or_flow_id:
+            activity_or_flow_id = (
+                str(filters.activity_or_flow_id)
+                if isinstance(filters.activity_or_flow_id, uuid.UUID)
+                else filters.activity_or_flow_id
+            )
+
+            query = query.where(
+                or_(
+                    AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == activity_or_flow_id,
+                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == activity_or_flow_id,
+                )
+            )
         query = query.order_by(AnswerSchema.created_at.asc())
         db_result = await self._execute(query)
 

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -244,9 +244,12 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
             activity_or_flow_id = str(filters.activity_or_flow_id)
 
             query = query.where(
-                or_(
-                    AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == activity_or_flow_id,
-                    AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == activity_or_flow_id,
+                case(
+                    (
+                        AnswerSchema.flow_history_id.isnot(None),
+                        AnswerSchema.id_from_history_id(AnswerSchema.flow_history_id) == activity_or_flow_id,
+                    ),
+                    else_=AnswerSchema.id_from_history_id(AnswerSchema.activity_history_id) == activity_or_flow_id,
                 )
             )
         query = query.order_by(AnswerSchema.created_at.asc())

--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -241,11 +241,7 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
             query = query.where(AnswerSchema.target_subject_id == filters.target_subject_id)
 
         if filters.activity_or_flow_id:
-            activity_or_flow_id = (
-                str(filters.activity_or_flow_id)
-                if isinstance(filters.activity_or_flow_id, uuid.UUID)
-                else filters.activity_or_flow_id
-            )
+            activity_or_flow_id = str(filters.activity_or_flow_id)
 
             query = query.where(
                 or_(

--- a/src/apps/answers/filters.py
+++ b/src/apps/answers/filters.py
@@ -36,6 +36,7 @@ class AppletSubmitDateFilter(BaseQueryParams):
     target_subject_id: uuid.UUID | None
     from_date: datetime.date
     to_date: datetime.date
+    activity_or_flow_id: uuid.UUID | None = None
 
     @classmethod
     @root_validator

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1033,6 +1033,51 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         assert len(response.json()["result"]["dates"]) == 1
 
+    async def test_list_submit_dates_with_activity_id(
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet: AppletFull
+    ):
+        client.login(tom)
+
+        response = await client.post(self.answer_url, data=answer_create)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+
+    async def test_list_submit_dates_with_flow_id(
+        self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_with_flow: AppletFull
+    ):
+        client.login(tom)
+
+        data = answer_create.copy(deep=True)
+        data.applet_id = applet_with_flow.id
+        data.flow_id = applet_with_flow.activity_flows[0].id
+        data.activity_id = applet_with_flow.activities[0].id
+
+        response = await client.post(self.answer_url, data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+
     async def test_answer_flow_items_create_for_respondent(
         self, client: TestClient, tom: User, answer_create: AppletAnswerCreate
     ):

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -300,6 +300,87 @@ class TestAnswerActivityItems(BaseTest):
         assert response.status_code == 200
         assert len(response.json()["result"]["dates"]) == 1
 
+    async def test_list_submit_dates_with_activity_id(
+        self,
+        arbitrary_session: AsyncSession,
+        arbitrary_client: TestClient,
+        tom: User,
+        answer_create: AppletAnswerCreate,
+        applet: AppletFull,
+    ):
+        arbitrary_client.login(tom)
+
+        response = await arbitrary_client.post(self.answer_url, data=answer_create)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet.activities[0].id,
+            ),
+        )
+        assert response.status_code == 200
+        assert len(response.json()["result"]["dates"]) == 1
+
+    async def test_list_submit_dates_with_flow_id(
+        self,
+        arbitrary_session: AsyncSession,
+        arbitrary_client: TestClient,
+        tom: User,
+        answer_create: AppletAnswerCreate,
+        applet_with_flow: AppletFull,
+    ):
+        arbitrary_client.login(tom)
+
+        data = answer_create.copy(deep=True)
+        data.applet_id = applet_with_flow.id
+        data.flow_id = applet_with_flow.activity_flows[0].id
+        data.activity_id = applet_with_flow.activities[0].id
+
+        response = await arbitrary_client.post(self.answer_url, data=data)
+        assert response.status_code == http.HTTPStatus.CREATED
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert len(response.json()["result"]["dates"]) == 1
+        await assert_answer_exist_on_arbitrary(str(answer_create.submit_id), arbitrary_session)
+
+        response = await arbitrary_client.get(
+            self.applet_submit_dates_url.format(applet_id=str(applet_with_flow.id)),
+            dict(
+                respondentId=tom.id,
+                fromDate=datetime.date.today() - datetime.timedelta(days=10),
+                toDate=datetime.date.today() + datetime.timedelta(days=10),
+                activityOrFlowId=applet_with_flow.activity_flows[0].id,
+            ),
+        )
+        assert response.status_code == 200
+        assert len(response.json()["result"]["dates"]) == 1
+
     async def test_answer_flow_items_create_for_respondent(
         self,
         arbitrary_session: AsyncSession,


### PR DESCRIPTION
- [X] Tests for the changes have been added
- [X] For new features, QA automation engineers have been tagged

### 📝 Description

🔗 [Jira Ticket M2-8215](https://mindlogger.atlassian.net/browse/M2-8215)
🔗 [Jira Ticket M2-7348](https://mindlogger.atlassian.net/browse/M2-7348)

This PR adds optional filtering by activity or flow id to the applets dates endpoint via the `activityOrFlowId` parameter.

If the parameter is provided, the BE automatically determines which of the two is given, and filters accordingly.

### 🪤 Peer Testing

To test this, providing the `activityOrFlowId` parameter to the `/answers/applet/{applet_id}/dates` suffices. This can be tested providing either of the two (activity/flow ID)

### ✏️ Notes

Since this is an optional parameter, previous behavior isn't affected.