### PR TITLE
Adding logic to hardend the ECS security group

### DIFF
--- a/copilot/mindlogger-backend/manifest.yml
+++ b/copilot/mindlogger-backend/manifest.yml
@@ -40,9 +40,10 @@ count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 network:
   connect: false # Enable Service Connect for intra-environment traffic between services.
-#  vpc:
-#    security_groups:
-#      - sg-0fe1e219a0c0c5afb
+  vpc:
+    security_groups:
+      # This security group allows access to rabbit and redis
+      - sg-0fe1e219a0c0c5afb
 
 storage:
   readonly_fs: false

--- a/copilot/mindlogger-backend/manifest.yml
+++ b/copilot/mindlogger-backend/manifest.yml
@@ -40,9 +40,9 @@ count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 network:
   connect: false # Enable Service Connect for intra-environment traffic between services.
-  vpc:
-    security_groups:
-      - sg-0fe1e219a0c0c5afb
+#  vpc:
+#    security_groups:
+#      - sg-0fe1e219a0c0c5afb
 
 storage:
   readonly_fs: false

--- a/copilot/scripts/svc-deploy.sh
+++ b/copilot/scripts/svc-deploy.sh
@@ -9,46 +9,47 @@ copilot svc deploy \
     --force \
     --diff-yes
 
+PR_NUM=${ENV_NAME}
+
 # Add Datadog tags to ALB
-for PR_NUM in $(aws ecs list-clusters --output text | grep -E -o 'pr\-[0-9]+' | grep -E -o '[0-9]+'); do
-  echo "Working with ${PR_NUM}"
-  ALL_ALBS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text)
-  ALB_ARNS=$(IFS=, ; echo "${ALL_ALBS[*]}")
-  ARN=$(aws elbv2 describe-tags --resource-arns ${ALB_ARNS} --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='pr-${PR_NUM}']].ResourceArn" --output text)
-  echo "ALB ARN: ${ARN}"
+echo "Working with ${PR_NUM}"
+ALL_ALBS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text)
+ALB_ARNS=$(IFS=, ; echo "${ALL_ALBS[*]}")
+ARN=$(aws elbv2 describe-tags --resource-arns "${ALB_ARNS}" --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='pr-${PR_NUM}']].ResourceArn" --output text)
+echo "ALB ARN: ${ARN}"
 
-  DD_VERSION="pr-${PR_NUM}"
-  aws elbv2 add-tags \
-    --resource-arns "${ARN}" \
-    --tags Key=env,Value=feature Key=service,Value=backend-api Key=version,Value=${DD_VERSION}
+DD_VERSION="pr-${PR_NUM}"
+aws elbv2 add-tags \
+  --resource-arns "${ARN}" \
+  --tags Key=env,Value=feature Key=service,Value=backend-api Key=version,Value="${DD_VERSION}"
 
 
-  # GDPR and HIPAA security group rules
-  ALB_SG_ID=$(aws elbv2 describe-load-balancers --load-balancer-arns "${ARN}" --query "LoadBalancers[*].[SecurityGroups]" --output text)
+# GDPR and HIPAA security group rules
+ALB_SG_ID=$(aws elbv2 describe-load-balancers --load-balancer-arns "${ARN}" --query "LoadBalancers[*].[SecurityGroups]" --output text)
 
-  CLUSTERS=$(aws ecs list-clusters --query "clusterArns" --output text)
-  for CLUSTER in ${CLUSTERS}; do
-    TAGS=$(aws ecs list-tags-for-resource --resource-arn ${CLUSTER} --query "tags[?key=='copilot-environment' && value=='pr-${PR_NUM}']" --output text)
-    if [ -n "${TAGS}" ]; then
-      echo "Cluster ARN: ${CLUSTER}"
-      SERVICE_ARN=$(aws ecs list-services --cluster "${CLUSTER}" --query "serviceArns[0]" --output text)
-      SGS=$(aws ecs describe-services --cluster "${CLUSTER}" --service "${SERVICE_ARN}"  --query "services[0].networkConfiguration.awsvpcConfiguration.securityGroups" --output text)
-      for SG in ${SGS}; do
-        if [[ "${SG}" = "sg-0fe1e219a0c0c5afb" ]]; then continue; fi
-        echo "Processing Security group: ${SG}, limiting access from ${ALB_SG_ID}"
-        echo "Removing existing inbound rules"
-        IP_PERMS=$(aws ec2 describe-security-groups --group-ids "${SG}" --query "SecurityGroups[0].IpPermissions" --output json)
+CLUSTERS=$(aws ecs list-clusters --query "clusterArns" --output text)
+for CLUSTER in ${CLUSTERS}; do
+  TAGS=$(aws ecs list-tags-for-resource --resource-arn ${CLUSTER} --query "tags[?key=='copilot-environment' && value=='pr-${PR_NUM}']" --output text)
 
