### PR TITLE
feat: Add max retries and logging to OneUpHealth tasks (m2-8982)

### DIFF
--- a/src/apps/integrations/oneup_health/tests/test_task.py
+++ b/src/apps/integrations/oneup_health/tests/test_task.py
@@ -381,7 +381,7 @@ class TestTaskIngestUserData:
                     activity_id=applet_one.activities[0].id,
                     start_date=start_date,
                     retry_count=retry_count + 1,
-                    error_retry_count=error_retry_count + 1,
+                    error_retry_count=error_retry_count,
                 )
 
     @pytest.mark.asyncio

--- a/src/apps/integrations/oneup_health/tests/test_task.py
+++ b/src/apps/integrations/oneup_health/tests/test_task.py
@@ -404,5 +404,5 @@ class TestTaskIngestUserData:
                 result = await task.wait_result()
                 # The result should be None due to the connection error
                 assert result.return_value is None
-                # The function should have been retried a total of 5 times
-                assert mock_retry.call_count == 5
+                # The function should have been retried a total of 5 times, so the retry function is called 4 times.
+                assert mock_retry.call_count == 4

--- a/src/config/oneup_health.py
+++ b/src/config/oneup_health.py
@@ -8,3 +8,4 @@ class OneUpHealthSettings(BaseModel):
     auth_base_url: str = "https://auth.1up.health"
     base_backoff_delay: int = 5
     max_backoff_delay: int = 60 * 60 * 24
+    max_error_retries: int = 5


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->
(https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description


🔗 [Jira Ticket M2-8982](https://mindlogger.atlassian.net/browse/M2-8982)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Adds a max retries parameter to OneUpHealth config.
- Checks and retries up until max retries are spent
- Logs adequately
