### PR TITLE
feat: Return `scheduledEventHistoryId` from `/answers/applet/{applet_id}/data` endpoint (M2-9153)

### DIFF
--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -357,6 +357,7 @@ class AnswersCRUD(BaseCRUD[AnswerSchema]):
                 AnswerSchema.client,
                 AnswerItemSchema.tz_offset,
                 AnswerItemSchema.scheduled_event_id,
+                AnswerSchema.event_history_id.label("scheduled_event_history_id"),
             )
             .select_from(AnswerSchema)
             .join(AnswerItemSchema, AnswerItemSchema.answer_id == AnswerSchema.id)

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -554,6 +554,7 @@ class UserAnswerDataBase(BaseModel):
     migrated_date: datetime.datetime | None = None
     tz_offset: int | None = None
     scheduled_event_id: uuid.UUID | str | None = None
+    scheduled_event_history_id: str | None = None
     applet_history_id: str
     activity_history_id: str | None
     flow_history_id: str | None

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -2005,7 +2005,7 @@ class TestAnswerActivityItems(BaseTest):
             "sourceSubjectId", "sourceSecretId", "sourceUserNickname", "sourceUserTag",
             "targetSubjectId", "targetSecretId", "targetUserNickname", "targetUserTag",
             "inputSubjectId", "inputSecretId", "inputUserNickname",
-            "client", "tzOffset", "scheduledEventId", "reviewedFlowSubmitId"
+            "client", "tzOffset", "scheduledEventId", "scheduledEventHistoryId", "reviewedFlowSubmitId"
         }
         # Comment for now, wtf is it
         # assert int(answer['startDatetime'] * 1000) == answer_item_create.start_time

--- a/src/apps/answers/tests/test_answers_arbitrary.py
+++ b/src/apps/answers/tests/test_answers_arbitrary.py
@@ -704,7 +704,7 @@ class TestAnswerActivityItems(BaseTest):
             "sourceSubjectId", "sourceSecretId", "sourceUserNickname", "sourceUserTag",
             "targetSubjectId", "targetSecretId", "targetUserNickname", "targetUserTag",
             "inputSubjectId", "inputSecretId", "inputUserNickname",
-            "client", "tzOffset", "scheduledEventId", "reviewedFlowSubmitId"
+            "client", "tzOffset", "scheduledEventId", "scheduledEventHistoryId", "reviewedFlowSubmitId"
         }
 
         assert set(assessment.keys()) == expected_keys


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-9153](https://mindlogger.atlassian.net/browse/M2-9153)

This PR adds a new nullable `scheduledEventHistoryId` property to the data being returned from the `/answers/applet/{applet_id}/data` endpoint. It comes directly from the `event_history_id` column of the answers table.

### 🪤 Peer Testing

1. Create a new applet, or use an existing applet
2. Respond to an activity in the applet
3. Export the applet data
4. Inspect the response from the `/answers/applet/{applet_id}/data` endpoint in dev tools
5. Confirm that the `scheduledEventHistoryId` property is present

### ✏️ Notes

N/A