### PR TITLE
Add new item type for health record data (M2-8826) (M2-8926)

### DIFF
--- a/src/apps/activities/domain/activity_create.py
+++ b/src/apps/activities/domain/activity_create.py
@@ -9,6 +9,7 @@ from apps.activities.domain.custom_validation import (
     validate_item_flow,
     validate_performance_task_type,
     validate_phrasal_templates,
+    validate_request_health_record_data,
     validate_score_and_sections,
     validate_subscales,
 )
@@ -60,3 +61,7 @@ class ActivityCreate(ActivityBase, InternalModel):
     @root_validator()
     def validate_phrasal_templates(cls, values):
         return validate_phrasal_templates(values)
+
+    @root_validator()
+    def validate_request_health_record_data(cls, values):
+        return validate_request_health_record_data(values)

--- a/src/apps/activities/domain/activity_update.py
+++ b/src/apps/activities/domain/activity_update.py
@@ -9,6 +9,7 @@ from apps.activities.domain.custom_validation import (
     validate_item_flow,
     validate_performance_task_type,
     validate_phrasal_templates,
+    validate_request_health_record_data,
     validate_score_and_sections,
     validate_subscales,
 )
@@ -60,6 +61,10 @@ class ActivityUpdate(ActivityBase, PublicModel):
     @root_validator()
     def validate_phrasal_templates(cls, values):
         return validate_phrasal_templates(values)
+
+    @root_validator()
+    def validate_request_health_record_data(cls, values):
+        return validate_request_health_record_data(values)
 
 
 class ActivityReportConfiguration(PublicModel):

--- a/src/apps/activities/domain/custom_validation.py
+++ b/src/apps/activities/domain/custom_validation.py
@@ -1,5 +1,5 @@
 from apps.activities.domain.response_type_config import PerformanceTaskType, ResponseType
