### PR TITLE
feat: Add activityOrFlowHidden property to schedule history endpoint response (M2-8693)

### DIFF
--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -77,6 +77,9 @@ class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):
                 "activity_or_flow_id"
             ),
             func.coalesce(ActivityFlowHistoriesSchema.name, ActivityHistorySchema.name).label("activity_or_flow_name"),
+            func.coalesce(ActivityFlowHistoriesSchema.is_hidden, ActivityHistorySchema.is_hidden).label(
+                "activity_or_flow_hidden"
+            ),
             EventHistorySchema.access_before_schedule,
             EventHistorySchema.one_time_completion,
             EventHistorySchema.periodicity,

--- a/src/apps/schedule/domain/schedule/public.py
+++ b/src/apps/schedule/domain/schedule/public.py
@@ -148,6 +148,7 @@ class ExportEventHistoryDto(PublicModel):
     event_updated_by: uuid.UUID | None = None
     activity_or_flow_id: uuid.UUID
     activity_or_flow_name: str
+    activity_or_flow_hidden: bool
     access_before_schedule: bool | None = None
     one_time_completion: bool | None = None
     periodicity: str


### PR DESCRIPTION
- [ ] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8693](https://mindlogger.atlassian.net/browse/M2-8693)

This PR follows up on #1775 by adding an `activityOrFlowHidden` property to the schedule history response. This came out of a discussion with Natalia and the solution was proposed by Sailaja

### 🪤 Peer Testing

1. Create an applet with an activity and a flow and save it
2. Consume the schedule history endpoint with the applet ID
3. Confirm that the `activityOrFlowHidden` property is present for both of them and set to `false`
4. Hide the activity and the flow and save the applet
5. Consume the endpoint again and confirm that additional objects are returned in the response that have the `activityOrFlowHidden` property present and set to `true`

### ✏️ Notes

- I'm still deferring the tests for these new endpoints to a separate task