### PR TITLE
feat: Allow designating Single Selection items as response data identifiers (M2-8690)

### DIFF
--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -162,6 +162,7 @@ class _SelectionConfig(_ScreenConfig, PublicModel):
 class SingleSelectionConfig(_SelectionConfig, PublicModel):
     type: Literal[ResponseType.SINGLESELECT] | None
     auto_advance: bool = False
+    response_data_identifier: bool = False
 
 
 class MultiSelectionConfig(_SelectionConfig, PublicModel):

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -50,6 +50,7 @@ def single_select_config(default_config: DefaultConfig) -> SingleSelectionConfig
         set_alerts=False,
         add_tooltip=False,
         set_palette=False,
+        response_data_identifier=False,
         **default_config.dict(),
         type=ResponseType.SINGLESELECT,
     )

--- a/src/apps/activities/tests/unit/test_activity_item_change.py
+++ b/src/apps/activities/tests/unit/test_activity_item_change.py
@@ -388,6 +388,7 @@ def test_initial_single_selection_config_change(
         "Add Text Input Option was disabled",
         "Input Required was disabled",
         "Auto Advance was disabled",
+        "Response Data Identifier was disabled",
     ]
     assert changes == exp_changes
 
@@ -488,6 +489,7 @@ def test_initial_version_changes(
         "Add Text Input Option was disabled",
         "Input Required was disabled",
         "Auto Advance was disabled",
+        "Response Data Identifier was disabled",
     ]
     changes = item_change_service.get_changes_insert(new_item)
     assert changes == single_select_exp_changes

--- a/src/apps/jsonld_converter/service/document/field.py
+++ b/src/apps/jsonld_converter/service/document/field.py
@@ -342,6 +342,7 @@ class ReproFieldRadio(ReproFieldBase):
     ld_randomize_options: bool | None = None
     ld_scoring: bool | None = None
     ld_response_alert: bool | None = None
+    ld_is_response_identifier: bool | None = None
 
     is_multiple: bool = False
     choices: list[dict] | None = None
@@ -367,6 +368,7 @@ class ReproFieldRadio(ReproFieldBase):
             set_alerts=bool(self.ld_response_alert),
             add_tooltip=False,  # TODO
             set_palette=bool(self.ld_color_palette),  # TODO
+            response_data_identifier=bool(self.ld_is_response_identifier) if not self.is_multiple else None,
         )
         cfg_cls = MultiSelectionConfig if self.is_multiple else SingleSelectionConfig
 

--- a/src/apps/jsonld_converter/service/document/field.py
+++ b/src/apps/jsonld_converter/service/document/field.py
@@ -358,7 +358,9 @@ class ReproFieldRadio(ReproFieldBase):
         self.ld_randomize_options = self.attr_processor.get_attr_value(options_doc, "reproschema:randomizeOptions")
         self.ld_scoring = self.attr_processor.get_attr_value(options_doc, "reproschema:scoring")
         self.ld_response_alert = self.attr_processor.get_attr_value(options_doc, "reproschema:responseAlert")
-
+        self.ld_is_response_identifier = self.attr_processor.get_attr_value(
+            options_doc, "reproschema:isResponseIdentifier"
+        )
         self.choices = self._get_ld_choices_formatted(options_doc)
 
     def _build_config(self, _cls: Type | None, **attrs):

--- a/src/apps/jsonld_converter/service/export/activity_item.py
+++ b/src/apps/jsonld_converter/service/export/activity_item.py
@@ -144,6 +144,7 @@ class ActivityItemSingleSelectExport(ActivityItemBaseExport):
                 "valueType": "xsd:anyURI",  # todo tokens
                 "randomizeOptions": config.randomize_options,
                 "scoring": config.add_scores,
+                "isResponseIdentifier": config.response_data_identifier,
                 "responseAlert": config.set_alerts,
                 "colorPalette": config.set_palette,
                 "multipleChoice": False,

--- a/src/apps/test_data/service.py
+++ b/src/apps/test_data/service.py
@@ -181,6 +181,7 @@ class TestDataService:
             )
 
             result["response_values"] = None  # type: ignore  # noqa: E501
+
         elif type_ == ResponseType.SINGLESELECT:
             result["config"] = dict(
                 remove_back_button=False,
@@ -191,11 +192,13 @@ class TestDataService:
                 set_alerts=False,
                 add_tooltip=False,
                 set_palette=False,
+                response_data_identifier=False,
                 additional_response_option=dict(  # type: ignore  # noqa: E501
                     text_input_option=False,
                     text_input_required=False,
                 ),
             )
