### PR TITLE
fix: Link old event versions to new applet versions (M2-9135)

### DIFF
--- a/src/apps/applets/service/applet.py
+++ b/src/apps/applets/service/applet.py
@@ -187,6 +187,7 @@ class AppletService:
 
     async def update(self, applet_id: uuid.UUID, update_data: AppletUpdate) -> AppletFull:
         old_applet_schema = await AppletsCRUD(self.session).get_by_id(applet_id)
+        old_applet_version = old_applet_schema.version
 
         next_version = await self.get_next_version(old_applet_schema.version, update_data, applet_id)
 
@@ -226,9 +227,9 @@ class AppletService:
         )
         await asyncio.gather(*to_await)
 
-        if next_version != old_applet_schema.version:
+        if next_version != old_applet_version:
             await ScheduleHistoryService(self.session).update_applet_event_links(
-                applet_id=applet_id, current_applet_version=old_applet_schema.version, new_applet_version=applet.version
+                applet_id=applet_id, current_applet_version=old_applet_version, new_applet_version=applet.version
             )
 
         return applet


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9135](https://mindlogger.atlassian.net/browse/M2-9135)

This PR fixes a regression introduced by #1820 wherein old event version weren't being linked to the new applet versions in the `applet_events` table. The bug happens when the applet version is increased by creating a new activity/flow.

### 🪤 Peer Testing

1. Create an applet with 1 activity and note the ID of the applet
2. Run the query and observe the results: `SELECT applet_id, event_id from applet_events WHERE applet_id ilike :applet_id || '%'`
3. Confirm that there is one row in the result with the applet_id ending in `_1.1.0`
4. Add a new activity to the applet
5. Run the query again and observe the results
6. Confirm that there are now two (2) additional rows with the applet_id ending in `_2.0.0`. One of these rows should have the same `event_id` as the row with applet_id ending in `_1.1.0`
7. Remove the new activity from the applet
8. Run the query again and observe the results
9. Confirm that there is now one (1) additional row with the applet_id ending in `_3.0.0`. This row should have the same `event_id` as the row with applet_id ending in `_1.1.0`

### ✏️ Notes

N/A
