### PR TITLE
fix: Update event_history_id validation (M2-8482)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -94,8 +94,7 @@ async def create_answer(
             event = await ScheduleHistoryService(session).get_by_id(schema.event_history_id)
             if (
                 event is None
-                or event.activity_flow_id != schema.flow_id
-                or event.activity_id != schema.activity_id
+                or (event.activity_flow_id != schema.flow_id and event.activity_id != schema.activity_id)
                 or (event.user_id is not None and event.user_id != user.id)
             ):
                 raise NotFoundError("Invalid event_history_id provided")

--- a/src/apps/answers/tests/conftest.py
+++ b/src/apps/answers/tests/conftest.py
@@ -310,19 +310,19 @@ def public_answer_create(
 
 @pytest.fixture
 def answer_with_flow_create(
-    applet: AppletFull,
+    applet_with_flow: AppletFull,
     answer_item_create: ItemAnswerCreate,
     client_meta: ClientMeta,
 ) -> AppletAnswerCreate:
     return AppletAnswerCreate(
-        applet_id=applet.id,
-        version=applet.version,
+        applet_id=applet_with_flow.id,
+        version=applet_with_flow.version,
         submit_id=uuid.uuid4(),
-        activity_id=applet.activities[0].id,
+        activity_id=applet_with_flow.activities[0].id,
         answer=answer_item_create,
         created_at=datetime.datetime.now(datetime.UTC).replace(microsecond=0),
         client=client_meta,
-        flow_id=applet.activity_flows[0].id,
+        flow_id=applet_with_flow.activity_flows[0].id,
         is_flow_completed=True,
         consent_to_share=False,
     )


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8482](https://mindlogger.atlassian.net/browse/M2-8482)

This PR updates the validation of the `event_history_id` property in the answer data to work for both activities and flows. Previously it was only working for activities.

The reason it failed is because of an assumption that the `event` data contains both the activity and the flow ID, but this is not the case, it only has one or the other. Thus, we can only perform one comparison based on what type of submission is being done.

### 🪤 Peer Testing

1. Create an applet with an activity flow
2. Submit the flow via the mobile app
3. Profit (Confirm that the submission works)


### ✏️ Notes

N/A