### PR TITLE
feat: Remove date filtering from schedule history endpoints (M2-8485)

### DIFF
--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -27,8 +27,6 @@ from infrastructure.database import BaseCRUD
 class _ScheduleHistoryExportFilters(Filtering):
     respondent_ids = FilterField(EventHistorySchema.user_id, method_name="filter_respondent_ids")
     subject_ids = FilterField(SubjectSchema.id, Comparisons.IN)
-    from_date = FilterField(EventHistorySchema.created_at, Comparisons.GREAT_OR_EQUAL)
-    to_date = FilterField(EventHistorySchema.created_at, Comparisons.LESS_OR_EQUAL)
 
     def filter_respondent_ids(self, field, value):
         return or_(field.in_(value), EventHistorySchema.user_id.is_(None))

--- a/src/apps/schedule/crud/user_device_events_history.py
+++ b/src/apps/schedule/crud/user_device_events_history.py
@@ -21,8 +21,6 @@ from infrastructure.database import BaseCRUD
 
 class _UserDeviceEventsHistoryExportFilters(Filtering):
     respondent_ids = FilterField(UserDeviceEventsHistorySchema.user_id, Comparisons.IN)
-    from_date = FilterField(EventHistorySchema.created_at, Comparisons.GREAT_OR_EQUAL)
-    to_date = FilterField(EventHistorySchema.created_at, Comparisons.LESS_OR_EQUAL)
 
 
 class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):

--- a/src/apps/schedule/domain/schedule/filters.py
+++ b/src/apps/schedule/domain/schedule/filters.py
@@ -1,4 +1,3 @@
-import datetime
 import uuid
 
 from fastapi import Query
@@ -19,6 +18,4 @@ class EventQueryParams(InternalModel):
 class ScheduleEventsExportParams(BaseQueryParams):
     respondent_ids: list[uuid.UUID] | None = Field(Query(None))
     subject_ids: list[uuid.UUID] | None = Field(Query(None))
-    from_date: datetime.datetime | None = None
-    to_date: datetime.datetime | None = None
     limit: int = Field(gt=0, default=settings.service.result_limit, le=settings.service.result_limit)


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8485](https://mindlogger.atlassian.net/browse/M2-8485)

This PR removes the date query parameters from the schedule history endpoints because they are not needed on the backend. The way these data parameters are intended to be used is to exclude rows from the exported CSV file. These rows are enumerated such that one event object in the API response may produce 0 or more rows in the export file.

However, these rows are only generated on the frontend. When the API uses dates to filter event objects from the response (based on creation time), it could be removing valid events that would have otherwise generated rows that fall within the date range.

### 🪤 Peer Testing

Consume the schedule history endpoints and confirm that the `fromDate` and `toDate` query parameters are ignored

### ✏️ Notes

N/A
