### PR TITLE
feat: Add item_type column to data export (M2-8276)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -735,6 +735,7 @@ async def applet_answers_export(
         applet_id, query_params, activities_last_version
     )
     total_answers = data.total_answers
+    await AnswerService(session, user.id, answer_session).map_answer_item_types(data.answers, data.activities)
     for answer in data.answers:
         if answer.is_manager:
             answer.respondent_secret_id = f"[admin account] ({answer.respondent_secret_id})"

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -585,6 +585,7 @@ class UserAnswerDataBase(BaseModel):
     created_at: datetime.datetime
     migrated_data: dict | None = None
     client: ClientMeta | None = None
+    item_type: dict[str, ItemType] = {}
 
 
 class RespondentAnswerData(UserAnswerDataBase, InternalModel):

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 from copy import deepcopy
+from enum import Enum
 from typing import Any, Generic
 
 from pydantic import BaseModel, Field, root_validator, validator
@@ -23,6 +24,27 @@ from apps.shared.domain.custom_validations import datetime_from_ms
 from apps.shared.domain.types import _BaseModel
 from apps.shared.locale import I18N
 from apps.subjects.domain import SubjectReadResponse
+
+
+class ItemType(str, Enum):
+    SINGLE_SELECTION = "single_selection"
+    MULTIPLE_SELECTION = "multiple_selection"
+    DISCRETE_SLIDER = "discrete_slider"
+    CONTINUOUS_SLIDER = "continuous_slider"
+    DATE = "date"
+    TIME = "time"
+    TIME_RANGE = "time_range"
+    SINGLE_SELECTION_PER_ROW = "single_selection_per_row"
+    MULTIPLE_SELECTION_PER_ROW = "multiple_selection_per_row"
+    DISCRETE_SLIDER_PER_ROW = "discrete_slider_per_row"
+    CONTINUOUS_SLIDER_PER_ROW = "continuous_slider_per_row"
+    TEXT = "text"
+    DRAWING = "drawing"
+    PHOTO = "photo"
+    VIDEO = "video"
+    GEOLOCATION = "geolocation"
+    AUDIO = "audio"
+    AUDIO_PLAYER = "audio_player"
 
 
 class ClientMeta(InternalModel):

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1331,9 +1331,6 @@ class AnswerService:
                 activity_items_map[str(item.id)] = item
 
         for answer in answers:
-            if not hasattr(answer, "item_type") or answer.item_type is None:
-                answer.item_type = {}
-
             for item_id in answer.item_ids:
                 if item := activity_items_map.get(item_id):
                     config = item.config

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1332,48 +1332,46 @@ class AnswerService:
 
         for answer in answers:
             for item_id in answer.item_ids:
-                item = activity_items_map.get(item_id)
-                if not item:
-                    continue
+                if (_item := activity_items_map.get(item_id)) is not None:
+                    item = _item
+                    config = item.config
+                    response_type = item.response_type
 