-from apps.activities.domain.response_values import PhrasalTemplateFieldType
+from apps.activities.domain.response_values import PhrasalTemplateFieldType, RequestHealthRecordDataOptType
 from apps.activities.domain.scores_reports import ReportType, Score, SubscaleItemType, SubscaleSetting
 from apps.activities.errors import (
     IncorrectConditionItemError,
@@ -272,5 +272,35 @@ def validate_phrasal_templates(values: dict):
 
                         if referenced_item.response_type in [ResponseType.SLIDERROWS] and field.item_index is None:
                             raise IncorrectPhrasalTemplateItemIndexError()
+
+    return values
+
+
+def validate_request_health_record_data(values: dict):
+    items = values.get("items", [])
+    for item in items:
+        if item.response_type == ResponseType.REQUEST_HEALTH_RECORD_DATA:
+            if item.response_values.opt_in_out_options is None or len(item.response_values.opt_in_out_options) != 2:
+                raise ValueError("Request Health Record Data item must have 2 opt-in/out options")
+            opt_in_item = next(
+                (
+                    option
+                    for option in item.response_values.opt_in_out_options
+                    if option.id == RequestHealthRecordDataOptType.OPT_IN
+                ),
+                None,
+            )
+            if opt_in_item is None:
+                raise ValueError("Request Health Record Data item must have opt-in option")
+            opt_out_item = next(
+                (
+                    option
+                    for option in item.response_values.opt_in_out_options
+                    if option.id == RequestHealthRecordDataOptType.OPT_OUT
+                ),
+                None,
+            )
+            if opt_out_item is None:
+                raise ValueError("Request Health Record Data item must have opt-out option")
 
     return values

--- a/src/apps/activities/domain/response_type_config.py
+++ b/src/apps/activities/domain/response_type_config.py
@@ -56,6 +56,7 @@ class ResponseType(StrEnum):
     ABTRAILS = "ABTrails"
     UNITY = "unity"
     PHRASAL_TEMPLATE = "phrasalTemplate"
+    REQUEST_HEALTH_RECORD_DATA = "requestHealthRecordData"
 
     @classmethod
     def get_non_response_types(cls):
@@ -260,6 +261,11 @@ class AudioPlayerConfig(_ScreenConfig, PublicModel):
 
 class PhrasalTemplateConfig(PublicModel):
     type: Literal[ResponseType.PHRASAL_TEMPLATE] | None
+    remove_back_button: bool
+
+
+class RequestHealthRecordDataConfig(PublicModel):
+    type: Literal[ResponseType.REQUEST_HEALTH_RECORD_DATA] | None
     remove_back_button: bool
 
 
@@ -472,4 +478,5 @@ ResponseTypeConfig = (
     | ABTrailsConfig
     | PhrasalTemplateConfig
     | UnityConfig
+    | RequestHealthRecordDataConfig
 )

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -389,9 +389,14 @@ class PhrasalTemplateValues(PublicModel):
     phrases: list[PhrasalTemplatePhrase]
 
 
+class RequestHealthRecordDataOption(PublicModel):
+    id: str
+    label: str
+
+
 class RequestHealthRecordDataValues(PublicModel):
     type: Literal[ResponseType.REQUEST_HEALTH_RECORD_DATA] | None
-    import_additional_docs: bool = Field(default=False)
+    opt_in_out_options: list[RequestHealthRecordDataOption]
 
 
 ResponseValueConfigOptions = [

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -42,6 +42,11 @@ from apps.activities.errors import (
 from apps.shared.domain import PublicModel, validate_color, validate_image, validate_uuid
 
 
+class RequestHealthRecordDataOptType(StrEnum):
+    OPT_IN = "opt_in"
+    OPT_OUT = "opt_out"
+
+
 class PhrasalTemplateFieldType(StrEnum):
     SENTENCE = "sentence"
     ITEM_RESPONSE = "item_response"
@@ -390,8 +395,8 @@ class PhrasalTemplateValues(PublicModel):
 
 
 class RequestHealthRecordDataOption(PublicModel):
-    id: str
-    label: str
+    id: RequestHealthRecordDataOptType = Field(default=...)  # ellipsis indicates that the field is required
+    label: str = Field(default=...)
 
 
 class RequestHealthRecordDataValues(PublicModel):

--- a/src/apps/activities/domain/response_values.py
+++ b/src/apps/activities/domain/response_values.py
@@ -19,6 +19,7 @@ from apps.activities.domain.response_type_config import (
     ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
+    RequestHealthRecordDataConfig,
     ResponseType,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
@@ -388,6 +389,11 @@ class PhrasalTemplateValues(PublicModel):
     phrases: list[PhrasalTemplatePhrase]
 
 
+class RequestHealthRecordDataValues(PublicModel):
+    type: Literal[ResponseType.REQUEST_HEALTH_RECORD_DATA] | None
+    import_additional_docs: bool = Field(default=False)
+
+
 ResponseValueConfigOptions = [
     TextValues,
     ParagraphTextValues,
@@ -413,6 +419,7 @@ ResponseValueConfigOptions = [
     ABTrailsValues,
     UnityValues,
     PhrasalTemplateValues,
+    RequestHealthRecordDataValues,
 ]
 
 
@@ -430,6 +437,7 @@ ResponseValueConfig = (
     | TimeValues
     | UnityValues
     | PhrasalTemplateValues
+    | RequestHealthRecordDataValues
 )
 
 
@@ -486,6 +494,7 @@ ResponseTypeConfigOptions = [
     ABTrailsConfig,
     UnityConfig,
     PhrasalTemplateConfig,
+    RequestHealthRecordDataConfig,
 ]
 
 ResponseTypeValueConfig = {}

--- a/src/apps/activities/tests/fixtures/configs.py
+++ b/src/apps/activities/tests/fixtures/configs.py
@@ -15,6 +15,7 @@ from apps.activities.domain.response_type_config import (
     ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
+    RequestHealthRecordDataConfig,
     ResponseType,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
@@ -186,3 +187,8 @@ def phrasal_template_config(default_config: DefaultConfig) -> PhrasalTemplateCon
 @pytest.fixture
 def unity_config(default_config: DefaultConfig) -> UnityConfig:
     return UnityConfig(**default_config.dict(), type=ResponseType.UNITY)
+
+
+@pytest.fixture
+def request_health_record_data_config(default_config: DefaultConfig) -> RequestHealthRecordDataConfig:
+    return RequestHealthRecordDataConfig(**default_config.dict(), type=ResponseType.REQUEST_HEALTH_RECORD_DATA)

--- a/src/apps/activities/tests/fixtures/items.py
+++ b/src/apps/activities/tests/fixtures/items.py
@@ -14,6 +14,7 @@ from apps.activities.domain.response_type_config import (
     ParagraphTextConfig,
     PhotoConfig,
     PhrasalTemplateConfig,
+    RequestHealthRecordDataConfig,
     ResponseType,
     SingleSelectionConfig,
     SingleSelectionRowsConfig,
@@ -32,6 +33,7 @@ from apps.activities.domain.response_values import (
     MultiSelectionValues,
     NumberSelectionValues,
     PhrasalTemplateValues,
+    RequestHealthRecordDataValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
     SliderRowsValues,
@@ -334,3 +336,17 @@ def phrasal_template_with_paragraph_create(
     )
 
     return [paragraph_text_item_create, phrasal_item]
+
+
+@pytest.fixture
+def request_health_record_data_create(
+    request_health_record_data_config: RequestHealthRecordDataConfig,
+    request_health_record_data_response_values: RequestHealthRecordDataValues,
+    base_item_data: BaseItemData,
+) -> ActivityItemCreate:
+    return ActivityItemCreate(
+        **base_item_data.dict(),
+        response_type=ResponseType.REQUEST_HEALTH_RECORD_DATA,
+        config=request_health_record_data_config,
+        response_values=request_health_record_data_response_values,
+    )

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -17,6 +17,7 @@ from apps.activities.domain.response_values import (
     PhrasalTemplateField,
     PhrasalTemplatePhrase,
     PhrasalTemplateValues,
+    RequestHealthRecordDataValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
     SliderRowsValue,
@@ -263,3 +264,8 @@ def phrasal_template_with_paragraph_response_values(
         card_title="test paragraph card title",
         type=ResponseType.PHRASAL_TEMPLATE,
     )
+
+
+@pytest.fixture
+def request_health_record_data_response_values() -> RequestHealthRecordDataValues:
+    return RequestHealthRecordDataValues(type=ResponseType.REQUEST_HEALTH_RECORD_DATA, import_additional_docs=True)

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -17,6 +17,7 @@ from apps.activities.domain.response_values import (
     PhrasalTemplateField,
     PhrasalTemplatePhrase,
     PhrasalTemplateValues,
+    RequestHealthRecordDataOption,
     RequestHealthRecordDataValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
@@ -268,4 +269,17 @@ def phrasal_template_with_paragraph_response_values(
 
 @pytest.fixture
 def request_health_record_data_response_values() -> RequestHealthRecordDataValues:
-    return RequestHealthRecordDataValues(type=ResponseType.REQUEST_HEALTH_RECORD_DATA, import_additional_docs=True)
+    opt_in_out_options = [
+        RequestHealthRecordDataOption(
+            id="Opt In",
+            label="Opt In label",
+        ),
+        RequestHealthRecordDataOption(
+            id="Opt Out",
+            label="Opt Out label",
+        ),
+    ]
+
+    return RequestHealthRecordDataValues(
+        type=ResponseType.REQUEST_HEALTH_RECORD_DATA, opt_in_out_options=opt_in_out_options
+    )

--- a/src/apps/activities/tests/fixtures/response_values.py
+++ b/src/apps/activities/tests/fixtures/response_values.py
@@ -18,6 +18,7 @@ from apps.activities.domain.response_values import (
     PhrasalTemplatePhrase,
     PhrasalTemplateValues,
     RequestHealthRecordDataOption,
+    RequestHealthRecordDataOptType,
     RequestHealthRecordDataValues,
     SingleSelectionRowsValues,
     SingleSelectionValues,
@@ -271,11 +272,11 @@ def phrasal_template_with_paragraph_response_values(
 def request_health_record_data_response_values() -> RequestHealthRecordDataValues:
     opt_in_out_options = [
         RequestHealthRecordDataOption(
-            id="Opt In",
+            id=RequestHealthRecordDataOptType.OPT_IN,
             label="Opt In label",
         ),
         RequestHealthRecordDataOption(
-            id="Opt Out",
+            id=RequestHealthRecordDataOptType.OPT_OUT,
             label="Opt Out label",
         ),
     ]

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -212,6 +212,38 @@ class TestActivityItems:
         assert resp.json()["result"]["activities"][0]["isPerformanceTask"]
         assert resp.json()["result"]["activities"][0]["performanceTaskType"] == performance_task_type
 
+    async def test_create_applet_with_request_health_record_data_invalid(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_minimal_data: AppletCreate,
+        request_health_record_data_create: ActivityItemCreate,
+    ):
+        client.login(tom)
+        data = applet_minimal_data.copy(deep=True)
+        data.activities[0].items = [request_health_record_data_create]
+
+        data_dict = data.dict(by_alias=True)
+        data_dict["activities"][0]["items"][0]["responseValues"]["optInOutOptions"][1]["id"] = "opt_in"
+
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data_dict)
+        assert resp.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
+        assert resp.json()["result"][0]["message"] == "Request Health Record Data item must have opt-out option"
+
+        data_dict = data.dict(by_alias=True)
+        data_dict["activities"][0]["items"][0]["responseValues"]["optInOutOptions"][0]["id"] = "opt_out"
+
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data_dict)
+        assert resp.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
+        assert resp.json()["result"][0]["message"] == "Request Health Record Data item must have opt-in option"
+
+        data_dict = data.dict(by_alias=True)
+        data_dict["activities"][0]["items"][0]["responseValues"]["optInOutOptions"] = []
+
+        resp = await client.post(self.applet_create_url.format(owner_id=tom.id), data=data_dict)
+        assert resp.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
+        assert resp.json()["result"][0]["message"] == "Request Health Record Data item must have 2 opt-in/out options"
+
     async def test_creating_applet_with_activity_items_condition(
         self,
         client: TestClient,

--- a/src/apps/applets/tests/test_applet_activity_items.py
+++ b/src/apps/applets/tests/test_applet_activity_items.py
@@ -94,6 +94,7 @@ class TestActivityItems:
             "message_item_create",
             "audio_player_item_create",
             "paragraph_text_item_create",
+            "request_health_record_data_create",
         ),
     )
     async def test_create_applet_with_each_activity_item(


### PR DESCRIPTION
Extend the item types with a new option for health record data flow. 
Add models for configuration and value handling.
Update test fixtures and item creation to cover the new functionality.

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [x] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-8826](https://mindlogger.atlassian.net/browse/M2-8826)
🔗 [Jira Ticket M2-8926](https://mindlogger.atlassian.net/browse/M2-8926)

@egodoy-metalab @Phillipe-Bojorquez This PR add a new activity item type, should update tests