-        aws ec2 revoke-security-group-ingress --group-id "${SG}" --ip-permissions "${IP_PERMS}" > /dev/null
+  if [ -n "${TAGS}" ]; then
+    echo "Cluster ARN: ${CLUSTER}"
+    SERVICE_ARN=$(aws ecs list-services --cluster "${CLUSTER}" --query "serviceArns[0]" --output text)
+    SGS=$(aws ecs describe-services --cluster "${CLUSTER}" --service "${SERVICE_ARN}"  --query "services[0].networkConfiguration.awsvpcConfiguration.securityGroups" --output text)
 
-        echo "Creating new ingress rule"
-        aws ec2 authorize-security-group-ingress \
-          --group-id "${SG}" \
-          --protocol tcp \
-          --port 1024-65535 \
-          --source-group "${ALB_SG_ID}" > /dev/null
-      done
-    fi
-  done
+    for SG in ${SGS}; do
+      if [[ "${SG}" = "sg-0fe1e219a0c0c5afb" ]]; then continue; fi
+      echo "Processing Security group: ${SG}, limiting access from ${ALB_SG_ID}"
+      echo "Removing existing inbound rules"
+      IP_PERMS=$(aws ec2 describe-security-groups --group-ids "${SG}" --query "SecurityGroups[0].IpPermissions" --output json)
 
+      aws ec2 revoke-security-group-ingress --group-id "${SG}" --ip-permissions "${IP_PERMS}" > /dev/null
+
+      echo "Creating new ingress rule"
+      aws ec2 authorize-security-group-ingress \
+        --group-id "${SG}" \
+        --protocol tcp \
+        --port 1024-65535 \
+        --source-group "${ALB_SG_ID}" > /dev/null
+    done
+  fi
 done

--- a/copilot/scripts/svc-deploy.sh
+++ b/copilot/scripts/svc-deploy.sh
@@ -8,3 +8,47 @@ copilot svc deploy \
     --env "$ENV_NAME" \
     --force \
     --diff-yes
+
+# Add Datadog tags to ALB
+for PR_NUM in $(aws ecs list-clusters --output text | grep -E -o 'pr\-[0-9]+' | grep -E -o '[0-9]+'); do
+  echo "Working with ${PR_NUM}"
+  ALL_ALBS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text)
+  ALB_ARNS=$(IFS=, ; echo "${ALL_ALBS[*]}")
+  ARN=$(aws elbv2 describe-tags --resource-arns ${ALB_ARNS} --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='pr-${PR_NUM}']].ResourceArn" --output text)
+  echo "ALB ARN: ${ARN}"
+
+  DD_VERSION="pr-${PR_NUM}"
+  aws elbv2 add-tags \
+    --resource-arns "${ARN}" \
+    --tags Key=datadog:env,Value=feature Key=datadog:service,Value=backend-api Key=datadog:version,Value=${DD_VERSION}
+
+
+  # GDPR and HIPAA security group rules
+  ALB_SG_ID=$(aws elbv2 describe-load-balancers --load-balancer-arns "${ARN}" --query "LoadBalancers[*].[SecurityGroups]" --output text)
+
+  CLUSTERS=$(aws ecs list-clusters --query "clusterArns" --output text)
+  for CLUSTER in ${CLUSTERS}; do
+    TAGS=$(aws ecs list-tags-for-resource --resource-arn ${CLUSTER} --query "tags[?key=='copilot-environment' && value=='pr-${PR_NUM}']" --output text)
+    if [ -n "${TAGS}" ]; then
+      echo "Cluster ARN: ${CLUSTER}"
+      SERVICE_ARN=$(aws ecs list-services --cluster "${CLUSTER}" --query "serviceArns[0]" --output text)
+      SGS=$(aws ecs describe-services --cluster "${CLUSTER}" --service "${SERVICE_ARN}"  --query "services[0].networkConfiguration.awsvpcConfiguration.securityGroups" --output text)
+      for SG in ${SGS}; do
+        if [[ "${SG}" = "sg-0fe1e219a0c0c5afb" ]]; then continue; fi
+        echo "Processing Security group: ${SG}, limiting access from ${ALB_SG_ID}"
+        echo "Removing existing inbound rules"
+        IP_PERMS=$(aws ec2 describe-security-groups --group-ids "${SG}" --query "SecurityGroups[0].IpPermissions" --output json)
+
+        aws ec2 revoke-security-group-ingress --group-id "${SG}" --ip-permissions "${IP_PERMS}" > /dev/null
+
+        echo "Creating new ingress rule"
+        aws ec2 authorize-security-group-ingress \
+          --group-id "${SG}" \
+          --protocol tcp \
+          --port 1024-65535 \
+          --source-group "${ALB_SG_ID}" > /dev/null
+      done
+    fi
+  done
+
+done

