### PR TITLE
Fix: Grammar mistake fix on email body (M2-5571)

### DIFF
--- a/src/apps/mailing/static/templates/invitation_new_user_en.html
+++ b/src/apps/mailing/static/templates/invitation_new_user_en.html
@@ -10,7 +10,7 @@
   </tr>
   <tr>
     <td style="padding-bottom: 1%">
-      You have been invited to become a {{role}} of <b>"{{applet_name}}"</b> in MindLogger, a data collection platform for mental health and learning challenges.
+      You have been invited to become {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} of <b>"{{applet_name}}"</b> in MindLogger, a data collection platform for mental health and learning challenges.
     </td>
   </tr>
   <tr>

--- a/src/apps/mailing/static/templates/invitation_registered_user_en.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_en.html
@@ -10,7 +10,7 @@
   </tr>
   <tr>
     <td style="padding-bottom: 1%">
-      You have been invited to become a {{role}} of <b>"{{applet_name}}"</b> in MindLogger.
+      You have been invited to become {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} of <b>"{{applet_name}}"</b> in MindLogger.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION


### 📝 Description


🔗 [Jira Ticket M2-#](https://mindlogger.atlassian.net/browse/M2-5571)


Example test step:

- When adding an Agent to an applet, the email states `Have been invited as AN agent` as opposed to `Have been invited as A agent`.

### ✏️ Notes

This fixes a small grammatical issue in our English email templates that improves the professionalism of our communications.
