### PR TITLE
Update Greek translations for age_screen and gender_screen items (M2-8840)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,13 +487,12 @@ python src/cli.py patch exec M2-8568 -a <applet_id>
 
 #### Note: You can use environment variables to overwrite default values.
 
-#### AGE_SCREEN_QUESTION_TRANSLATION to update the question value for the age screen.
-
-#### GENDER_SCREEN_QUESTION_TRANSLATION to update the question value for the gender screen.
-
-#### GENDER_SCREEN_RESPONSE_MALE_TRANSLATION to update the response value for the male option.
-
-#### GENDER_SCREEN_RESPONSE_FEMALE_TRANSLATION to update the response value for the female option.
+| Environment variable | Text string |
+| - | - |
+| `AGE_SCREEN_QUESTION_TRANSLATION` | Question text for the Age screen |
+| `GENDER_SCREEN_QUESTION_TRANSLATION` | Question text for the Gender screen |
+| `GENDER_SCREEN_RESPONSE_MALE_TRANSLATION` | "Male" response text |
+| `GENDER_SCREEN_RESPONSE_FEMALE_TRANSLATION` | "Female" response text |
 
 ### Database relation structure
 

--- a/README.md
+++ b/README.md
@@ -479,13 +479,23 @@ delete from alembic_version;
 alembic -c alembic_arbitrary.ini upgrade head
 ```
 
-### Update gender_screen and age_screen activity items strings to greek for an applet
+#### Update gender_screen and age_screen activity items strings to greek for an applet
 
 ```bash
 python src/cli.py patch exec M2-8568 -a <applet_id> 
 ```
 
-#### Database relation structure
+#### Note: You can use environment variables to overwrite default values.
+
+#### AGE_SCREEN_QUESTION_TRANSLATION to update the question value for the age screen.
+
+#### GENDER_SCREEN_QUESTION_TRANSLATION to update the question value for the gender screen.
+
+#### GENDER_SCREEN_RESPONSE_MALE_TRANSLATION to update the response value for the male option.
+
+#### GENDER_SCREEN_RESPONSE_FEMALE_TRANSLATION to update the response value for the female option.
+
+### Database relation structure
 
 ```mermaid
 

--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -114,9 +114,7 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
             (
                 index
                 for (index, option) in enumerate(item.response_values["options"])
-                if option["text"] == "Male"
-                or option["text"] == translations["Male"]
-                or option["text"] == "Ανδρας"  # This will fix typo for "male" in previous versions
+                if option["value"] == 0  # male option will always have value 0
             ),
             -1,
         )
@@ -125,7 +123,7 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
             (
                 index
                 for (index, option) in enumerate(item.response_values["options"])
-                if option["text"] == "Female" or option["text"] == translations["Female"]
+                if option["value"] == 1  # female option will always have value 1
             ),
             -1,
         )

--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from uuid import UUID
 
@@ -13,11 +14,17 @@ from apps.activities.db.schemas import (
     ActivitySchema,
 )
 
+# Note: You can use environment variables to overwrite default values.
+# AGE_SCREEN_QUESTION_TRANSLATION to update the question value for the age screen.
+# GENDER_SCREEN_QUESTION_TRANSLATION to update the question value for the gender screen.
+# GENDER_SCREEN_RESPONSE_MALE_TRANSLATION to update the response value for the male option.
+# GENDER_SCREEN_RESPONSE_FEMALE_TRANSLATION to update the response value for the female option.
+
 
 async def update_age_screen(session: AsyncSession, applet_id: UUID):
     print(f"Updating age screen for applet_id: {applet_id}")
 
-    new_question_value = {"el": "Ηλικία:"}
+    new_question_value = os.environ.get("AGE_SCREEN_QUESTION_TRANSLATION", "Ηλικία:")
 
     update_query = (
         update(ActivityItemSchema)
@@ -29,7 +36,7 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
             question=func.jsonb_set(
                 ActivityItemSchema.question,
                 ["en"],
-                cast(new_question_value["el"], JSONB),
+                cast(new_question_value, JSONB),
                 True,
             )
         )
