### PR TITLE
fix: Add cleanup migration for erroneous records in applet_events (M2-9237)

### DIFF
--- a/src/infrastructure/database/migrations/versions/2025_05_21_10_55-clean_up_applet_events_table.py
+++ b/src/infrastructure/database/migrations/versions/2025_05_21_10_55-clean_up_applet_events_table.py
@@ -1,0 +1,109 @@
+"""Clean up applet_events table
+
+Revision ID: b35481672766
+Revises: a05c838b8aad
+Create Date: 2025-05-21 10:55:15.571446
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "b35481672766"
+down_revision = "a05c838b8aad" # This revision ID does not exist on the develop branch yet, so this PR should not be merged until it does
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create a temporary table to remove the deleted records
+    # Should be removed in a subsequent migration
+    op.create_table(
+        "applet_events_cleanup",
+        sa.Column("is_deleted", sa.Boolean(), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("migrated_date", sa.DateTime(), nullable=True),
+        sa.Column("migrated_updated", sa.DateTime(), nullable=True),
+        sa.Column("applet_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_applet_events_cleanup")),
+        sa.UniqueConstraint("applet_id", "event_id", "is_deleted", name="_unique_applet_events_cleanup"),
+    )
+
+    # Archive the rows that will be deleted
+    op.execute("""
+               INSERT INTO applet_events_cleanup (is_deleted, id, created_at, updated_at,
+                                                  migrated_date,
+                                                  migrated_updated,
+                                                  applet_id,
+                                                  event_id)
+               SELECT applet_events.is_deleted,
+                      applet_events.id,
+                      applet_events.created_at,
+                      applet_events.updated_at,
+                      applet_events.migrated_date,
+                      applet_events.migrated_updated,
+                      applet_events.applet_id,
+                      applet_events.event_id
+               FROM event_histories
+                        JOIN applet_events ON event_histories.id_version = applet_events.event_id
+                        JOIN applet_histories ON applet_events.applet_id = applet_histories.id_version
+                        LEFT OUTER JOIN subjects
+                                        ON event_histories.user_id = subjects.user_id AND
+                                           applet_histories.id = subjects.applet_id
+                        LEFT OUTER JOIN activity_histories
+                                        ON event_histories.activity_id = activity_histories.id AND
+                                           applet_histories.id_version = activity_histories.applet_id
+                        LEFT OUTER JOIN flow_histories
+                                        ON event_histories.activity_flow_id = flow_histories.id AND
+                                           applet_histories.id_version = flow_histories.applet_id
+               WHERE coalesce(flow_histories.applet_id, activity_histories.applet_id) IS NULL
+               """)
+
+    # Delete entries from applet_events
+    op.execute("""
+        DELETE FROM applet_events
+        WHERE id IN (
+            SELECT applet_events.id
+            FROM event_histories
+                     JOIN applet_events ON event_histories.id_version = applet_events.event_id
+                     JOIN applet_histories ON applet_events.applet_id = applet_histories.id_version
+                     LEFT OUTER JOIN subjects
+                                     ON event_histories.user_id = subjects.user_id AND
+                                        applet_histories.id = subjects.applet_id
+                     LEFT OUTER JOIN activity_histories
+                                     ON event_histories.activity_id = activity_histories.id AND
+                                        applet_histories.id_version = activity_histories.applet_id
+                     LEFT OUTER JOIN flow_histories
+                                     ON event_histories.activity_flow_id = flow_histories.id AND
+                                        applet_histories.id_version = flow_histories.applet_id
+            WHERE coalesce(flow_histories.applet_id, activity_histories.applet_id) IS NULL
+        )
+    """)
+
+
+def downgrade() -> None:
+    # Restore the archived rows
+    op.execute("""
+               INSERT INTO applet_events (is_deleted, id, created_at, updated_at,
+                                          migrated_date,
+                                          migrated_updated,
+                                          applet_id,
+                                          event_id)
+               SELECT is_deleted,
+                      id,
+                      created_at,
+                      updated_at,
+                      migrated_date,
+                      migrated_updated,
+                      applet_id,
+                      event_id
+               FROM applet_events_cleanup
+               """)
+
+    # Drop the archive table
+    op.drop_table('applet_events_cleanup')


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9237](https://mindlogger.atlassian.net/browse/M2-9237)

> [!NOTE]
> This PR should **not** be reviewed until this ticket has been prioritised

This PR adds a migration that moves the erroneous entries in the `applet_events` table to a temporary table called `applet_events_cleanup` for eventual permanent deletion. This should fix failed data exports in applets with deleted activities/flows before the implementation of M2 9161.

Prior to the implementation of that ticket, rows were created in the applet_events table linking activities/flows (and their events) with versions of the applet they don't exist in. The downstream effect of this is that the API endpoint that returns applet schedule history fails because the query returns `NULL` values for the result of the JOINs with the `activity_histories`and `flow_histories` tables for these rows

### 🪤 Peer Testing

> [!IMPORTANT]
> Start this test **before** running the migration

#### Prepare

1. Create an applet with two activities and two flows. Save it.
2. Remove the first activity and the first flow from the applet. Save it
3. Perform a data export with the schedule history checkbox checked. Confirm the export succeeds.
4. Now we need to simulate the erroneous data by adding extra rows to the `applet_events` table representing the deleted items linked to the new applet version

To do this, we will first need to identify the IDs of the deleted activity and flow. Run this query to get a rundown of the history of the applet (replace the applet ID)

```sql
SELECT applet_histories.id_version applet_history_id,
       coalesce(flow_histories.id_version, activity_histories.id_version) activity_or_flow_history_id,
       coalesce(flow_histories.name, activity_histories.name) activity_or_flow_name,
       event_histories.id_version event_history_id
FROM event_histories
         JOIN applet_events ON event_histories.id_version = applet_events.event_id
         JOIN applet_histories ON applet_events.applet_id = applet_histories.id_version
         LEFT OUTER JOIN activity_histories
                         ON event_histories.activity_id = activity_histories.id AND
                            applet_histories.id_version = activity_histories.applet_id
         LEFT OUTER JOIN flow_histories
                         ON event_histories.activity_flow_id = flow_histories.id AND
                            applet_histories.id_version = flow_histories.applet_id
WHERE applet_events.applet_id ilike '451a9989-a3b2-4844-818f-130dceaf55a0%'
ORDER BY applet_events.created_at;
```

This should give a result like this

<img width="1637" alt="image" src="https://github.com/user-attachments/assets/17108818-9649-4683-b8b5-3fa86308288d" />

These are the entities are are interested in:

- New Activity 1 (d8b10853-8db6-4366-92df-34aa73430672) and its event history ID 5a00c6cb-f8a0-425a-bbd0-1c45090d6ff7_20250521-1
- Flow 1 (7a75475e-6d9a-4451-a0e9-ad09500f7d57) and its event history ID 422a8b18-a123-4b6e-8569-7583a3c88ff7_20250521-1

Now let's insert new rows into applet_events

```sql
INSERT INTO applet_events (is_deleted, created_at, updated_at, migrated_date, migrated_updated, applet_id, event_id)
SELECT is_deleted,
       created_at,
       updated_at,
       migrated_date,
       migrated_updated,
       applet_id,
       '5a00c6cb-f8a0-425a-bbd0-1c45090d6ff7_20250521-1' as event_id
FROM applet_events
WHERE applet_id = '451a9989-a3b2-4844-818f-130dceaf55a0_2.0.0'
AND event_id = 'f920005b-f1c8-424b-9356-78d2c3a4be17_20250521-1';

INSERT INTO applet_events (is_deleted, created_at, updated_at, migrated_date, migrated_updated, applet_id, event_id)
SELECT is_deleted,
       created_at,
       updated_at,
       migrated_date,
       migrated_updated,
       applet_id,
       '422a8b18-a123-4b6e-8569-7583a3c88ff7_20250521-1' as event_id
FROM applet_events
WHERE applet_id = '451a9989-a3b2-4844-818f-130dceaf55a0_2.0.0'
  AND event_id = 'f920005b-f1c8-424b-9356-78d2c3a4be17_20250521-1';
```

Here we're using the event history ID of _New Activity 2_ (which already has a row in applet_events for applet version 2) for the insert

#### Test

1. Log into the admin panel
5. Perform a data export with the schedule history checkbox checked
6. Confirm the data export fails with a 500 error
7. Run the migration with `alembic upgrade head`
8. Perform the data export again and confirm it works this time

### ✏️ Notes

N/A
