### PR TITLE
chore: Revise applet-event version linking logic (M2-8973) (M2-8983) (M2-9047)

### DIFF
--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -196,9 +196,6 @@ class AppletService:
         applet = await self._update(applet_id, update_data, next_version)
         await AppletHistoryService(self.session, applet.id, applet.version).add_history(self.user_id, applet)
 
-        if next_version != old_applet_schema.version:
-            await ScheduleHistoryService(self.session).update_applet_event_links(applet_id, applet.version)
-
         applet.activities = await ActivityService(self.session, self.user_id).update_create(
             applet_id, update_data.activities
         )
@@ -228,6 +225,12 @@ class AppletService:
             )
         )
         await asyncio.gather(*to_await)
+
+        if next_version != old_applet_schema.version:
+            await ScheduleHistoryService(self.session).update_applet_event_links(
+                applet_id=applet_id, current_applet_version=old_applet_schema.version, new_applet_version=applet.version
+            )
+
         return applet
 
     async def update_encryption(self, applet_id: uuid.UUID, encryption: Encryption):

--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -17,7 +17,7 @@ from apps.schedule.db.schemas import (
     ReminderHistorySchema,
 )
 from apps.schedule.domain.schedule.public import ExportEventHistoryDto
-from apps.shared.filtering import Comparisons, FilterField, Filtering
+from apps.shared.filtering import FilterField, Filtering
 from apps.shared.paging import paging
 from apps.shared.query_params import QueryParams
 from apps.subjects.db.schemas import SubjectSchema
@@ -25,11 +25,11 @@ from infrastructure.database import BaseCRUD
 
 
 class _ScheduleHistoryExportFilters(Filtering):
-    respondent_ids = FilterField(EventHistorySchema.user_id, method_name="filter_respondent_ids")
-    subject_ids = FilterField(SubjectSchema.id, Comparisons.IN)
+    respondent_ids = FilterField(EventHistorySchema.user_id, method_name="filter_nullable_ids")
+    subject_ids = FilterField(SubjectSchema.id, method_name="filter_nullable_ids")
 
-    def filter_respondent_ids(self, field, value):
-        return or_(field.in_(value), EventHistorySchema.user_id.is_(None))
+    def filter_nullable_ids(self, field, value):
+        return or_(field.in_(value), field.is_(None))
 
 
 class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):

--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -148,6 +148,17 @@ class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):
 
 
 class AppletEventsCRUD(BaseCRUD[AppletEventsSchema]):
+    async def find_by_applet_id_version(self, applet_id_version: str) -> list[AppletEventsSchema]:
+        query = select(AppletEventsSchema)
+        query = query.where(
+            AppletEventsSchema.applet_id == applet_id_version,
+            AppletEventsSchema.soft_exists(),
+        )
+
+        res = await self._execute(query)
+
+        return res.scalars().all()
+
     async def add(self, applet_event: AppletEventsSchema) -> AppletEventsSchema:
         return await self._create(applet_event)
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8973](https://mindlogger.atlassian.net/browse/M2-8973)
🔗 [Jira Ticket M2-8983](https://mindlogger.atlassian.net/browse/M2-8983)
🔗 [Jira Ticket M2-9047](https://mindlogger.atlassian.net/browse/M2-9047)

This PR revises the logic that links versions of schedule events and applets together in the `applet_events` table. The current logic has a bug where an update to an applet that deletes an activity/flow results in the events for that activity/flow being linked to the new version of the applet in `applet_events`.

The root cause is that the linking action was being done before the events for the activity/flow were marked as deleted. This PR moves the linking action to the end of the update method to account for this.

I also took the opportunity to fix the `subject_id` field filter in the schedule history endpoints. The `subject_id` filter was missing the None condition because similar to `user_id`, when filtering by `subject_id` the event object should be returned when the field matches, or when it is null

### 🪤 Peer Testing

1. Create an applet with two activities and one activity flow. Make sure the applet is saved
2. Edit the applet to delete the second activity and the activity flow
3. Inspect the `applet_events` table by running the query below

```sql
SELECT event_histories.id as event_id,
       event_histories.version as event_version,
       applet_histories.id as applet_id,
       applet_histories.version as applet_version,
       coalesce(flow_histories.name, activity_histories.name) AS activity_or_flow_name
FROM applet_events
         JOIN event_histories ON applet_events.event_id = event_histories.id_version
         JOIN applet_histories ON applet_events.applet_id = applet_histories.id_version
         LEFT OUTER JOIN activity_histories ON event_histories.activity_id = activity_histories.id AND
                                               applet_histories.id_version = activity_histories.applet_id
         LEFT OUTER JOIN flow_histories ON event_histories.activity_flow_id = flow_histories.id AND
                                           applet_histories.id_version = flow_histories.applet_id
WHERE applet_events.applet_id ilike :applet_id || '%'
ORDER BY applet_version, event_histories.created_at;
```

Ensure the deleted activity and flow are not linked to applet version 2.0.0

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/c9499ac7-fdc4-40c0-b0d2-dc402f2964e4" />

### ✏️ Notes

N/A
