### PR TITLE
fix: Check applet name uniqueness against owned applets rather than accessible applets (M2-8969)

### DIFF
--- a/src/apps/applets/crud/applets.py
+++ b/src/apps/applets/crud/applets.py
@@ -669,6 +669,12 @@ class AppletsCRUD(BaseCRUD[AppletSchema]):
         )
         await self._execute(query)
 
+    def owner_applet_ids_query(self, owner_id: uuid.UUID) -> Query:
+        query: Query = select(AppletSchema.id)
+        query = query.where(AppletSchema.soft_exists())
+        query = query.where(AppletSchema.creator_id == owner_id)
+        return query
+
     async def get_respondents_device_ids(
         self,
         applet_id: uuid.UUID,

--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -352,11 +352,11 @@ class AppletService:
         )
 
     async def _validate_applet_name(self, display_name: str, exclude_by_id: uuid.UUID | None = None):
-        applet_ids_query = UserAppletAccessCRUD(self.session).user_applet_ids_query(self.user_id)
-        existed_applet = await AppletsCRUD(self.session).get_by_display_name(
+        applet_ids_query = AppletsCRUD(self.session).owner_applet_ids_query(self.user_id)
+        existing_applet = await AppletsCRUD(self.session).get_by_display_name(
             display_name, applet_ids_query, exclude_by_id
         )
-        if existed_applet:
+        if existing_applet:
             raise AppletAlreadyExist()
 
     async def _update(self, applet_id: uuid.UUID, update_data: AppletUpdate, version: str) -> AppletFull:


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-8969](https://mindlogger.atlassian.net/browse/M2-8969)

When creating, updating or duplicating applets, applet name uniqueness should now be checked against applets owned by that user (in the same workspace), rather than all applets that the user has access to.

### 🪤 Peer Testing

1. Create an applet in a workspace owned by User1 with a name such as "ProblemApplet"
2. Log in as a User2 and create an applet with the same name as above, "ProblemApplet", in the workspace owned by this user
3. Invite User3 to both of these applets as either a manager or editor:
    1.  Log in as User1
    2.  Invite User3 to "ProblemApplet", and User3 accepts the invitation
    3.  Log in as User2
    4.  Invite User3 to "ProblemApplet", and User3 accepts the invitation
4. Log in as User3
5. Edit either of the two applets named "ProblemApplet" in the corresponding workspace by doing something other than changing the applet's name (such as editing one of the activities).
    **Expected outcome:** The applet should be saved successfully, rather than cause a 400 error.