### PR TITLE
feat: Add `updated_by` column to `event_histories` table (M2-8760)

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -125,7 +125,7 @@ async def applet_activities_for_subject(
         activities_future = ActivityService(session, user.id).get_single_language_with_items_by_applet_id(
             applet_id, language
         )
-        flows_future = FlowService(session).get_single_language_by_applet_id(applet_id, language)
+        flows_future = FlowService(session, admin_user_id=user.id).get_single_language_by_applet_id(applet_id, language)
 
         query_params = QueryParams(filters={"respondent_subject_id": subject_id, "target_subject_id": subject_id})
         assignments_future = ActivityAssignmentService(session).get_all_with_subject_entities(applet_id, query_params)
@@ -301,7 +301,7 @@ async def applet_activities_and_flows(
         activities_future = ActivityService(session, user.id).get_single_language_with_items_by_applet_id(
             applet_id, language
         )
-        flows_future = FlowService(session).get_full_flows(applet_id)
+        flows_future = FlowService(session, admin_user_id=user.id).get_full_flows(applet_id)
 
         activities, flows = await asyncio.gather(activities_future, flows_future)
 

--- a/src/apps/activities/services/activity.py
+++ b/src/apps/activities/services/activity.py
@@ -102,7 +102,7 @@ class ActivityService:
             activity_id_map[activity_item.activity_id].items.append(activity_item)
 
         # add default schedule for activities
-        await ScheduleService(self.session).create_default_schedules(
+        await ScheduleService(self.session, admin_user_id=self.user_id).create_default_schedules(
             applet_id=applet_id,
             activity_ids=[activity.id for activity in activities if not activity.is_reviewable],
             is_activity=True,
@@ -201,15 +201,15 @@ class ActivityService:
         # Remove events for deleted activities
         deleted_activity_ids = set(all_activity_ids) - set(existing_activities)
 
+        schedule_service = ScheduleService(self.session, admin_user_id=self.user_id)
+
         if deleted_activity_ids:
-            await ScheduleService(self.session).delete_by_activity_ids(
-                applet_id=applet_id, activity_ids=list(deleted_activity_ids)
-            )
+            await schedule_service.delete_by_activity_ids(applet_id=applet_id, activity_ids=list(deleted_activity_ids))
             await ActivityAssignmentService(self.session).delete_by_activity_or_flow_ids(list(deleted_activity_ids))
 
         # Create default events for new activities
         if new_activities:
-            await ScheduleService(self.session).create_default_schedules(
+            await schedule_service.create_default_schedules(
                 applet_id=applet_id,
                 activity_ids=list(new_activities),
                 is_activity=True,
@@ -230,7 +230,7 @@ class ActivityService:
 
             if respondents_with_indvdl_schdl:
                 for respondent_uuid in respondents_with_indvdl_schdl:
-                    await ScheduleService(self.session).create_default_schedules(
+                    await schedule_service.create_default_schedules(
                         applet_id=applet_id,
                         activity_ids=list(new_activities),
                         is_activity=True,

--- a/src/apps/activities/tests/test_activities.py
+++ b/src/apps/activities/tests/test_activities.py
@@ -876,7 +876,7 @@ class TestActivities:
             ],
         )
 
-        flows = await FlowService(session).update_create(
+        flows = await FlowService(session, lucy.id).update_create(
             empty_applet_lucy_manager.id,
             [
                 FlowUpdate(
@@ -1005,7 +1005,7 @@ class TestActivities:
             ],
         )
 
-        flows = await FlowService(session).update_create(
+        flows = await FlowService(session, lucy.id).update_create(
             empty_applet_lucy_manager.id,
             [
                 FlowUpdate(
@@ -1462,7 +1462,7 @@ class TestActivities:
             ],
         )
 
-        flows = await FlowService(session).update_create(
+        flows = await FlowService(session, lucy.id).update_create(
             empty_applet_lucy_manager.id,
             [
                 FlowUpdate(
@@ -1825,7 +1825,7 @@ class TestActivities:
             ],
         )
 
-        flows = await FlowService(session).update_create(
+        flows = await FlowService(session, lucy.id).update_create(
             empty_applet_lucy_manager.id,
             [
                 FlowUpdate(

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -214,7 +214,7 @@ async def flow_report_config_update(
     schema: ActivityFlowReportConfiguration = Body(...),
     session=Depends(get_session),
 ):
-    service = FlowService(session)
+    service = FlowService(session, admin_user_id=user.id)
     await AppletService(session, user.id).exist_by_id(applet_id)
     await CheckAccessService(session, user.id).check_applet_edit_access(applet_id)
     flow = await service.get_by_id(flow_id)
@@ -294,7 +294,7 @@ async def applet_flow_versions_data_retrieve(
 ) -> ResponseMulti[VersionPublic]:
     await AppletService(session, user.id).exist_by_id(applet_id)
     await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
-    service = FlowService(session=session)
+    service = FlowService(session=session, admin_user_id=user.id)
     versions = await service.get_versions(applet_id, flow_id)
     return ResponseMulti(
         result=versions,

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -132,7 +132,7 @@ class AppletService:
         for activity in applet.activities:
             activity_key_id_map[activity.key] = activity.id
 
-        applet.activity_flows = await FlowService(self.session).create(
+        applet.activity_flows = await FlowService(self.session, self.user_id).create(
             applet.id, create_data.activity_flows, activity_key_id_map
         )
         await FlowHistoryService(self.session, applet.id, applet.version).add(applet.activity_flows)
@@ -179,7 +179,8 @@ class AppletService:
 
         next_version = await self.get_next_version(old_applet_schema.version, update_data, applet_id)
 
-        await FlowService(self.session).remove_applet_flows(applet_id)
+        flow_service = FlowService(self.session, self.user_id)
+        await flow_service.remove_applet_flows(applet_id)
         await ActivityService(self.session, self.user_id).remove_applet_activities(applet_id)
         applet = await self._update(applet_id, update_data, next_version)
         await AppletHistoryService(self.session, applet.id, applet.version).add_history(self.user_id, applet)
@@ -200,12 +201,12 @@ class AppletService:
             activity_ids.append(activity.id)
             if activity.is_reviewable:
                 assessment_id = activity.id
-        applet.activity_flows = await FlowService(self.session).update_create(
+        applet.activity_flows = await flow_service.update_create(
             applet_id, update_data.activity_flows, activity_key_id_map
         )
         await FlowHistoryService(self.session, applet.id, applet.version).add(applet.activity_flows)
 
-        event_serv = ScheduleService(self.session)
+        event_serv = ScheduleService(self.session, admin_user_id=self.user_id)
         to_await = []
         if assessment_id:
             to_await.append(event_serv.delete_by_activity_ids(applet_id, [assessment_id]))
@@ -262,7 +263,7 @@ class AppletService:
         for activity in applet.activities:
             activity_key_id_map[activity.key] = activity.id
 
-        applet.activity_flows = await FlowService(self.session).create(
+        applet.activity_flows = await FlowService(self.session, self.user_id).create(
             applet.id, create_data.activity_flows, activity_key_id_map
         )
         await FlowHistoryService(self.session, applet.id, applet.version).add(applet.activity_flows)
@@ -514,7 +515,7 @@ class AppletService:
             stream_port=schema.stream_port,
         )
         activities = ActivityService(self.session, self.user_id).get_single_language_by_applet_id(applet_id, language)
-        activity_flows = FlowService(self.session).get_single_language_by_applet_id(applet_id, language)
+        activity_flows = FlowService(self.session, self.user_id).get_single_language_by_applet_id(applet_id, language)
         integrations = IntegrationsCRUD(self.session).retrieve_list_by_applet(schema.id)
         futures = await asyncio.gather(activities, activity_flows, integrations)
         applet.activities = futures[0]
@@ -557,7 +558,9 @@ class AppletService:
         applet.activities = await ActivityService(self.session, self.user_id).get_single_language_by_applet_id(
             applet.id, language
         )
-        applet.activity_flows = await FlowService(self.session).get_single_language_by_applet_id(applet.id, language)
+        applet.activity_flows = await FlowService(self.session, self.user_id).get_single_language_by_applet_id(
+            applet.id, language
+        )
         return applet
 
     async def get_by_id_for_duplicate(self, applet_id: uuid.UUID) -> AppletDuplicate:
@@ -588,7 +591,7 @@ class AppletService:
             retention_type=schema.retention_type,
         )
         applet.activities = await ActivityService(self.session, self.user_id).get_by_applet_id_for_duplicate(applet_id)
-        applet.activity_flows = await FlowService(self.session).get_by_applet_id_duplicate(applet_id)
+        applet.activity_flows = await FlowService(self.session, self.user_id).get_by_applet_id_duplicate(applet_id)
         return applet
 
     async def delete_applet_by_id(self, applet_id: uuid.UUID):
@@ -719,7 +722,7 @@ class AppletService:
         schema = await AppletsCRUD(self.session).get_by_id(applet_id)
         applet = AppletFull.from_orm(schema)
         applet.activities = await ActivityService(self.session, self.user_id).get_full_activities(applet_id)
-        applet.activity_flows = await FlowService(self.session).get_full_flows(applet_id)
+        applet.activity_flows = await FlowService(self.session, self.user_id).get_full_flows(applet_id)
         applet_owner = await UserAppletAccessCRUD(self.session).get_applet_owner(applet_id)
         applet.owner_id = applet_owner.owner_id
 
@@ -788,7 +791,7 @@ class AppletService:
             activity_flows=[],
         )
         activities = ActivityService(self.session, self.user_id).get_info_by_applet_id(schema.id, language)
-        activity_flows = FlowService(self.session).get_info_by_applet_id(schema.id, language)
+        activity_flows = FlowService(self.session, self.user_id).get_info_by_applet_id(schema.id, language)
         subject = SubjectsService(self.session, self.user_id).get_by_user_and_applet(self.user_id, schema.id)
         futures = await asyncio.gather(activities, activity_flows, subject)
         applet.activities = futures[0]

--- a/src/apps/schedule/api/schedule.py
+++ b/src/apps/schedule/api/schedule.py
@@ -41,7 +41,7 @@ async def schedule_create(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         schedule = await service.create_schedule(schema, applet_id)
 
     try:
@@ -74,7 +74,9 @@ async def schedule_get_by_id(
     """Get a schedule by id."""
     async with atomic(session):
         await AppletService(session, user.id).exist_by_id(applet_id)
-        schedule = await ScheduleService(session).get_schedule_by_id(applet_id=applet_id, schedule_id=schedule_id)
+        schedule = await ScheduleService(session, admin_user_id=user.id).get_schedule_by_id(
+            applet_id=applet_id, schedule_id=schedule_id
+        )
     return Response(result=schedule)
 
 
@@ -100,7 +102,9 @@ async def schedule_get_all(
         if not roles & accessed_roles:
             raise UserDoesNotHavePermissionError()
 
-        public_events = await ScheduleService(session).get_all_schedules(applet_id, deepcopy(query_params))
+        public_events = await ScheduleService(session, admin_user_id=user.id).get_all_schedules(
+            applet_id, deepcopy(query_params)
+        )
 
     return ResponseMulti(result=public_events, count=len(public_events))
 
@@ -127,7 +131,7 @@ async def schedule_delete_all(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         await service.delete_all_schedules(applet_id)
 
     try:
@@ -156,7 +160,7 @@ async def schedule_delete_by_id(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         respondent_id = await service.delete_schedule_by_id(schedule_id)
 
     try:
@@ -191,7 +195,7 @@ async def schedule_update(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         public_event = await service.update_schedule(applet_id, schedule_id, schema)
 
     try:
@@ -223,7 +227,7 @@ async def schedule_count(
     """Get the count of schedules for an applet."""
     async with atomic(session):
         await AppletService(session, user.id).exist_by_id(applet_id)
-        count: PublicEventCount = await ScheduleService(session).count_schedules(applet_id)
+        count: PublicEventCount = await ScheduleService(session, admin_user_id=user.id).count_schedules(applet_id)
     return Response(result=count)
 
 
@@ -238,7 +242,7 @@ async def schedule_delete_by_user(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         await service.delete_by_user_id(applet_id=applet_id, user_id=respondent_id)
 
     try:
@@ -260,8 +264,10 @@ async def schedule_get_all_by_user(
 ) -> ResponseMulti[PublicEventByUser]:
     """Get all schedules for a user."""
     async with atomic(session):
-        public_events_by_user = await ScheduleService(session).get_events_by_user(user_id=user.id)
-        count = await ScheduleService(session).count_events_by_user(user_id=user.id)
+        public_events_by_user = await ScheduleService(session, admin_user_id=user.id).get_events_by_user(
+            user_id=user.id
+        )
+        count = await ScheduleService(session, admin_user_id=user.id).count_events_by_user(user_id=user.id)
     return ResponseMulti(result=public_events_by_user, count=count)
 
 
@@ -295,7 +301,7 @@ async def schedule_get_all_by_respondent_user(
         )
         applet_ids: list[uuid.UUID] = [applet.id for applet in applets]
 
-        public_events_by_user = await ScheduleService(session).get_upcoming_events_by_user(
+        public_events_by_user = await ScheduleService(session, admin_user_id=user.id).get_upcoming_events_by_user(
             user_id=user.id,
             applet_ids=applet_ids,
             min_end_date=min_end_date,
@@ -316,7 +322,7 @@ async def schedule_get_by_user(
     """Get all schedules for a respondent per applet id."""
     async with atomic(session):
         await AppletService(session, user.id).exist_by_id(applet_id)
-        public_event_by_user = await ScheduleService(session).get_events_by_user_and_applet(
+        public_event_by_user = await ScheduleService(session, admin_user_id=user.id).get_events_by_user_and_applet(
             user_id=user.id, applet_id=applet_id
         )
     return Response(result=public_event_by_user)
@@ -333,7 +339,7 @@ async def schedule_remove_individual_calendar(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         await service.remove_individual_calendar(applet_id=applet_id, user_id=respondent_id)
     try:
         await applet_service.send_notification_to_applet_respondents(
@@ -359,7 +365,7 @@ async def schedule_import(
     """Create a new event for an applet."""
     async with atomic(session):
         await AppletService(session, user.id).exist_by_id(applet_id)
-        schedules = await ScheduleService(session).import_schedule(event_requests, applet_id)
+        schedules = await ScheduleService(session, admin_user_id=user.id).import_schedule(event_requests, applet_id)
     return ResponseMulti(
         result=schedules,
         count=len(schedules),
@@ -379,7 +385,7 @@ async def schedule_create_individual(
     async with atomic(session):
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_applet_schedule_create_access(applet_id)
-        service = ScheduleService(session)
+        service = ScheduleService(session, admin_user_id=user.id)
         schedules = await service.create_schedule_individual(applet_id, respondent_id)
 
     try:

--- a/src/apps/schedule/db/schemas.py
+++ b/src/apps/schedule/db/schemas.py
@@ -16,7 +16,6 @@ class _BaseEventSchema:
     timer_type = Column(String(10), nullable=False)  # NOT_SET, TIMER, IDLE
     version = Column(
         String(13),
-        nullable=True,
         default=lambda: datetime.datetime.now(datetime.UTC).strftime("%Y%m%d") + "-1",
         server_default=text("TO_CHAR(timezone('utc', now()), 'YYYYMMDD') || '-1'"),
     )
@@ -44,6 +43,7 @@ class EventHistorySchema(_BaseEventSchema, HistoryAware, Base):
     id_version = Column(String(), primary_key=True)
     id = Column(UUID(as_uuid=True))
     user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=True)
+    updated_by = Column(UUID(as_uuid=True), nullable=True)
 
 
 class AppletEventsSchema(Base):
@@ -108,7 +108,7 @@ class UserDeviceEventsHistorySchema(Base):
 
     unique_constraint = "_unique_user_device_events_history"
 
-    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=True)
+    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"))
     device_id = Column(String(255), nullable=False)
     os_name = Column(Text, nullable=True)
     os_version = Column(Text, nullable=True)

--- a/src/apps/schedule/service/schedule.py
+++ b/src/apps/schedule/service/schedule.py
@@ -49,8 +49,9 @@ __all__ = ["ScheduleService"]
 
 
 class ScheduleService:
-    def __init__(self, session):
+    def __init__(self, session, admin_user_id: uuid.UUID | None = None):
         self.session = session
+        self.admin_user_id = admin_user_id
 
     async def create_schedule(self, schedule: EventRequest, applet_id: uuid.UUID) -> PublicEvent:
         # Validate schedule data before saving
@@ -154,8 +155,7 @@ class ScheduleService:
             )
 
         await ScheduleHistoryService(self.session).add_history(
-            event=schedule_event,
-            applet_id=applet_id,
+            event=schedule_event, applet_id=applet_id, updated_by=self.admin_user_id
         )
 
         return PublicEvent(
@@ -444,6 +444,7 @@ class ScheduleService:
         await ScheduleHistoryService(self.session).add_history(
             event=schedule_event,
             applet_id=applet_id,
+            updated_by=self.admin_user_id,
         )
 
         return PublicEvent(

--- a/src/apps/schedule/service/schedule_history.py
+++ b/src/apps/schedule/service/schedule_history.py
@@ -27,7 +27,7 @@ class ScheduleHistoryService:
     async def get_by_id(self, id_version: str) -> EventHistorySchema | None:
         return await ScheduleHistoryCRUD(self.session).get_by_id(id_version)
 
-    async def add_history(self, applet_id: uuid.UUID, event: ScheduleEvent):
+    async def add_history(self, applet_id: uuid.UUID, event: ScheduleEvent, updated_by: uuid.UUID | None) -> None:
         applet = await AppletsCRUD(self.session).get_by_id(applet_id)
 
         # Refresh the applet so we don't get the old version number, in case the version has changed
@@ -52,6 +52,7 @@ class ScheduleHistoryService:
                 activity_id=event.activity_id,
                 activity_flow_id=event.flow_id,
                 user_id=event.user_id,
+                updated_by=updated_by,
             )
         )
 

--- a/src/infrastructure/database/migrations/versions/2025_02_27_06_57-add_updated_by_column.py
+++ b/src/infrastructure/database/migrations/versions/2025_02_27_06_57-add_updated_by_column.py
@@ -1,0 +1,67 @@
+"""Add updated_by column
+
+Revision ID: a9cd537fa8b4
+Revises: 4e2b42e69c39
+Create Date: 2025-02-27 06:57:54.848199
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a9cd537fa8b4"
+down_revision = "4e2b42e69c39"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add updated_by column to event_histories table
+    op.add_column("event_histories", sa.Column("updated_by", postgresql.UUID(as_uuid=True), nullable=True))
+
+    # Fix the definitions of some existing columns to match the schema in code
+
+    op.drop_constraint("_unique_user_device_events_history", "user_device_events_history", type_="unique")
+
+    # Forgot to include the user_id column in the unique constraint the first time
+    op.create_unique_constraint(
+        "_unique_user_device_events_history",
+        "user_device_events_history",
+        ["user_id", "device_id", "event_id", "event_version"],
+    )
+
+    op.drop_constraint("fk_user_device_events_history_user_id_users", "user_device_events_history", type_="foreignkey")
+
+    # This was defined as `CASCADE` in the original migration, but should be `RESTRICT`
+    op.create_foreign_key(
+        op.f("fk_user_device_events_history_user_id_users"),
+        "user_device_events_history",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_user_device_events_history_user_id_users"), "user_device_events_history", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "fk_user_device_events_history_user_id_users",
+        "user_device_events_history",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("_unique_user_device_events_history", "user_device_events_history", type_="unique")
+    op.create_unique_constraint(
+        "_unique_user_device_events_history", "user_device_events_history", ["device_id", "event_id", "event_version"]
+    )
+
+    op.drop_column("event_histories", "updated_by")
+    # ### end Alembic commands ###

--- a/src/infrastructure/database/migrations/versions/2025_02_27_12_23-add_updated_by_column.py
+++ b/src/infrastructure/database/migrations/versions/2025_02_27_12_23-add_updated_by_column.py
@@ -1,7 +1,7 @@
 """Add updated_by column
 
 Revision ID: a9cd537fa8b4
-Revises: 4e2b42e69c39
+Revises: a620e11dda13
 Create Date: 2025-02-27 06:57:54.848199
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "a9cd537fa8b4"
-down_revision = "4e2b42e69c39"
+down_revision = "a620e11dda13"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8760](https://mindlogger.atlassian.net/browse/M2-8760)

This PR adds a new nullable column called `updated_by` to the `event_histories` table that tracks the logged-in user who submits an update to an event that creates a new version, including the first version.

The column is not back-filled for existing records, so they will remain `null`.

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/527bae32-5dd5-4b92-b2c4-89436244ecb5" />

I've also done a bit of other cleaning up in this PR based on things I noticed that were out of line:
- Updated the `_unique_user_device_events_history` unique constraint to include the `user_id` column. I forgot to include this in the previous migration
- Updated the `fk_user_device_events_history_user_id_users` foreign key to be `RESTRICT` instead of `CASCADE`. This is in line with the code
- Removed `nullable=True` from the version column in the event schemas classes
- Removed `nullable=True` from the `user_id` field of the `UserDeviceEventsHistorySchema` class

### 🪤 Peer Testing

1. Create an activity
2. Inspect the row for that activity in `event_histories`
3. Confirm that the `updated_by` column matches the user ID of the admin user who create the activity
4. If there are existing records in your table, confirm that the `updated_by` column is `null` for them


### ✏️ Notes

~This was a last minute request from @yenepallisai and I'm confirming whether this should be the user's ID or something else. I expect it will be the user's ID though~ This doesn't matter until it's actually in the export