### PR TITLE
fix: Relax validations during answer submission (M2-8924)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -105,7 +105,7 @@ async def create_answer(
                 device_id=device_id, user_id=user.id, event_id=event_id, event_version=event_version
             )
             if device is None:
-                raise NotFoundError("Invalid device_id provided")
+                logger.info(f"Invalid device_id {device_id} provided")
 
         service = AnswerService(session, user.id, answer_session)
         if tz_offset is not None and schema.answer.tz_offset is None:

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -95,7 +95,8 @@ async def create_answer(
                 or (event.activity_flow_id != schema.flow_id and event.activity_id != schema.activity_id)
                 or (event.user_id is not None and event.user_id != user.id)
             ):
-                raise NotFoundError("Invalid event_history_id provided")
+                logger.info(f"Invalid event_history_id {schema.event_history_id} provided")
+                schema.event_history_id = None
 
         device = None
         if device_id and schema.event_history_id:

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -917,8 +917,8 @@ class TestAnswerActivityItems(BaseTest):
         data.event_history_id = f"{event.id}_{event.version}"
         response = await client.post(self.answer_url, data=data, headers={"Device-Id": "wrong_device_id"})
 
-        assert response.status_code == http.HTTPStatus.NOT_FOUND
-        assert response.json()["result"][0]["message"] == "Invalid device_id provided"
+        # The validation on the device ID has been removed
+        assert response.status_code == http.HTTPStatus.CREATED
 
     async def test_create_activity_answers__submit_duplicate(
         self,

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -904,8 +904,8 @@ class TestAnswerActivityItems(BaseTest):
         data.event_history_id = str(uuid.uuid4())
         response = await client.post(self.answer_url, data=data)
 
-        assert response.status_code == http.HTTPStatus.NOT_FOUND
-        assert response.json()["result"][0]["message"] == "Invalid event_history_id provided"
+        # The validation on the event history ID has been removed
+        assert response.status_code == http.HTTPStatus.CREATED
 
     async def test_create_answer_with_wrong_device_id(
         self, client: TestClient, tom: User, answer_create: AppletAnswerCreate, applet_default_events


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8924](https://mindlogger.atlassian.net/browse/M2-8924)

This PR removes the device ID and event history ID validations in the answer submission endpoint. This should make it possible to submits answers again, even when having invalid values for these parameters.


### 🪤 Peer Testing

> [!TIP]
> If you are testing this locally, you answer submission may fail for an unrelated reason. Please comment out [this line](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/f59fc672a77c23596b5e8a3f24199a46beed3a6a/src/apps/answers/crud/answers.py#L506) in your API server to eliminate this possibility

1. Launch the mobile app and start an activity
2. Before submitting, edit or delete the row from both the `user_device_events_history` and `event_histories` tables for the activity you are completing
3. Complete and submit the activity in the mobile app
4. Observe that the answer is accepted without error


### ✏️ Notes

N/A
