### PR TITLE
chore: Presign All URLs (M2-9231)

### DIFF
--- a/src/apps/file/services.py
+++ b/src/apps/file/services.py
@@ -67,8 +67,6 @@ class S3PresignService:
             if not await self._check_access_to_legacy_url(url):
                 return url
             key = self._get_key(url)
-            if legacy_cdn_client.is_bucket_public() or await legacy_cdn_client.is_object_public(key):
-                return await legacy_cdn_client.generate_public_url(key)
             return await legacy_cdn_client.generate_presigned_url(key)
         elif self._is_regular_file_url_format(url):
             if not await self._check_access_to_regular_url(url):


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9231](https://mindlogger.atlassian.net/browse/M2-9231)

This PR updates the logic in the S3PresignService to sign all URLs sent to the `/file/{applet_id}/presign` endpoint. This makes the behaviour of all such services (i.e. GCPPresignService, AzurePresignService) consistent.

### 🪤 Peer Testing

There's really no easy way to test this in dev, as there are no legacy media URLs in its applets as far as I am aware. In UAT, it's just a matter of exporting data from a legacy applet that has legacy media links in the answers and observing the result from the presign endpoint. Prior to this change, the endpoints URLs would be unsigned, but with the change they should all be signed.

Let me know if you are keen to verify this through peer testing in dev and I'll devise a method to do it.

### ✏️ Notes

N/A
