### PR TITLE
fix: Improve 1UpHealth error handling (M2-8955)

### DIFF
--- a/src/apps/integrations/oneup_health/domain.py
+++ b/src/apps/integrations/oneup_health/domain.py
@@ -1,5 +1,3 @@
-import uuid
-
 from pydantic import Field
 
 from apps.shared.domain import PublicModel
@@ -7,13 +5,15 @@ from apps.shared.domain import PublicModel
 
 class OneupHealthToken(PublicModel):
     access_token: str = Field(default=...)
-    refresh_token: str | None = Field(default=None)
+    refresh_token: str = Field(default=...)
     app_user_id: str
     oneup_user_id: int
 
 
 class RefreshTokenRequest(PublicModel):
     refresh_token: str = Field(description="The refresh token to use for getting a new access token")
-    oneup_user_id: int | None = Field(default=0, description="The 1UpHealth user ID (optional)")
-    submit_id: uuid.UUID | None = Field(default=None)
-    activity_id: uuid.UUID | None = Field(default=None)
+
+
+class OneupHealthRefreshToken(PublicModel):
+    access_token: str = Field(default=...)
+    refresh_token: str = Field(default=...)

--- a/src/apps/integrations/oneup_health/errors.py
+++ b/src/apps/integrations/oneup_health/errors.py
@@ -49,6 +49,7 @@ class OneUpHealthServiceUnavailableError(OneUpHealthAPIError):
 
 OneUpHealthAPIErrorMessageMap = {
     "this user already exists": OneUpHealthUserAlreadyExists,
-    "service unavailable": OneUpHealthServiceUnavailableError,
     "token expired": OneUpHealthTokenExpiredError,
+    "geographic restriction": OneUpHealthAPIForbiddenError,
+    "service unavailable": OneUpHealthServiceUnavailableError,
 }

--- a/src/apps/integrations/oneup_health/service/oneup_health.py
+++ b/src/apps/integrations/oneup_health/service/oneup_health.py
@@ -70,7 +70,6 @@ class OneupHealthAPIClient:
         and a 201 status code if the request is successful.
 
         1UpHealth API returns the following error codes that are currently being mapped:
-        - 400: 1UpHealth request failed. This is due to the request body being invalid.
         - 401: 1UpHealth token expired
         - 403: Forbidden access to 1UpHealth API. This is due to the user being outside the United States.
         - 503, 504: 1UpHealth service unavailable
@@ -342,7 +341,7 @@ class OneupHealthService:
             code (str, optional): An existing authentication code to use.
 
         Returns:
-            dict: A dictionary containing the access_token and refresh_token.
+            dict: A dictionary containing the access_token, the refresh_token, and the app_user_id.
 
         Raises:
             OneUpHealthAPIError: If the API request fails.

--- a/src/apps/integrations/oneup_health/service/oneup_health.py
+++ b/src/apps/integrations/oneup_health/service/oneup_health.py
@@ -85,7 +85,7 @@ class OneupHealthAPIClient:
             OneUpHealthAPIForbiddenError: If the API returns a 403 status code.
             OneUpHealthServiceUnavailableError: If the API returns a 503 or 504 status code.
         """
-        if resp.status_code not in (200, 201):
+        if resp.status_code not in (200, 201, 400):
             if resp.status_code == 401:
                 # The API returns a 401 status code if the token has expired
                 logger.error(

--- a/src/apps/integrations/oneup_health/service/oneup_health.py
+++ b/src/apps/integrations/oneup_health/service/oneup_health.py
@@ -355,20 +355,15 @@ class OneupHealthService:
         assert code
         return {**await self._get_token(code), "app_user_id": app_user_id}
 
-    async def refresh_token(
-        self, refresh_token: str, submit_id: uuid.UUID | None = None, activity_id: uuid.UUID | None = None
-    ) -> dict[str, str]:
+    async def refresh_token(self, refresh_token: str) -> dict[str, str]:
         """
         Refresh an access token using a refresh token.
 
         Args:
             refresh_token (str): The refresh token to use for getting a new access token.
-            submit_id (uuid.UUID, optional): The unique identifier for the submission.
-            activity_id (uuid.UUID, optional): The unique identifier for the activity.
 
         Returns:
-            dict: A dictionary containing the new access_token, refresh_token, and
-            app_user_id if submit_id and activity_id are provided.
+            dict: A dictionary containing the new access_token and refresh_token
 
         Raises:
             OneUpHealthAPIError: If the API request fails.
@@ -380,14 +375,7 @@ class OneupHealthService:
         access_token = result.get("access_token")
         new_refresh_token = result.get("refresh_token")
 
-        response = dict(access_token=access_token, refresh_token=new_refresh_token)
-
-        # Generate app_user_id if submit_id and activity_id are provided
-        if submit_id is not None and activity_id is not None:
-            app_user_id = get_unique_short_id(submit_id=submit_id, activity_id=activity_id)
-            response["app_user_id"] = app_user_id
-
-        return response
+        return dict(access_token=access_token, refresh_token=new_refresh_token)
 
     async def check_audit_events(self, oneup_user_id: int, start_date: datetime | None) -> dict[str, int]:
         """

--- a/src/apps/integrations/oneup_health/tests/test_oneup_health.py
+++ b/src/apps/integrations/oneup_health/tests/test_oneup_health.py
@@ -390,9 +390,6 @@ class TestOneupHealth:
             "/integrations/oneup_health/refresh_token",
             {
                 "refreshToken": "old_refresh_token",
-                "oneupUserId": 1,
-                "submitId": str(submit_id),
-                "activityId": str(activity_id),
             },
         )
 
@@ -400,8 +397,6 @@ class TestOneupHealth:
         result = response.json()["result"]
         assert result["accessToken"] == "new_access_token"
         assert result["refreshToken"] == "new_refresh_token"
-        assert result["oneupUserId"] == 1
-        assert result["appUserId"] == app_user_id
 
     @pytest.mark.asyncio
     async def test_refresh_token_without_ids(
@@ -425,7 +420,6 @@ class TestOneupHealth:
             "/integrations/oneup_health/refresh_token",
             {
                 "refreshToken": "old_refresh_token",
-                "oneupUserId": 1,
             },
         )
 
@@ -433,6 +427,3 @@ class TestOneupHealth:
         result = response.json()["result"]
         assert result["accessToken"] == "new_access_token"
         assert result["refreshToken"] == "new_refresh_token"
-        assert result["oneupUserId"] == 1
-        # The app_user_id will be empty because submit_id and activity_id were not provided
-        assert result["appUserId"] == ""


### PR DESCRIPTION
- [X] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8955](https://mindlogger.atlassian.net/browse/M2-8955)

This PR adds an improvement to 1UpHealth error handling on token fetching. Now, when a token is requested with params that return an already existing user, BE handles it accordingly, returning the token anyways, instead of failing
