### PR TITLE
chore: Fix encryption function (M2-9066)

### DIFF
--- a/src/infrastructure/database/migrations/versions/2025_04_18_05_24-fix_encrypt_internal_function.py
+++ b/src/infrastructure/database/migrations/versions/2025_04_18_05_24-fix_encrypt_internal_function.py
@@ -1,0 +1,83 @@
+"""Fix encrypt_internal function
+
+Revision ID: 2a9ee1cea9c6
+Revises: c4e312ad0798
+Create Date: 2025-04-18 05:24:08.432983
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2a9ee1cea9c6"
+down_revision = "c4e312ad0798"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(sa.DDL(
+        """
+        create or replace function encrypt_internal(text, bytea) returns text
+        language plpgsql as
+        $$
+        declare
+            res text;
+            key_digest bytea;
+            block_size integer;
+            padded_value bytea;
+        begin
+            key_digest = digest($2, 'sha256');
+            block_size = 16;
+            padded_value = (concat($1, repeat('*', block_size - octet_length($1) %% block_size)))::bytea;
+            select
+                encode(
+                    encrypt_iv(
+                        padded_value,
+                        key_digest,
+                        substring(key_digest, 1, block_size),
+                        'aes-cbc/pad:none'
+                    ),
+                    'base64'
+                )
+            into res;
+
+            return res;
+        end;
+        $$;
+        """
+    ))
+
+
+def downgrade() -> None:
+    op.execute(sa.DDL(
+        """
+        create or replace function encrypt_internal(text, bytea) returns text
+        language plpgsql as
+        $$
+        declare
+            res text;
+            key_digest bytea;
+            block_size integer;
+            padded_value bytea;
+        begin
+            key_digest = digest($2, 'sha256');
+            block_size = 16;
+            padded_value = (concat($1, repeat('*', block_size - length($1) %% block_size)))::bytea;
+            select
+                encode(
+                    encrypt_iv(
+                        padded_value,
+                        key_digest,
+                        substring(key_digest, 1, block_size),
+                        'aes-cbc/pad:none'
+                    ),
+                    'base64'
+                )
+            into res;
+
+            return res;
+        end;
+        $$;
+        """
+    ))


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9066](https://mindlogger.atlassian.net/browse/M2-9066)

This PR updates the `encrypt_internal` postgres function to support non-english characters.

The content of encrypted columns in the database is encrypted/decrypted by SQLAlchemy's `StringEncryptedType` during normal operation of the API. We have created `encrypt_internal` and `decrypt_internal` functions in the database to mirror this, but the definition of the `encrypt_internal` function currently does not support non-english characters because it uses the `length` function to determine the padding to add to the plaintext.

The `length` function counts characters, whereas the `encrypt_iv` function operates on bytes in multiples of the block size. Some non-english characters can represent multiple bytes, and using `length` results in a padded plaintext that is not a multiple of the block size, and in turn the inability to encrypt these characters using the same key that the API is using (as in the case of the `encryption reencrypt` command).

This PR simply changes the `encrypt_internal` function to use `octet_length` instead (which counts bytes) to determine how much padding is needed.

### 🪤 Peer Testing

1. Run this query on your local database before running the migration:
    ```sql
    -- This is a random secret key for the purpose of this PR
    SELECT encrypt_internal('ЯЂҤНӤЏДЏ', decode('ae3d6778b4cbaaba2230685961ca5d0eff309510a15578725da5cb459cfe23f3', 'hex'));
    ```
2. Confirm that you received this error
    ```text
    [2025-04-18 05:42:04] [39000] ERROR: encrypt_iv error: Encryption failed
    [2025-04-18 05:42:04] Where: SQL statement "select
    [2025-04-18 05:42:04] encode(
    [2025-04-18 05:42:04] encrypt_iv(
    [2025-04-18 05:42:04] padded_value,
    [2025-04-18 05:42:04] key_digest,
    [2025-04-18 05:42:04] substring(key_digest, 1, block_size),
    [2025-04-18 05:42:04] 'aes-cbc/pad:none'
    [2025-04-18 05:42:04] ),
    [2025-04-18 05:42:04] 'base64'
    [2025-04-18 05:42:04] )"
    [2025-04-18 05:42:04] PL/pgSQL function encrypt_internal(text,bytea) line 11 at SQL statement
    ```
3. Run the migration `alembic upgrade head`
4. Run the query again
    ```sql
    -- This is a random secret key for the purpose of this PR
    SELECT encrypt_internal('ЯЂҤНӤЏДЏ', decode('ae3d6778b4cbaaba2230685961ca5d0eff309510a15578725da5cb459cfe23f3', 'hex'));
    ```
5. Confirm success
    <img width="394" alt="image" src="https://github.com/user-attachments/assets/19a0a35c-f6d1-47e5-87d7-c83bf25dd8ce" />

### ✏️ Notes

N/A