--- a/copilot/scripts/svc-deploy.sh
+++ b/copilot/scripts/svc-deploy.sh
@@ -16,47 +16,54 @@ echo "Working with ${PR_NUM}"
 ALL_ALBS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text | tr '\t' ' ')
 ALB_ARNS=$(IFS=, ; echo "${ALL_ALBS[*]}")
 ARN=$(aws elbv2 describe-tags --resource-arns "${ALB_ARNS}" --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='${PR_NUM}']].ResourceArn" --output text)
-echo "ALB ARN: ${ARN}"
 
-DD_VERSION="${PR_NUM}"
-aws elbv2 add-tags \
-  --resource-arns "${ARN}" \
-  --tags Key=env,Value=feature Key=service,Value=backend-api Key=version,Value="${DD_VERSION}"
+for ALB in ${ALB_ARNS}; do
 
+  ARN=$(aws elbv2 describe-tags --resource-arns ${ALB} --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='pr-${PR_NUM}']].ResourceArn" --output text)
 
-# GDPR and HIPAA security group rules
-ALB_SG_ID=$(aws elbv2 describe-load-balancers --load-balancer-arns "${ARN}" --query "LoadBalancers[*].[SecurityGroups]" --output text)
+  if [ -n "${ARN}" ]; then
+    echo "ALB ARN: ${ARN}"
 
-CLUSTERS=$(aws ecs list-clusters --query "clusterArns" --output text)
-for CLUSTER in ${CLUSTERS}; do
-  TAGS=$(aws ecs list-tags-for-resource --resource-arn ${CLUSTER} --query "tags[?key=='copilot-environment' && value=='${PR_NUM}']" --output text)
+    DD_VERSION="${PR_NUM}"
+    aws elbv2 add-tags \
+      --resource-arns "${ARN}" \
+      --tags Key=env,Value=feature Key=service,Value=backend-api Key=version,Value="${DD_VERSION}"
 
-  if [ -n "${TAGS}" ]; then
-    echo "Cluster ARN: ${CLUSTER}"
-    SERVICE_ARN=$(aws ecs list-services --cluster "${CLUSTER}" --query "serviceArns[0]" --output text)
-    SGS=$(aws ecs describe-services --cluster "${CLUSTER}" --service "${SERVICE_ARN}"  --query "services[0].networkConfiguration.awsvpcConfiguration.securityGroups" --output text)
+    # GDPR and HIPAA security group rules
+    ALB_SG_ID=$(aws elbv2 describe-load-balancers --load-balancer-arns "${ARN}" --query "LoadBalancers[*].[SecurityGroups]" --output text)
 
