### PR TITLE
fix: Prolific - if the study validation fails on submission nothing i…

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -53,7 +53,6 @@ from apps.applets.errors import InvalidVersionError, NotValidAppletHistory
 from apps.applets.service import AppletHistoryService, AppletService
 from apps.authentication.deps import get_current_user
 from apps.integrations.prolific.domain import ProlificUserInfo
-from apps.integrations.prolific.service.prolific import ProlificIntegrationService
 from apps.schedule.crud.user_device_events_history import UserDeviceEventsHistoryCRUD
 from apps.schedule.service.schedule_history import ScheduleHistoryService
 from apps.shared.deps import get_client_ip, get_i18n
@@ -122,23 +121,17 @@ async def create_anonymous_answer(
     tz_offset: int | None = Depends(get_tz_utc_offset()),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
-    language=Depends(get_language),
 ) -> None:
     async with atomic(session):
         respondent = None
         if schema.prolific_params:
-            study_validation = await ProlificIntegrationService(
-                session=session, applet_id=schema.applet_id
-            ).validate_prolific_study(schema.prolific_params.study_id, language, is_private_applet_id=True)
-
-            if study_validation.accepted:
-                prolific_service = ProlificUserService(
-                    session,
-                    ProlificUserInfo(
-                        study_id=schema.prolific_params.study_id, prolific_pid=schema.prolific_params.prolific_pid
-                    ),
-                )
-                respondent = await prolific_service.create_prolific_respondent(schema.applet_id)
+            prolific_service = ProlificUserService(
+                session,
+                ProlificUserInfo(
+                    study_id=schema.prolific_params.study_id, prolific_pid=schema.prolific_params.prolific_pid
+                ),
+            )
+            respondent = await prolific_service.create_prolific_respondent(schema.applet_id)
         else:
             respondent = await UsersCRUD(session).get_anonymous_respondent()
         assert respondent

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -70,7 +70,6 @@ from apps.workspaces.service.workspace import WorkspaceService
 from infrastructure.database import atomic, session_manager
 from infrastructure.database.deps import get_session
 from infrastructure.http import get_tz_utc_offset
-from infrastructure.http.deps import get_language
 from infrastructure.logger import logger
 
 


### PR DESCRIPTION
…s thrown

- Add a raise of ProlificInvalidStudy when the study couldn't be validated on answer submission

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description
If a prolific user submits their answer but the api token is invalid, nothing happens while in the backend an unexpected exception is raised. This PR is for fixing this behavior, we remove the validation on answers submission and wait that the answers are saved before raising and invalid study (The raise happens on completion code retrieval).

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8836](https://mindlogger.atlassian.net/browse/M2-8836)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Removed the validation of the study when the answers are the submitted.