### PR TITLE
fix: Filters EHR data by ingestion status  (M2-9397)

### DIFF
--- a/src/apps/answers/crud/answers.py
+++ b/src/apps/answers/crud/answers.py
@@ -1236,6 +1236,7 @@ class AnswersEHRCRUD(BaseCRUD[AnswerEHRSchema]):
                 AnswerSchema.applet_id == applet_id,
                 AnswerEHRSchema.activity_id.in_(activity_ids),
                 AnswerSchema.submit_id.in_(submit_ids),
+                AnswerEHRSchema.ehr_ingestion_status == EHRIngestionStatus.COMPLETED,
             )
             .order_by(self.schema_class.created_at.desc())
         )


### PR DESCRIPTION
Addresses issue with EHR data retrieval by filtering results based on ingestion status:

- Ensures only EHR records with a 'completed' ingestion status are retrieved.

🔗 [Jira Ticket M2-9397](https://mindlogger.atlassian.net/browse/M2-9397)