### PR TITLE
fix: Fix linking of individual events to new applet versions in `applet_events` (M2-8743)

### DIFF
--- a/src/apps/schedule/crud/events.py
+++ b/src/apps/schedule/crud/events.py
@@ -98,6 +98,14 @@ class EventCRUD(BaseCRUD[EventSchema]):
         result = await self._execute(query)
         return result.scalars().all()
 
+    async def get_all_by_applet_id(self, applet_id: uuid.UUID) -> list[EventSchema]:
+        """Return all events linked to a specific applet"""
+        query: Query = select(EventSchema)
+        query = query.where(EventSchema.applet_id == applet_id, EventSchema.is_deleted.is_(False))
+
+        result = await self._execute(query)
+        return result.scalars().all()
+
     async def get_public_by_applet_id(self, applet_id: uuid.UUID) -> list[EventSchema]:
         """Return event instance."""
         query: Query = select(EventSchema)

--- a/src/apps/schedule/service/schedule_history.py
+++ b/src/apps/schedule/service/schedule_history.py
@@ -100,7 +100,7 @@ class ScheduleHistoryService:
         This method is useful when an applet has its version bumped and the events are not updated. The previous entries
         in `applet_events` are not removed to maintain the history of the applet.
         """
-        events = await EventCRUD(self.session).get_all_by_applet_id_with_filter(applet_id)
+        events = await EventCRUD(self.session).get_all_by_applet_id(applet_id)
 
         if len(events) > 0:
             await AppletEventsCRUD(self.session).add_many(


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8743](https://mindlogger.atlassian.net/browse/M2-8743)

This PR updates the query being used to find all the events linked to an applet when that applet is updated. This list of events is used as the base for which rows get inserted into `applet_events` whenever the applet version changes without changing any event versions.

Previously, the query being used was excluding individual events by adding the condition `WHERE user_id = NULL`

### 🪤 Peer Testing

1. Create an applet with an activity
2. Save the applet
3. Go to the applet owner's PDP schedule tab and create an individual schedule for them
4. Update the applet name
5. Inspect the `applet_events` table to ensure there are entries for each of the events linked to both versions of the applet

This query may help

```sql
SELECT ae.applet_id, ae.event_id, eh.user_id, eh.activity_id
FROM applet_events ae
JOIN event_histories eh ON ae.event_id = eh.id_version
WHERE ae.applet_id ilike 'eb206e0f-7d1a-4f80-a1d1-dedc943e400b%'
ORDER BY ae.updated_at DESC;
```

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/000fddfd-5f49-4349-8955-e0abdbdac9e6" />

### ✏️ Notes

N/A