-                config = item.config
-                response_type = item.response_type
-
-                if response_type == ResponseType.SLIDER:
-                    if getattr(config, "is_discrete", False):
-                        answer.item_type[item_id] = ItemType.DISCRETE_SLIDER
-                    else:
-                        answer.item_type[item_id] = ItemType.CONTINUOUS_SLIDER
-                elif response_type == ResponseType.SINGLESELECT:
-                    if getattr(config, "is_per_row", False):
-                        answer.item_type[item_id] = ItemType.SINGLE_SELECTION_PER_ROW
-                    else:
-                        answer.item_type[item_id] = ItemType.SINGLE_SELECTION
-                elif response_type == ResponseType.MULTISELECT:
-                    if getattr(config, "is_per_row", False):
-                        answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION_PER_ROW
-                    else:
-                        answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION
-                elif response_type == ResponseType.DATE:
-                    answer.item_type[item_id] = ItemType.DATE
-                elif response_type == ResponseType.TIME:
-                    answer.item_type[item_id] = ItemType.TIME
-                elif response_type == ResponseType.TIMERANGE:
-                    answer.item_type[item_id] = ItemType.TIME_RANGE
-                elif response_type == ResponseType.TEXT:
-                    answer.item_type[item_id] = ItemType.TEXT
-                elif response_type == ResponseType.DRAWING:
-                    answer.item_type[item_id] = ItemType.DRAWING
-                elif response_type == ResponseType.PHOTO:
-                    answer.item_type[item_id] = ItemType.PHOTO
-                elif response_type == ResponseType.VIDEO:
-                    answer.item_type[item_id] = ItemType.VIDEO
-                elif response_type == ResponseType.GEOLOCATION:
-                    answer.item_type[item_id] = ItemType.GEOLOCATION
-                elif response_type == ResponseType.AUDIO:
-                    answer.item_type[item_id] = ItemType.AUDIO
-                elif response_type == ResponseType.AUDIOPLAYER:
-                    answer.item_type[item_id] = ItemType.AUDIO_PLAYER
+                    if response_type == ResponseType.SLIDER:
+                        if getattr(config, "is_discrete", False):
+                            answer.item_type[item_id] = ItemType.DISCRETE_SLIDER
+                        else:
+                            answer.item_type[item_id] = ItemType.CONTINUOUS_SLIDER
+                    elif response_type == ResponseType.SINGLESELECT:
+                        if getattr(config, "is_per_row", False):
+                            answer.item_type[item_id] = ItemType.SINGLE_SELECTION_PER_ROW
+                        else:
+                            answer.item_type[item_id] = ItemType.SINGLE_SELECTION
+                    elif response_type == ResponseType.MULTISELECT:
+                        if getattr(config, "is_per_row", False):
+                            answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION_PER_ROW
+                        else:
+                            answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION
+                    elif response_type == ResponseType.DATE:
+                        answer.item_type[item_id] = ItemType.DATE
+                    elif response_type == ResponseType.TIME:
+                        answer.item_type[item_id] = ItemType.TIME
+                    elif response_type == ResponseType.TIMERANGE:
+                        answer.item_type[item_id] = ItemType.TIME_RANGE
+                    elif response_type == ResponseType.TEXT:
+                        answer.item_type[item_id] = ItemType.TEXT
+                    elif response_type == ResponseType.DRAWING:
+                        answer.item_type[item_id] = ItemType.DRAWING
+                    elif response_type == ResponseType.PHOTO:
+                        answer.item_type[item_id] = ItemType.PHOTO
+                    elif response_type == ResponseType.VIDEO:
+                        answer.item_type[item_id] = ItemType.VIDEO
+                    elif response_type == ResponseType.GEOLOCATION:
+                        answer.item_type[item_id] = ItemType.GEOLOCATION
+                    elif response_type == ResponseType.AUDIO:
+                        answer.item_type[item_id] = ItemType.AUDIO
+                    elif response_type == ResponseType.AUDIOPLAYER:
+                        answer.item_type[item_id] = ItemType.AUDIO_PLAYER
 
     async def get_activity_identifiers(
         self, activity_id: uuid.UUID, filters: IdentifiersQueryParams

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -1332,45 +1332,48 @@ class AnswerService:
 
         for answer in answers:
             for item_id in answer.item_ids:
-                if item := activity_items_map.get(item_id):
-                    config = item.config
-                    response_type = item.response_type
+                item = activity_items_map.get(item_id)
+                if not item:
+                    continue
 
-                    if response_type == ResponseType.SLIDER:
-                        if getattr(config, "is_discrete", False):
-                            answer.item_type[item_id] = ItemType.DISCRETE_SLIDER
-                        else:
-                            answer.item_type[item_id] = ItemType.CONTINUOUS_SLIDER
-                    elif response_type == ResponseType.SINGLESELECT:
-                        if getattr(config, "is_per_row", False):
-                            answer.item_type[item_id] = ItemType.SINGLE_SELECTION_PER_ROW
-                        else:
-                            answer.item_type[item_id] = ItemType.SINGLE_SELECTION
-                    elif response_type == ResponseType.MULTISELECT:
-                        if getattr(config, "is_per_row", False):
-                            answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION_PER_ROW
-                        else:
-                            answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION
-                    elif response_type == ResponseType.DATE:
-                        answer.item_type[item_id] = ItemType.DATE
-                    elif response_type == ResponseType.TIME:
-                        answer.item_type[item_id] = ItemType.TIME
-                    elif response_type == ResponseType.TIME_RANGE:
-                        answer.item_type[item_id] = ItemType.TIME_RANGE
-                    elif response_type == ResponseType.TEXT:
-                        answer.item_type[item_id] = ItemType.TEXT
-                    elif response_type == ResponseType.DRAWING:
-                        answer.item_type[item_id] = ItemType.DRAWING
-                    elif response_type == ResponseType.PHOTO:
-                        answer.item_type[item_id] = ItemType.PHOTO
-                    elif response_type == ResponseType.VIDEO:
-                        answer.item_type[item_id] = ItemType.VIDEO
-                    elif response_type == ResponseType.GEOLOCATION:
-                        answer.item_type[item_id] = ItemType.GEOLOCATION
-                    elif response_type == ResponseType.AUDIO:
-                        answer.item_type[item_id] = ItemType.AUDIO
-                    elif response_type == ResponseType.AUDIO_PLAYER:
-                        answer.item_type[item_id] = ItemType.AUDIO_PLAYER
+                config = item.config
+                response_type = item.response_type
+
+                if response_type == ResponseType.SLIDER:
+                    if getattr(config, "is_discrete", False):
+                        answer.item_type[item_id] = ItemType.DISCRETE_SLIDER
+                    else:
+                        answer.item_type[item_id] = ItemType.CONTINUOUS_SLIDER
+                elif response_type == ResponseType.SINGLESELECT:
+                    if getattr(config, "is_per_row", False):
+                        answer.item_type[item_id] = ItemType.SINGLE_SELECTION_PER_ROW
+                    else:
+                        answer.item_type[item_id] = ItemType.SINGLE_SELECTION
+                elif response_type == ResponseType.MULTISELECT:
+                    if getattr(config, "is_per_row", False):
+                        answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION_PER_ROW
+                    else:
+                        answer.item_type[item_id] = ItemType.MULTIPLE_SELECTION
+                elif response_type == ResponseType.DATE:
+                    answer.item_type[item_id] = ItemType.DATE
+                elif response_type == ResponseType.TIME:
+                    answer.item_type[item_id] = ItemType.TIME
+                elif response_type == ResponseType.TIMERANGE:
+                    answer.item_type[item_id] = ItemType.TIME_RANGE
+                elif response_type == ResponseType.TEXT:
+                    answer.item_type[item_id] = ItemType.TEXT
+                elif response_type == ResponseType.DRAWING:
+                    answer.item_type[item_id] = ItemType.DRAWING
+                elif response_type == ResponseType.PHOTO:
+                    answer.item_type[item_id] = ItemType.PHOTO
+                elif response_type == ResponseType.VIDEO:
+                    answer.item_type[item_id] = ItemType.VIDEO
+                elif response_type == ResponseType.GEOLOCATION:
+                    answer.item_type[item_id] = ItemType.GEOLOCATION
+                elif response_type == ResponseType.AUDIO:
+                    answer.item_type[item_id] = ItemType.AUDIO
+                elif response_type == ResponseType.AUDIOPLAYER:
+                    answer.item_type[item_id] = ItemType.AUDIO_PLAYER
 
     async def get_activity_identifiers(
         self, activity_id: uuid.UUID, filters: IdentifiersQueryParams

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -1958,7 +1958,7 @@ class TestAnswerActivityItems(BaseTest):
         expected_keys = {
             "activityHistoryId", "activityId", "answer", "appletHistoryId",
             "appletId", "createdAt", "events", "flowHistoryId", "flowId",
-            "flowName", "id", "itemIds", "migratedData", "respondentId",
+            "flowName", "id", "itemIds", "itemType", "migratedData", "respondentId",
             "respondentSecretId", "reviewedAnswerId", "userPublicKey",
             "version", "submitId", "scheduledDatetime", "startDatetime",
             "endDatetime", "legacyProfileId", "migratedDate", "relation",

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -697,7 +697,7 @@ class TestAnswerActivityItems(BaseTest):
         expected_keys = {
             "activityHistoryId", "activityId", "answer", "appletHistoryId",
             "appletId", "createdAt", "events", "flowHistoryId", "flowId",
-            "flowName", "id", "itemIds", "migratedData", "respondentId",
+            "flowName", "id", "itemIds", "itemType", "migratedData", "respondentId",
             "respondentSecretId", "reviewedAnswerId", "userPublicKey",
             "version", "submitId", "scheduledDatetime", "startDatetime",
             "endDatetime", "legacyProfileId", "migratedDate", "relation",


### PR DESCRIPTION
- [X] Tests for the changes have been added
- [X] For new features, QA automation engineers have been tagged

### 📝 Description

🔗 [Jira Ticket M2-8276](https://mindlogger.atlassian.net/browse/M2-8276)

This PR adds an extra field to the data export endpoint (`item_type`) which maps response types depending into a similar item type, with some variations:

- `"single_selection"`
- `"multiple_selection"`
- `"discrete_slider"`
- `"continuous_slider"`
- `"date"`
- `"time"`
- `"time_range"`
- `"single_selection_per_row"`
- `"multiple_selection_per_row"`
- `"discrete_slider_per_row"`
- `"continuous_slider_per_row"`
- `"text"`
- `"drawing"`
- `"photo"`
- `"video"`
- `"geolocation"`
- `"audio"`
- `"audio_player"`

### 🪤 Peer Testing

This change build on top of the pre-existing data export endpoint for answers, so only an additional `itemType` value should be returned for each of the answers returned in that response.

### ✏️ Notes

A subsequent PR making use of these changes in the admin repo will be added.