### PR TITLE
fix: Support nuanced applet update scenario (M2-8969)

### DIFF
--- a/src/apps/applets/commands/applet/seed/command.py
+++ b/src/apps/applets/commands/applet/seed/command.py
@@ -728,7 +728,11 @@ async def seed_applet_v1(config: AppletConfigFileV1, from_cli: bool = False) -> 
                         pass
 
                     try:
-                        await applet_service._validate_applet_name(applet.display_name)
+                        # When seeding applets, validate name uniqueness against the authenticated user's applets
+                        # since they will be the owner of the newly seeded applet.
+                        # We pass applet_service.user_id as the owner_id to check for name conflicts
+                        # only among applets owned by this user.
+                        await applet_service._validate_applet_name(applet.display_name, applet_service.user_id)
                     except AppletAlreadyExist as e:
                         raise AppletNameAlreadyExistsError(applet.display_name) from e
 

--- a/src/apps/integrations/oneup_health/tests/test_oneup_health.py
+++ b/src/apps/integrations/oneup_health/tests/test_oneup_health.py
@@ -152,6 +152,7 @@ class TestOneupHealth:
             },
         )
 
+        assert tom_applet_one_subject.id is not None
         app_user_id = get_unique_short_id(submit_id=tom_applet_one_subject.id, activity_id=None)
         client.login(tom)
         response = await client.get(url=self.get_token_url.format(subject_id=tom_applet_one_subject.id))


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8969](https://mindlogger.atlassian.net/browse/M2-8969)

This change allows a user A who owns an applet having the same name as user B's applet, and is also a manager/editor of user B's applet, to successfully update user B's applet.

### 🪤 Peer Testing

From the Admin App:
1. As User A, create an applet `test applet same name`.
2. As User B, create an applet with the same name, `test applet same name`.
3. Add User A as a manager to User B's applet.
4. Log in as User B, navigate to User B's workspace.
5. Edit User B's applet, change the applet's description, and Save & Publish.
    **Expected outcome:** Saving the applet should succeed.
