### PR TITLE
fix: Scheduling History Logic Fixes (M2-8494) (M2-8717) (M2-8725)

### DIFF
--- a/src/apps/schedule/crud/events.py
+++ b/src/apps/schedule/crud/events.py
@@ -323,7 +323,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
         )
         # select only always available if requested
         if only_always_available:
-            query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
+            query = query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
         query = query.where(EventSchema.applet_id == applet_id)
         query = query.where(EventSchema.is_deleted.is_(False))
 
@@ -368,10 +368,12 @@ class EventCRUD(BaseCRUD[EventSchema]):
             isouter=True,
         )
 
-        query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
-        query = query.where(EventSchema.applet_id == applet_id)
-        query = query.where(EventSchema.is_deleted.is_(False))
-        query = query.where(UserEventsSchema.user_id == respondent_id)
+        query = query.where(
+            EventSchema.periodicity == PeriodicityType.ALWAYS,
+            EventSchema.applet_id == applet_id,
+            EventSchema.is_deleted.is_(False),
+            UserEventsSchema.user_id == respondent_id,
+        )
         query = query.limit(1)
 
         result = await self._execute(query)
@@ -403,7 +405,7 @@ class EventCRUD(BaseCRUD[EventSchema]):
 
         # select only always available if requested
         if only_always_available:
-            query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
+            query = query.where(EventSchema.periodicity == PeriodicityType.ALWAYS)
 
         query = query.where(EventSchema.applet_id == applet_id)
         query = query.where(EventSchema.is_deleted.is_(False))

--- a/src/apps/schedule/service/schedule.py
+++ b/src/apps/schedule/service/schedule.py
@@ -8,6 +8,7 @@ from apps.applets.crud import AppletsCRUD, UserAppletAccessCRUD
 from apps.applets.errors import AppletNotFoundError
 from apps.schedule.crud.events import ActivityEventsCRUD, EventCRUD, FlowEventsCRUD, UserEventsCRUD
 from apps.schedule.crud.notification import NotificationCRUD, ReminderCRUD
+from apps.schedule.crud.schedule_history import NotificationHistoryCRUD, ReminderHistoryCRUD
 from apps.schedule.db.schemas import EventSchema, NotificationSchema
 from apps.schedule.domain.constants import DefaultEvent, PeriodicityType
 from apps.schedule.domain.schedule import BaseEvent
@@ -380,6 +381,8 @@ class ScheduleService:
                 except_event_id=schedule_id,
             )
 
+        old_event_version = event.version
+
         # Update event
         event = await EventCRUD(self.session).update(
             pk=schedule_id,
@@ -408,6 +411,11 @@ class ScheduleService:
         # Update notification
         await NotificationCRUD(self.session).delete_by_event_ids([schedule_id])
         await ReminderCRUD(self.session).delete_by_event_ids([schedule_id])
+
+        await asyncio.gather(
+            NotificationHistoryCRUD(self.session).mark_as_deleted([(event.id, old_event_version)]),
+            ReminderHistoryCRUD(self.session).mark_as_deleted([(event.id, old_event_version)]),
+        )
 
         notification_public = None
         if schedule.notification:

--- a/src/apps/schedule/service/schedule_history.py
+++ b/src/apps/schedule/service/schedule_history.py
@@ -27,6 +27,9 @@ class ScheduleHistoryService:
     async def add_history(self, applet_id: uuid.UUID, event: ScheduleEvent):
         applet = await AppletsCRUD(self.session).get_by_id(applet_id)
 
+        # Refresh the applet so we don't get the old version number, in case the version has changed
+        await self.session.refresh(applet)
+
         event_history = await ScheduleHistoryCRUD(self.session).add(
             EventHistorySchema(
                 start_time=event.start_time,


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8494](https://mindlogger.atlassian.net/browse/M2-8494)
🔗 [Jira Ticket M2-8717](https://mindlogger.atlassian.net/browse/M2-8717)
🔗 [Jira Ticket M2-8725](https://mindlogger.atlassian.net/browse/M2-8725)

This PR fixes the following issues:
- After adding a new activity to an applet, its entry to `applet_events` uses the old applet version number
- Adding a new scheduled event for an activity/flow removes all its previous scheduled event(s). There can be only one "always available" event, whereas many scheduled events per activity/flow should be allowed
- In the *notification_histories* table, the *is_deleted* column doesn't become `true` after removing the notification from the event
- In the *reminder_histories* table, the *is_deleted* column doesn’t become `true` after removing the reminder from the event

### 🪤 Peer Testing

#### `applet_event` applet version number

1. Create an applet with an activity
2. Save the applet
3. Inspect the `applet_events` table to ensure there's an entry for the applet
4. Add a new activity to the applet
5. Inspect the `applet_events` table to ensure there are now three (3) entries for the applet: the old one, and two new ones. They should all have the same event version number, but the new ones should use the new applet version number

#### Adding new scheduled event removes previous scheduled

1. Create an applet with an activity
2. Update the default event for the activity such that it has scheduled access (once, daily, etc.)
3. Click the plus button on the calendar to create a new, second scheduled access event for the same activity
4. Confirm that both events exist on the calendar

#### Notification and reminder histories

1. Create an applet with an activity
2. Edit the default event for the activity and add a single notification and reminder
3. Inspect the `notification_histories` and `reminder_histories` tables and confirm there are entries for the event
4. Edit the event again and remove the notification and reminder
5. Inspect the `notification_histories` and `reminder_histories` tables again and confirm that the entries have their `is_deleted` column set to `true`

### ✏️ Notes

N/A