+
             result["response_values"] = {
                 "options": [  # type: ignore  # noqa: E501
                     {


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8690](https://mindlogger.atlassian.net/browse/M2-8690)

This change allows Single Selection item type to have the `response_data_identifier` configuration property, which up till now has only been supported by the Short Text item type.

### 🪤 Peer Testing

1. From FastAPI Swagger UI or Postman, authenticate then do a POST with this body to `/workspaces/{your_user_id}/applets` where `{your_user_id}` is replaced with an admin user's ID. (Hopefully it works, not sure if the `encryption` is user-specific?)
    <details>
      <summary>Expand for JSON</summary>
      <pre>
      {
          "displayName": "Applet",
          "description": {
              "en": ""
          },
          "themeId": null,
          "about": {
              "en": ""
          },
          "image": "",
          "watermark": "",
          "activities": [
              {
                  "name": "Activity",
                  "description": {
                      "en": ""
                  },
                  "showAllAtOnce": false,
                  "isSkippable": false,
                  "responseIsEditable": true,
                  "isHidden": false,
                  "autoAssign": true,
                  "isReviewable": false,
                  "items": [
                      {
                          "responseType": "singleSelect",
                          "name": "Item",
                          "question": {
                              "en": "Content"
                          },
                          "config": {
                              "removeBackButton": false,
                              "skippableItem": false,
                              "randomizeOptions": false,
                              "addScores": false,
                              "setAlerts": false,
                              "addTooltip": false,
                              "setPalette": false,
                              "timer": 0,
                              "additionalResponseOption": {
                                  "textInputOption": false,
                                  "textInputRequired": false
                              },
                              "portraitLayout": false,
                              "autoAdvance": false,
                              "responseDataIdentifier": true
                          },
                          "isHidden": false,
                          "allowEdit": true,
                          "responseValues": {
                              "options": [
                                  {
                                      "id": "334b4bb9-a424-466f-85bf-736314be5178",
                                      "text": "Option 1",
                                      "isHidden": false,
                                      "value": 0
                                  },
                                  {
                                      "id": "d27941c5-d134-4b74-a7ca-ba61ad8884ec",
                                      "text": "Option 2",
                                      "isHidden": false,
                                      "value": 1
                                  }
                              ]
                          }
                      }
                  ],
                  "scoresAndReports": {
                      "generateReport": false,
                      "reports": [],
                      "showScoreSummary": false
                  },
                  "key": "bf54a6c2-b1a1-4f90-8c1e-67a17f89eefb",
                  "reportIncludedItemName": ""
              }
          ],
          "activityFlows": [],
          "reportEmailBody": "Please see the report attached to this email.",
          "streamIpAddress": null,
          "streamPort": null,
          "encryption": {
              "publicKey": "[126,196,49,153,100,164,234,245,103,5,35,203,138,37,194,143,67,232,82,28,184,63,98,219,124,197,174,92,133,70,182,77,94,42,61,34,204,196,6,58,186,36,245,80,149,174,117,38,127,186,0,143,16,129,133,166,138,85,39,116,233,194,97,63,72,176,169,98,222,58,191,49,26,221,158,234,178,46,112,88,167,108,149,208,187,140,151,254,137,50,74,101,48,204,119,117,62,186,44,13,83,195,200,62,199,111,24,212,208,147,203,19,186,222,77,92,104,68,177,62,252,79,43,195,250,54,15,60]",
              "prime": "[145,81,247,158,61,18,219,202,232,226,212,174,111,182,150,2,124,131,141,217,20,249,196,189,199,196,207,95,5,52,165,181,243,87,37,128,31,187,107,38,34,134,129,167,201,71,221,179,234,206,184,156,159,153,69,255,92,94,216,92,123,213,75,229,157,100,42,138,122,46,115,197,82,150,22,65,122,143,9,1,9,34,18,10,239,223,17,113,111,203,244,74,115,61,18,215,18,168,123,39,236,18,244,253,181,111,215,221,106,188,21,6,44,91,150,49,151,218,39,73,254,108,160,249,81,35,165,67]",
              "base": "[2]",
              "accountId": "32fcb8ec-719e-4594-8de6-6194159045fb"
          }
      }
      </pre>
    </details>

    **Expected outcome:** The request should succeed, and the response should contain `"responseDataIdentifier": true` for the `singleSelect` item.
2. Using the same body JSON, but with `"responseDataIdentifier": false`, do a PUT to the `/applets/{applet_id}` endpoint.
    **Expected outcome:** The request should succeed, and the response should contain `"responseDataIdentifier": false` for the `singleSelect` item.