### PR TITLE
M2 9399 transfer ownership

### DIFF
--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -33,7 +33,3 @@ class EmailDoesNotExist(AccessDeniedError):
 class InvalidCredentials(AccessDeniedError):
     message = _("Incorrect email or password")
     status_code = status.HTTP_401_UNAUTHORIZED
-
-class AccessDenied(AccessDeniedError):
-    message = _("Access denied to create transfer ownership request for the applet.")
-    status_code = status.HTTP_403_FORBIDDEN

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -33,3 +33,7 @@ class EmailDoesNotExist(AccessDeniedError):
 class InvalidCredentials(AccessDeniedError):
     message = _("Incorrect email or password")
     status_code = status.HTTP_401_UNAUTHORIZED
+
+class AccessDenied(AccessDeniedError):
+    message = _("Access denied to create transfer ownership request for the applet.")
+    status_code = status.HTTP_403_FORBIDDEN

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -11,7 +11,6 @@ from apps.applets.domain.applet_create_update import AppletReportConfiguration
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.service import AppletService
 from apps.authentication.errors import PermissionsError
-from apps.authentication.errors import AccessDenied
 from apps.invitations.constants import InvitationStatus
 from apps.invitations.errors import ManagerInvitationExist
 from apps.mailing.services import TestMail
@@ -22,6 +21,7 @@ from apps.subjects.services import SubjectsService
 from apps.transfer_ownership.crud import TransferCRUD
 from apps.transfer_ownership.errors import TransferEmailError
 from apps.users.domain import User
+from apps.workspaces.errors import TransferOwnershipAccessDenied
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
 
 
@@ -546,26 +546,30 @@ class TestTransfer(BaseTest):
         assert result[0]["message"] == PermissionsError.message
 
     async def test_manager_can_not_transfer_ownership(
-        self, client: TestClient, applet_one: AppletFull, lucy: User, tom: User, mocker: MockerFixture
+        self,
+        client: TestClient,
+        applet_one: AppletFull,
+        lucy: User,
+        tom: User,
     ):
         client.login(lucy)
         data = {"email": tom.email_encrypted}
-        key = uuid.uuid4()
-        mocker.patch("uuid.uuid4", return_value=key)
         resp = await client.post(self.transfer_url.format(applet_id=applet_one.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
-        assert resp.json()["result"][0]["message"] == AccessDenied.message
+        assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message
 
     async def test_respondent_can_not_transfer_ownershipto(
-        self, client: TestClient, applet_one_lucy_respondent: AppletFull, lucy: User, tom: User, mocker: MockerFixture
+        self,
+        client: TestClient,
+        applet_one_lucy_respondent: AppletFull,
+        lucy: User,
+        tom: User,
     ):
         client.login(lucy)
         data = {"email": tom.email_encrypted}
-        key = uuid.uuid4()
-        mocker.patch("uuid.uuid4", return_value=key)
         resp = await client.post(self.transfer_url.format(applet_id=applet_one_lucy_respondent.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
-        assert resp.json()["result"][0]["message"] == AccessDenied.message
+        assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message
 
     async def test_reviewer_can_not_transfer_ownership(
         self,
@@ -573,26 +577,25 @@ class TestTransfer(BaseTest):
         applet_one_bob_coordinator_reviewer: AppletFull,
         lucy: User,
         tom: User,
-        mocker: MockerFixture,
     ):
         client.login(lucy)
         data = {"email": tom.email_encrypted}
-        key = uuid.uuid4()
-        mocker.patch("uuid.uuid4", return_value=key)
         resp = await client.post(self.transfer_url.format(applet_id=applet_one_bob_coordinator_reviewer.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
-        assert resp.json()["result"][0]["message"] == AccessDenied.message
+        assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message
 
     async def test_editor_can_not_transfer_ownership(
-        self, client: TestClient, applet_one_lucy_editor: AppletFull, lucy: User, tom: User, mocker: MockerFixture
+        self,
+        client: TestClient,
+        applet_one_lucy_editor: AppletFull,
+        lucy: User,
+        tom: User,
     ):
         client.login(lucy)
         data = {"email": tom.email_encrypted}
-        key = uuid.uuid4()
-        mocker.patch("uuid.uuid4", return_value=key)
         resp = await client.post(self.transfer_url.format(applet_id=applet_one_lucy_editor.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
-        assert resp.json()["result"][0]["message"] == AccessDenied.message
+        assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message
 
     async def test_coordinator_can_not_transfer_ownership(
         self,
@@ -600,12 +603,9 @@ class TestTransfer(BaseTest):
         applet_one_bob_coordinator_reviewer: AppletFull,
         lucy: User,
         tom: User,
-        mocker: MockerFixture,
     ):
         client.login(lucy)
         data = {"email": tom.email_encrypted}
-        key = uuid.uuid4()
-        mocker.patch("uuid.uuid4", return_value=key)
         resp = await client.post(self.transfer_url.format(applet_id=applet_one_bob_coordinator_reviewer.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
-        assert resp.json()["result"][0]["message"] == AccessDenied.message
+        assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [x] Related documentation has been added / updated
- [x] For new features, QA automation engineers have been tagged
- [x] OSS packages added to

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9399](https://mindlogger.atlassian.net/browse/M2-9399)

Changes include:
- Adding a new expected message error for the Transfer Ownership
- Adding new migrated test cases from TAF

> test_manager_can_not_transfer_ownership
> test_respondent_can_not_transfer_ownershipto
> test_reviewer_can_not_transfer_ownership
> test_editor_can_not_transfer_ownership
> test_coordinator_can_not_transfer_ownership

### 🪤 Peer Testing

Run the tests mentioned above
