### PR TITLE
fix: Prevent upsert query if events list is empty (M2-8924)

### DIFF
--- a/src/apps/schedule/service/schedule.py
+++ b/src/apps/schedule/service/schedule.py
@@ -722,14 +722,15 @@ class ScheduleService:
 
         if device_id:
             all_events = [event for value in full_events_map.values() for event in value]
-            await UserDeviceEventsHistoryCRUD(self.session).record_event_versions(
-                user_id=user_id,
-                device_id=device_id,
-                event_versions=[(event.id, event.version) for event in all_events],
-                os_name=os_name,
-                os_version=os_version,
-                app_version=app_version,
-            )
+            if len(all_events) > 0:
+                await UserDeviceEventsHistoryCRUD(self.session).record_event_versions(
+                    user_id=user_id,
+                    device_id=device_id,
+                    event_versions=[(event.id, event.version) for event in all_events],
+                    os_name=os_name,
+                    os_version=os_version,
+                    app_version=app_version,
+                )
 
         return events
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8924](https://mindlogger.atlassian.net/browse/M2-8924)

This PR adds an if statement that prevents attempted insertion to the `user_device_events_history` table when the user has no events. This can happen for a few reasons, mainly:
- The user has been deleted, but they still have a valid auth token and consume this endpoint via the mobile app
- The user is not part of any applets

### 🪤 Peer Testing

1. Create an account in the admin panel, but create no applets
2. Sign in to the mobile app
3. Confirm there is no 500 error on the API server


### ✏️ Notes

N/A