@@ -71,7 +78,7 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
                 question=func.jsonb_set(
                     ActivityItemHistorySchema.question,
                     ["en"],
-                    cast(new_question_value["el"], JSONB),
+                    cast(new_question_value, JSONB),
                     True,
                 )
             )
@@ -84,11 +91,11 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
 
 async def update_gender_screen(session: AsyncSession, applet_id: UUID):
     print(f"Updating gender screen for applet_id: {applet_id}")
-    new_question_value = {"el": "Φύλο:"}
+    new_question_value = os.environ.get("GENDER_SCREEN_QUESTION_TRANSLATION", "Φύλο:")
 
     translations = {
-        "Male": "Άντρας",
-        "Female": "Γυναίκα",
+        "Male": os.environ.get("GENDER_SCREEN_RESPONSE_MALE_TRANSLATION", "Άντρας"),
+        "Female": os.environ.get("GENDER_SCREEN_RESPONSE_FEMALE_TRANSLATION", "Γυναίκα"),
     }
 
     query = select(ActivityItemSchema.id, ActivityItemSchema.response_values, ActivityItemSchema.activity_id).where(
@@ -148,7 +155,7 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
                 question=func.jsonb_set(
                     ActivityItemSchema.question,
                     ["en"],
-                    cast(new_question_value["el"], JSONB),
+                    cast(new_question_value, JSONB),
                     True,
                 ),
                 response_values=update_response_values,
@@ -193,7 +200,7 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
                 question=func.jsonb_set(
                     ActivityItemHistorySchema.question,
                     ["en"],
-                    cast(new_question_value["el"], JSONB),
+                    cast(new_question_value, JSONB),
                     True,
                 ),
                 response_values=update_history_response_values,

--- a/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
+++ b/src/apps/shared/commands/patches/m2_8568_update_subscale_items_to_greek.py
@@ -17,7 +17,7 @@ from apps.activities.db.schemas import (
 async def update_age_screen(session: AsyncSession, applet_id: UUID):
     print(f"Updating age screen for applet_id: {applet_id}")
 
-    new_question_value = {"el": "Πόσων χρονών είστε;"}
+    new_question_value = {"el": "Ηλικία:"}
 
     update_query = (
         update(ActivityItemSchema)
@@ -84,7 +84,7 @@ async def update_age_screen(session: AsyncSession, applet_id: UUID):
 
 async def update_gender_screen(session: AsyncSession, applet_id: UUID):
     print(f"Updating gender screen for applet_id: {applet_id}")
-    new_question_value = {"el": "Ποιο φύλο σας αποδόθηκε κατά την γέννησή σας;"}
+    new_question_value = {"el": "Φύλο:"}
 
     translations = {
         "Male": "Άντρας",
@@ -101,12 +101,26 @@ async def update_gender_screen(session: AsyncSession, applet_id: UUID):
     for item in res.mappings().all():
         print(f"Updating item id: {item.id}")
 
+        # Checking for male/female index response_values, even for already translated items,
+        # this will make sure this script always update items to new translations
         male_index = next(
-            (index for (index, option) in enumerate(item.response_values["options"]) if option["text"] == "Male"), -1
+            (
+                index
+                for (index, option) in enumerate(item.response_values["options"])
+                if option["text"] == "Male"
+                or option["text"] == translations["Male"]
+                or option["text"] == "Ανδρας"  # This will fix typo for "male" in previous versions
+            ),
+            -1,
         )
 
         female_index = next(
-            (index for (index, option) in enumerate(item.response_values["options"]) if option["text"] == "Female"), -1
+            (
+                index
+                for (index, option) in enumerate(item.response_values["options"])
+                if option["text"] == "Female" or option["text"] == translations["Female"]
+            ),
+            -1,
         )
 
         if (male_index == -1) or (female_index == -1):


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

- Changed age question to "Ηλικία:" in Greek.
- Updated gender question to "Φύλο:" in Greek.
- Ensured consistent updates for male/female options.


<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8840](https://mindlogger.atlassian.net/browse/M2-8840)


