### PR TITLE
Adding new scenarios in invite test

### DIFF
--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -1183,7 +1183,6 @@ class TestInvite(BaseTest):
             invitation_reviewer_data,
         )
         assert response.status_code == http.HTTPStatus.FORBIDDEN
-        result= response.json()["result"]
         assert response.json()["result"][0]["message"] == AppletInviteAccessDenied.message
 
     async def test_editor_can_NOT_invite_new_reviewer_for_a_specific_respondent(

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -30,6 +30,7 @@ from apps.invitations.errors import (
     RespondentInvitationExist,
 )
 from apps.mailing.services import TestMail
+from apps.shared.exception import AccessDeniedError
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
 from apps.subjects.crud import SubjectsCrud
@@ -38,6 +39,7 @@ from apps.subjects.services import SubjectsService
 from apps.users import UserSchema
 from apps.users.domain import User, UserCreate, UserCreateRequest
 from apps.workspaces.domain.constants import UserPinRole
+from apps.workspaces.errors import AppletInviteAccessDenied
 from apps.workspaces.service.user_access import UserAccessService
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
 
@@ -1167,3 +1169,52 @@ class TestInvite(BaseTest):
         assert response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
         message = response.json()["result"][0]["message"]
         assert message == RespondentInvitationExist.message
+
+    async def test_respondent_can_NOT_invite_new_reviewer_for_a_specific_respondent(
+        self,
+        client: TestClient,
+        invitation_reviewer_data: InvitationReviewerRequest,
+        lucy: User,
+        applet_one: AppletFull,
+    ):
+        client.login(lucy)
+        # try to invite a reviewer for a specific respondent
+        response = await client.post(
+            self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
+            invitation_reviewer_data,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        result= response.json()["result"]
+        assert response.json()["result"][0]["message"] == AppletInviteAccessDenied.message
+
+    async def test_editor_can_NOT_invite_new_reviewer_for_a_specific_respondent(
+        self,
+        client: TestClient,
+        invitation_reviewer_data: InvitationReviewerRequest,
+        mike: User,
+        applet_one: AppletFull,
+    ):
+        client.login(mike)
+        # try to invite a reviewer for a specific respondent
+        response = await client.post(
+            self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
+            invitation_reviewer_data,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        assert response.json()["result"][0]["message"] == AppletInviteAccessDenied.message
+
+    async def test_coordinator_can_NOT_invite_new_reviewer_for_a_specific_respondent(
+        self,
+        client: TestClient,
+        invitation_reviewer_data: InvitationReviewerRequest,
+        bob: User,
+        applet_one: AppletFull,
+    ):
+        client.login(bob)
+        # try to invite a reviewer for a specific respondent
+        response = await client.post(
+            self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
+            invitation_reviewer_data,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        assert response.json()["result"][0]["message"] == AppletInviteAccessDenied.message

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -30,7 +30,6 @@ from apps.invitations.errors import (
     RespondentInvitationExist,
 )
 from apps.mailing.services import TestMail
-from apps.shared.exception import AccessDeniedError
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
 from apps.subjects.crud import SubjectsCrud


### PR DESCRIPTION
Adding 3 scenarios, invitation scenarios:
Respondent, editor, and coordinator can not invite a new reviewer

- [x] Tests for the changes have been added
- [x] Related documentation has been added / updated
- [x] For new features, QA automation engineers have been tagged


### 📝 Description
On this PR, we are adding 3 new scenarios from the old TAF API to the Backend repo, Those test are:
403 Forbidden (Coordinator can NOT invite new reviewer for a specific respondent)
403 Forbidden (Editor can NOT invite new reviewer for a specific respondent)
403 Forbidden (Respondent can NOT invite new reviewer for a specific respondent)


Code in TAF
https://github.com/ChildMindInstitute/MindLogger-TAF/blob/f9dcfb7aa516ecee3c8530c7e8675f7bf1135854/tests/api/permissions/administration.tests.ts#L854


🔗 [Jira Ticket M2-9264](https://mindlogger.atlassian.net/browse/M2-9264))

Changes include:

- The new 3 test, migrated from TAF

### 🪤 Peer Testing
Check if the logic is correct
Run the test and check if everything passes