-    for SG in ${SGS}; do
-      if [[ "${SG}" = "sg-0fe1e219a0c0c5afb" ]]; then continue; fi
-      echo "Processing Security group: ${SG}, limiting access from ${ALB_SG_ID}"
-      echo "Removing existing inbound rules"
-      IP_PERMS=$(aws ec2 describe-security-groups --group-ids "${SG}" --query "SecurityGroups[0].IpPermissions" --output json)
+    CLUSTERS=$(aws ecs list-clusters --query "clusterArns" --output text)
+    for CLUSTER in ${CLUSTERS}; do
+      TAGS=$(aws ecs list-tags-for-resource --resource-arn ${CLUSTER} --query "tags[?key=='copilot-environment' && value=='${PR_NUM}']" --output text)
 
-      aws ec2 revoke-security-group-ingress --group-id "${SG}" --ip-permissions "${IP_PERMS}" > /dev/null
+      if [ -n "${TAGS}" ]; then
+        echo "Cluster ARN: ${CLUSTER}"
+        SERVICE_ARN=$(aws ecs list-services --cluster "${CLUSTER}" --query "serviceArns[0]" --output text)
+        SGS=$(aws ecs describe-services --cluster "${CLUSTER}" --service "${SERVICE_ARN}"  --query "services[0].networkConfiguration.awsvpcConfiguration.securityGroups" --output text)
 
-      echo "Creating new ingress rules"
-      # Health check
-      aws ec2 authorize-security-group-ingress \
-        --group-id "${SG}" \
-        --protocol tcp \
-        --port 1024-65535 \
-        --source-group "${ALB_SG_ID}" > /dev/null
-      # App
-      aws ec2 authorize-security-group-ingress \
-          --group-id "${SG}" \
-          --protocol tcp \
-          --port 80 \
-          --source-group "${ALB_SG_ID}" > /dev/null
+        for SG in ${SGS}; do
+          if [[ "${SG}" = "sg-0fe1e219a0c0c5afb" ]]; then continue; fi
+          echo "Processing Security group: ${SG}, limiting access from ${ALB_SG_ID}"
+          echo "Removing existing inbound rules"
+          IP_PERMS=$(aws ec2 describe-security-groups --group-ids "${SG}" --query "SecurityGroups[0].IpPermissions" --output json)
+
+          aws ec2 revoke-security-group-ingress --group-id "${SG}" --ip-permissions "${IP_PERMS}" > /dev/null
+
+          echo "Creating new ingress rules"
+          # Health check
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${SG}" \
+            --protocol tcp \
+            --port 1024-65535 \
+            --source-group "${ALB_SG_ID}" > /dev/null
+          # App
+          aws ec2 authorize-security-group-ingress \
+              --group-id "${SG}" \
+              --protocol tcp \
+              --port 80 \
+              --source-group "${ALB_SG_ID}" > /dev/null
+        done
+      fi
     done
   fi
 done

--- a/copilot/scripts/svc-deploy.sh
+++ b/copilot/scripts/svc-deploy.sh
@@ -20,7 +20,7 @@ for PR_NUM in $(aws ecs list-clusters --output text | grep -E -o 'pr\-[0-9]+' | 
   DD_VERSION="pr-${PR_NUM}"
   aws elbv2 add-tags \
     --resource-arns "${ARN}" \
-    --tags Key=datadog:env,Value=feature Key=datadog:service,Value=backend-api Key=datadog:version,Value=${DD_VERSION}
+    --tags Key=env,Value=feature Key=service,Value=backend-api Key=version,Value=${DD_VERSION}
 
 
   # GDPR and HIPAA security group rules

--- a/copilot/scripts/svc-deploy.sh
+++ b/copilot/scripts/svc-deploy.sh
@@ -15,11 +15,9 @@ PR_NUM=${ENV_NAME}
 echo "Working with ${PR_NUM}"
 ALL_ALBS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text | tr '\t' ' ')
 ALB_ARNS=$(IFS=, ; echo "${ALL_ALBS[*]}")
-ARN=$(aws elbv2 describe-tags --resource-arns "${ALB_ARNS}" --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='${PR_NUM}']].ResourceArn" --output text)
 
 for ALB in ${ALB_ARNS}; do
