### PR TITLE
fix: Clean up subjects table is_deleted column (M2-9161) (M2-9250)

### DIFF
--- a/src/infrastructure/database/migrations/versions/2025_05_20_09_52-clean_up_subjects_is_deleted.py
+++ b/src/infrastructure/database/migrations/versions/2025_05_20_09_52-clean_up_subjects_is_deleted.py
@@ -31,5 +31,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(sa.text("UPDATE subjects SET is_deleted = NULL WHERE is_deleted_null = TRUE"))
+    op.execute(sa.text("UPDATE subjects SET is_deleted = NULL WHERE is_deleted IS FALSE AND is_deleted_null IS TRUE"))
     op.drop_column("subjects", "is_deleted_null")

--- a/src/infrastructure/database/migrations/versions/2025_05_20_09_52-clean_up_subjects_is_deleted.py
+++ b/src/infrastructure/database/migrations/versions/2025_05_20_09_52-clean_up_subjects_is_deleted.py
@@ -1,0 +1,35 @@
+"""Clean up the subjects table is_deleted column
+
+Revision ID: a05c838b8aad
+Revises: 9b882445f218
+Create Date: 2025-05-20 09:52:05.737528
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a05c838b8aad"
+down_revision = "9b882445f218"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("subjects", sa.Column("is_deleted_null", sa.Boolean(), server_default=sa.false(), nullable=False))
+    op.execute(sa.text("UPDATE subjects SET is_deleted_null = TRUE, is_deleted = FALSE WHERE is_deleted IS NULL"))
+
+    # Alter the is_deleted column to be non-nullable
+    op.alter_column(
+        "subjects",
+        "is_deleted",
+        existing_type=sa.Boolean(),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("UPDATE subjects SET is_deleted = NULL WHERE is_deleted_null = TRUE"))
+    op.drop_column("subjects", "is_deleted_null")


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9161](https://mindlogger.atlassian.net/browse/M2-9161)
🔗 [Jira Ticket M2-9250](https://mindlogger.atlassian.net/browse/M2-9250)

This PR adds a data migration that changes `NULL` values in the `is_deleted` column of the `subjects` table to `FALSE`. This is in line with how the soft_exists method is implemented, where it returns records where `is_deleted IS NOT TRUE`

https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/be20fbecdfe55bc5959b94a8914202d63df59c8b/src/infrastructure/database/mixins.py#L12-L15

I've added an extra column to track these values, in case we need to go back

### 🪤 Peer Testing

> [!IMPORTANT]
> Begin this test **before** running the migration

1. Edit the database row of one of the subjects in your applet, setting `id_deleted` to `NULL`
2. Load the participants tab of the applet and confirm that the participants fail to load. Check the network tab for a 500 error
3. Run the migration with `alembic upgrade head`
4. Reload the participants tab and confirm that the participants load
5. Perform a data export with schedule history checked. Confirm that the export is successful

### ✏️ Notes

N/A
