### PR TITLE
feat: add percentage to SubscaleCalculationType (M2-8433)

### DIFF
--- a/src/apps/activities/domain/scores_reports.py
+++ b/src/apps/activities/domain/scores_reports.py
@@ -173,6 +173,7 @@ class ScoreConditionalLogicMobile(PublicModel):
 class SubscaleCalculationType(enum.StrEnum):
     SUM = "sum"
     AVERAGE = "average"
+    PERCENTAGE = "percentage"
 
 
 class SubScaleLookupTable(PublicModel):


### PR DESCRIPTION
### 📝 Description

Adds `PERCENTAGE` to `SubscaleCalculationType` to accept updated 
🔗 [Jira Ticket M2-8433](https://mindlogger.atlassian.net/browse/M2-8433)


### 🪤 Peer Testing

Test in conjunction with [Admin PR #2052](https://github.com/ChildMindInstitute/mindlogger-admin/pull/2052)

- Go to Applet Settings > Activity Settings
- Add scored items (Slider, Single Select, Multi Select)
  - Enable Score using the item settings menu under "Scores and Alerts"
- Add Subscale configuration selecting "Percentage" in Subscale scoring
- Enable "Calculate total score" and select "Percentage of Item Scores"
- Save applet 

**Expected behavior**: Admin is able to save/submit the applet

### ✏️ Notes

Required for https://github.com/ChildMindInstitute/mindlogger-admin/pull/2052