-
-  ARN=$(aws elbv2 describe-tags --resource-arns ${ALB} --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='pr-${PR_NUM}']].ResourceArn" --output text)
+  ARN=$(aws elbv2 describe-tags --resource-arns ${ALB} --query "TagDescriptions[?Tags[?Key=='copilot-environment' && Value=='${PR_NUM}']].ResourceArn" --output text)
 
   if [ -n "${ARN}" ]; then
     echo "ALB ARN: ${ARN}"

--- a/src/apps/file/test_file.py
+++ b/src/apps/file/test_file.py
@@ -504,8 +504,8 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == FileNotFoundError.message
-        assert len(caplog.messages) == 1
-        assert caplog.messages[0] == f"Trying to download not existing file {self.file_id}"
+        # assert len(caplog.messages) == 1
+        # assert caplog.messages[0] == f"Trying to download not existing file {self.file_id}"
 
     async def test_answer_download_client_error__unknown_error(
         self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture, caplog: LogCaptureFixture
@@ -521,11 +521,11 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == SomethingWentWrongError.message
-        assert len(caplog.messages) == 1
-        assert (
-            caplog.messages[0]
-            == f"Error when trying to download file {self.file_id}: An error occurred (0) when calling the Unknown operation: Unknown"  # noqa: E501
-        )
+        # assert len(caplog.messages) == 1
+        # assert (
+        #     caplog.messages[0]
+        #     == f"Error when trying to download file {self.file_id}: An error occurred (0) when calling the Unknown operation: Unknown"  # noqa: E501
+        # )
 
     async def test_answer_download_client_error__cdn_client_object_not_found_error(
         self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture
@@ -571,8 +571,8 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == FileNotFoundError.message
-        assert len(caplog.messages) == 1
-        assert caplog.messages[0] == f"Trying to download not existing file {self.file_id}"
+        # assert len(caplog.messages) == 1
+        # assert caplog.messages[0] == f"Trying to download not existing file {self.file_id}"
 
     async def test_general_file_download_client_error__unknown_error(
         self, client: TestClient, tom: User, mocker: MockerFixture, caplog: LogCaptureFixture
@@ -588,11 +588,11 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == SomethingWentWrongError.message
-        assert len(caplog.messages) == 1
-        assert (
-            caplog.messages[0]
-            == f"Error when trying to download file {self.file_id}: An error occurred (0) when calling the Unknown operation: Unknown"  # noqa: E501
-        )
+        # assert len(caplog.messages) == 1
+        # assert (
+        #     caplog.messages[0]
+        #     == f"Error when trying to download file {self.file_id}: An error occurred (0) when calling the Unknown operation: Unknown"  # noqa: E501
+        # )
 
     async def test_general_file_download_client_error__cdn_client_object_not_found_error(
         self, client: TestClient, tom: User, mocker: MockerFixture
@@ -731,7 +731,7 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == SomethingWentWrongError.message
-        assert len(caplog.messages) == 1
+        # assert len(caplog.messages) == 1
 
     async def test_upload_logs__arbitrary_logs_are_uploaded_to_the_mindlogger_answer_bucket(
         self,
@@ -826,7 +826,7 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == SomethingWentWrongError.message
-        assert len(caplog.messages) == 1
+        # assert len(caplog.messages) == 1
 
     async def test_check_log_exists__no_logs(
         self, client: TestClient, device_tom: str, tom: User, mocker: MockerFixture
@@ -882,4 +882,4 @@ class TestAnswerActivityItems(BaseTest):
         result = resp.json()["result"]
         assert len(result) == 1
         assert result[0]["message"] == SomethingWentWrongError.message
-        assert len(caplog.messages) == 1
+        # assert len(caplog.messages) == 1


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8904](https://mindlogger.atlassian.net/browse/M2-8904)


<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Fixed unit test suite.  Removed logging output check based on [Tech talk decision](https://mindlogger.atlassian.net/wiki/spaces/MINDLOGGER1/pages/963084689/December+17+2024+-+Tech+Talk#%E2%A4%B4-Decisions)
- Added Datadog environment tags to feature environment resources
- Changed a security group between ALB and Fargate to only allow access to ALB dynamic ports for health checks.  Remediates SSH not blocked finding for GDPR and HIPAA

