### PR TITLE
fix: EMA Fast Follows 2 (M2-9108) (M2-9161)

### DIFF
--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -85,9 +85,9 @@ class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):
             EventHistorySchema.one_time_completion,
             EventHistorySchema.periodicity,
             EventHistorySchema.start_date,
-            EventHistorySchema.start_time,
+            func.coalesce(EventHistorySchema.start_time, "00:00:00").label("start_time"),
             EventHistorySchema.end_date,
-            EventHistorySchema.end_time,
+            func.coalesce(EventHistorySchema.end_time, "23:59:00").label("end_time"),
             EventHistorySchema.selected_date,
         ]
 

--- a/src/apps/schedule/crud/schedule_history.py
+++ b/src/apps/schedule/crud/schedule_history.py
@@ -1,6 +1,7 @@
 __all__ = ["ScheduleHistoryCRUD", "AppletEventsCRUD", "NotificationHistoryCRUD", "ReminderHistoryCRUD"]
 
 import asyncio
+import datetime
 import uuid
 
 from sqlalchemy import or_, select, update
@@ -85,9 +86,9 @@ class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):
             EventHistorySchema.one_time_completion,
             EventHistorySchema.periodicity,
             EventHistorySchema.start_date,
-            func.coalesce(EventHistorySchema.start_time, "00:00:00").label("start_time"),
+            func.coalesce(EventHistorySchema.start_time, datetime.time(0, 0, 0)).label("start_time"),
             EventHistorySchema.end_date,
-            func.coalesce(EventHistorySchema.end_time, "23:59:00").label("end_time"),
+            func.coalesce(EventHistorySchema.end_time, datetime.time(23, 59, 0)).label("end_time"),
             EventHistorySchema.selected_date,
         ]
 
@@ -130,7 +131,7 @@ class ScheduleHistoryCRUD(BaseCRUD[EventHistorySchema]):
 
         unlabeled_columns = [col.element if hasattr(col, "element") else col for col in columns]
 
-        query = query.group_by(*unlabeled_columns)
+        query = query.group_by(*unlabeled_columns, EventHistorySchema.start_time, EventHistorySchema.end_time)
         query = query.order_by(EventHistorySchema.created_at, AppletEventsSchema.created_at)
 
         query_count: Query = select(func.count()).select_from(query.with_only_columns(*unlabeled_columns).subquery())

--- a/src/apps/schedule/crud/user_device_events_history.py
+++ b/src/apps/schedule/crud/user_device_events_history.py
@@ -102,9 +102,9 @@ class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):
             UserDeviceEventsHistorySchema.event_id,
             UserDeviceEventsHistorySchema.event_version,
             EventHistorySchema.start_date,
-            EventHistorySchema.start_time,
+            func.coalesce(EventHistorySchema.start_time, datetime.time(0, 0, 0)).label("start_time"),
             EventHistorySchema.end_date,
-            EventHistorySchema.end_time,
+            func.coalesce(EventHistorySchema.end_time, datetime.time(23, 59, 0)).label("end_time"),
             EventHistorySchema.access_before_schedule,
             UserDeviceEventsHistorySchema.created_at,
             UserDeviceEventsHistorySchema.time_zone.label("user_time_zone"),
@@ -134,7 +134,7 @@ class UserDeviceEventsHistoryCRUD(BaseCRUD[UserDeviceEventsHistorySchema]):
             query = query.where(*_filters)
 
         unlabeled_columns = [col.element if hasattr(col, "element") else col for col in columns]
-        query = query.group_by(*unlabeled_columns)
+        query = query.group_by(*unlabeled_columns, EventHistorySchema.start_time, EventHistorySchema.end_time)
 
         query = query.order_by(UserDeviceEventsHistorySchema.created_at)
 

--- a/src/apps/workspaces/domain/workspace.py
+++ b/src/apps/workspaces/domain/workspace.py
@@ -88,6 +88,8 @@ class WorkspaceRespondentDetails(InternalModel):
     subject_first_name: str
     subject_last_name: str
     subject_created_at: datetime.datetime
+    subject_updated_at: datetime.datetime
+    subject_is_deleted: bool
     invitation: InvitationDetail | None = None
     roles: list[Role]
 
@@ -202,6 +204,8 @@ class PublicWorkspaceRespondentDetails(PublicModel):
     subject_first_name: str
     subject_last_name: str
     subject_created_at: datetime.datetime
+    subject_updated_at: datetime.datetime
+    subject_is_deleted: bool
     invitation: InvitationResponse | None = None
     roles: list[Role]
     team_member_can_view_data: bool = False

--- a/src/apps/workspaces/filters.py
+++ b/src/apps/workspaces/filters.py
@@ -9,4 +9,5 @@ class WorkspaceUsersQueryParams(BaseQueryParams):
     shell: bool | None
     user_id: uuid.UUID | None = None
     respondent_secret_id: str | None = None
+    include_soft_deleted_subjects: bool = False
     ordering = "-isPinned,-createdAt"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9108](https://mindlogger.atlassian.net/browse/M2-9108)
🔗 [Jira Ticket M2-9161](https://mindlogger.atlassian.net/browse/M2-9161)

This PR updates a couple API endpoints in preparation for a corresponding PR that resolves the captioned tickets.

#### M2-9108: The whole schedule_history associated with the removed participant is also removed

This ticket is about retaining schedule history in the export file for participants whose subjects are soft deleted. The FE uses the workspace respondents endpoint to fetch the complete list of participants in the applet, and generate an enumerated export file for each of them for the selected date range. This PR updates the workspace respondents endpoint to optionally include soft deleted participants, and adds two key properties to the response:
- `subjectIsDeleted` - Whether the subject is soft deleted within a given applet
- `subjectUpdatedAt` - The date when the last change was made to this subject (approximating the deletion date)

This will allow the FE to generate an enumerated schedule history for soft deleted participants up to the day when they were removed from the applet.

> [!NOTE]
> This only applies to soft deletion, which is when the admin removes the participant without removing their data. When the admin chooses to remove the data, the subject is hard-deleted and will be removed from the workspace respondents api response

#### M2-9161: 500 error appears in the Console after starting export in Migrated applet

This is the result of migrated applets having `NULL` values in the `start_date` and `start_time` database columns for always available schedule events. Current applets always populate these fields for all periodicities. I have accounted for this in the schedule history endpoint by defaulting the values of these fields to those used by the BE when creating events with an always available periodicity: namely `'00:00:00'` and `'23:59:00'` respectively.

### 🪤 Peer Testing

#### M2-9108

- Remove a participant from one of your existing applets, without removing their data
- Export schedule history for the applet and confirm that their schedule history is still present

You could technically do this with a new applet as well, but the effect is more pronounced with an existing applet

#### M2-9161

- Manually edit the `start_time` and `end_time` column in the `event_histories` table for an always available event in one of your applets
- Export the schedule history for that applet
- Confirm that it exports successfully


### ✏️ Notes

N/A