### PR TITLE
fix: Associating Datadog logs and traces

### DIFF
--- a/src/infrastructure/dependency/structured_logs.py
+++ b/src/infrastructure/dependency/structured_logs.py
@@ -67,7 +67,7 @@ def setup_structured_logging(json_logs: bool = False, log_level: str = "INFO"):
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.stdlib.ExtraAdder(),
         drop_color_message_key,
-        # tracer_injection, # Not needed, patched in
+        tracer_injection,
         timestamper,
         # Console renderer does not like this, and it doesn't seem to affect JSON logs
         # structlog.processors.dict_tracebacks,


### PR DESCRIPTION


### 📝 Description

Fixed logging where traces and logs are not associated
