### PR TITLE
chore: Some EMA cleanup tasks (M2-8693)

### DIFF
--- a/src/apps/schedule/api/schedule.py
+++ b/src/apps/schedule/api/schedule.py
@@ -25,6 +25,7 @@ from apps.workspaces.domain.constants import Role
 from apps.workspaces.service.check_access import CheckAccessService
 from infrastructure.database import atomic
 from infrastructure.database.deps import get_session
+from infrastructure.http import get_local_tz
 from infrastructure.logger import logger
 from infrastructure.utility import FirebaseNotificationType
 
@@ -275,6 +276,7 @@ async def schedule_get_all_by_user(
 async def schedule_get_all_by_respondent_user(
     user: User = Depends(get_current_user),
     session=Depends(get_session),
+    time_zone: str | None = Depends(get_local_tz()),
     device_id: Annotated[str | None, Header()] = None,
     os_name: Annotated[str | None, Header()] = None,
     os_version: Annotated[str | None, Header()] = None,
@@ -307,6 +309,7 @@ async def schedule_get_all_by_respondent_user(
             applet_ids=applet_ids,
             min_end_date=min_end_date,
             max_start_date=max_start_date,
+            time_zone=time_zone,
             device_id=device_id,
             os_name=os_name,
             os_version=os_version,

--- a/src/apps/schedule/crud/user_device_events_history.py
+++ b/src/apps/schedule/crud/user_device_events_history.py
@@ -54,6 +54,7 @@ class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):
         os_name: str | None = None,
         os_version: str | None = None,
         app_version: str | None = None,
+        time_zone: str | None = None,
     ) -> list[UserDeviceEventsHistorySchema]:
         values = [
             dict(
@@ -64,6 +65,7 @@ class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):
                 os_name=os_name,
                 os_version=os_version,
                 app_version=app_version,
+                time_zone=time_zone,
             )
             for event_id, event_version in event_versions
         ]

--- a/src/apps/schedule/crud/user_device_events_history.py
+++ b/src/apps/schedule/crud/user_device_events_history.py
@@ -107,7 +107,9 @@ class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):
             EventHistorySchema.start_time,
             EventHistorySchema.end_date,
             EventHistorySchema.end_time,
+            EventHistorySchema.access_before_schedule,
             UserDeviceEventsHistorySchema.created_at,
+            UserDeviceEventsHistorySchema.time_zone.label("user_time_zone"),
         ]
 
         query: Query = select(*columns)

--- a/src/apps/schedule/db/schemas.py
+++ b/src/apps/schedule/db/schemas.py
@@ -108,13 +108,14 @@ class UserDeviceEventsHistorySchema(Base):
 
     unique_constraint = "_unique_user_device_events_history"
 
-    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"))
+    user_id = Column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
     device_id = Column(String(255), nullable=False)
     os_name = Column(Text, nullable=True)
     os_version = Column(Text, nullable=True)
     app_version = Column(Text, nullable=True)
     event_id = Column(UUID(as_uuid=True), nullable=False)
     event_version = Column(String(13), nullable=False)
+    time_zone = Column(Text, nullable=True)
 
     __table_args__ = (
         UniqueConstraint(

--- a/src/apps/schedule/domain/schedule/public.py
+++ b/src/apps/schedule/domain/schedule/public.py
@@ -168,4 +168,6 @@ class ExportDeviceHistoryDto(PublicModel):
     start_time: datetime.time
     end_date: date | None = None
     end_time: datetime.time
+    access_before_schedule: bool | None = None
     created_at: datetime.datetime
+    user_time_zone: str | None = None

--- a/src/apps/schedule/service/schedule.py
+++ b/src/apps/schedule/service/schedule.py
@@ -677,6 +677,7 @@ class ScheduleService:
         applet_ids: list[uuid.UUID],
         min_end_date: date | None = None,
         max_start_date: date | None = None,
+        time_zone: str | None = None,
         device_id: str | None = None,
         os_name: str | None = None,
         os_version: str | None = None,
@@ -730,6 +731,7 @@ class ScheduleService:
                     os_name=os_name,
                     os_version=os_version,
                     app_version=app_version,
+                    time_zone=time_zone,
                 )
 
         return events

--- a/src/infrastructure/database/migrations/versions/2025_03_20_22_38-add_time_zone_field_to_user_device_.py
+++ b/src/infrastructure/database/migrations/versions/2025_03_20_22_38-add_time_zone_field_to_user_device_.py
@@ -1,0 +1,25 @@
+"""Add time_zone field to user_device_events_history
+
+Revision ID: 6fb25329f7b1
+Revises: 5658857a84dc
+Create Date: 2025-03-20 22:38:11.454125
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "6fb25329f7b1"
+down_revision = "5658857a84dc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("user_device_events_history", sa.Column("time_zone", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_device_events_history", "time_zone")


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8693](https://mindlogger.atlassian.net/browse/M2-8693)

This PR accomplishes the following things:
- Record the user's time zone in the `user_device_events_history` table when they fetch their schedules. This is a new nullable column, and will not be populated for existing records
- Return this time zone, as well as the access before schedule property in the device schedule history endpoint

This PR contains a migrations that needs to be run before any testing can be done

```shell
alembic upgrade head
```

### 🪤 Peer Testing

#### Time zone submission

1. Run the mobile app
2. Log in, or swipe refresh
3. Observe the time_zone column in the `user_device_events_history` table

#### Device Schedule History

1. Consume the device schedule history endpoint
2. Observe the response for the new properties:
    - accessBeforeSchedule
    - userTimeZone 

### ✏️ Notes

N/A
