### PR TITLE
fix: displays translated subscale q/a in dataviz and data export

### DIFF
--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -43,7 +43,7 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
         .join(ActivityItemSchema, ActivityHistorySchema.id == ActivityItemSchema.activity_id)
         .join(ActivitySchema, ActivityItemSchema.activity_id == ActivitySchema.id)
         .where(ActivityItemSchema.name == "age_screen", ActivitySchema.applet_id == applet_id)
-        .order_by(desc(ActivityHistorySchema.id_version))
+        .order_by(desc(ActivityHistorySchema.updated_at))
         .limit(1)
     )
 
@@ -136,7 +136,7 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
         subquery = (
             select(ActivityHistorySchema.id_version)
             .where(ActivityHistorySchema.id == item.activity_id)
-            .order_by(desc(ActivityHistorySchema.id_version))
+            .order_by(desc(ActivityHistorySchema.updated_at))
             .limit(1)
         )
 

--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -1,12 +1,17 @@
 import uuid
 from uuid import UUID
 
-from sqlalchemy import cast, func, select, update, desc
+from sqlalchemy import cast, desc, func, select, update
 from sqlalchemy.cimmutabledict import immutabledict
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.activities.db.schemas import ActivityItemSchema, ActivitySchema, ActivityHistorySchema, ActivityItemHistorySchema
+from apps.activities.db.schemas import (
+    ActivityHistorySchema,
+    ActivityItemHistorySchema,
+    ActivityItemSchema,
+    ActivitySchema,
+)
 
 
 async def update_age_screen(session: AsyncSession, applet_id: UUID):
@@ -37,10 +42,7 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
         select(ActivityHistorySchema.id_version)
         .join(ActivityItemSchema, ActivityHistorySchema.id == ActivityItemSchema.activity_id)
         .join(ActivitySchema, ActivityItemSchema.activity_id == ActivitySchema.id)
-        .where(
-            ActivityItemSchema.name == "age_screen",
-            ActivitySchema.applet_id == applet_id
-        )
+        .where(ActivityItemSchema.name == "age_screen", ActivitySchema.applet_id == applet_id)
         .order_by(desc(ActivityHistorySchema.id_version))
         .limit(1)
     )

--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -50,6 +50,8 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
     current_version_activity_id = await session.execute(subquery)
     current_version_activity_id = current_version_activity_id.scalar()
 
+    print("Current activity version id: ", current_version_activity_id)
+
     # Update the ActivityItemHistorySchema table
     update_history_query = (
         update(ActivityItemHistorySchema)
@@ -142,6 +144,8 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
 
         current_version_activity_id = await session.execute(subquery)
         current_version_activity_id = current_version_activity_id.scalar()
+
+        print("Current activity version id: ", current_version_activity_id)
 
         # Update the ActivityItemHistorySchema table
         update_history_response_values = func.jsonb_set(


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

When web and mobile submits answers, the gender question’s value is not the translated male/female string value, but instead the index of the selected radio button (eg. 0, 1)

When backend retrieves the answer (eg. via `/applet/{applet_id}/activities/{activity_id}/answers/{answer_id}`) it uses the activity history ID provided by the answer to retrieve that version of the activity and it’s items, which it then uses to reconstruct both the question and answer.

Although the `src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py` script translates the subscale questions and & answers in the `activity_items` table which is used to display the translated text in the web and mobile app, it needed to be update to update the corresponding values in the `activity_items_histories` table, which is where the text of the question & answer is ultimately retrieved from for dataviz and data export. 

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8750](https://mindlogger.atlassian.net/browse/M2-8750)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Updates the `m2_8568_update_subscale_items_to_greek.py` script to update the activity_items_histories table as well, based on the activity’s current version.

### 🪤 Peer Testing

- In the admin panel, create an applet with an activity that includes a subscale
- Apply the script to translate the subscale questions
`python src/cli.py patch exec M2-8568 -a "{applet_id}"`
- In the web or mobile app complete the activity
- In Admin Panel, view the submission and exported data
- **Expected outcome:** The age and gender subscale questions and answers should be in Greek


### ✏️ Notes

