### PR TITLE
fix: Refactors ehr zip download to use storage path (M2-9443)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -969,7 +969,9 @@ async def applet_ehr_answers_export(
                 )
                 ehr_zip_buffer = io.BytesIO()
                 try:
-                    ehr_zip_filename = ehr_storage.download_ehr_zip(data, ehr_zip_buffer)
+                    ehr_zip_filename = ehr_storage.download_ehr_zip(
+                        storage_path=ehr_answer.ehr_storage_uri, data=data, file_buffer=ehr_zip_buffer
+                    )
 
                     zip_file.writestr(ehr_zip_filename, ehr_zip_buffer.getvalue())
                 finally:

--- a/src/apps/answers/tests/test_answers.py
+++ b/src/apps/answers/tests/test_answers.py
@@ -4432,7 +4432,7 @@ class TestAnswerActivityItems(BaseTest):
 
         file_names = []
 
-        def _mock_download_ehr_zip(data, file_buffer):
+        def _mock_download_ehr_zip(storage_path, data, file_buffer):
             file_buffer.write(b"mocked EHR zip data")
             file_buffer.seek(0)
 
@@ -4486,7 +4486,7 @@ class TestAnswerActivityItems(BaseTest):
 
         file_names = []
 
-        def _mock_download_ehr_zip(data, file_buffer):
+        def _mock_download_ehr_zip(storage_path, data, file_buffer):
             file_buffer.write(b"mocked EHR zip data")
             file_buffer.seek(0)
 

--- a/src/apps/integrations/oneup_health/service/ehr_storage.py
+++ b/src/apps/integrations/oneup_health/service/ehr_storage.py
@@ -85,10 +85,9 @@ class EHRStorage:
         finally:
             zip_buffer.close()
 
-    def download_ehr_zip(self, data: EHRData, file_buffer: BinaryIO) -> str:
-        base_path = self._get_base_path(data)
+    def download_ehr_zip(self, storage_path: str, data: EHRData, file_buffer: BinaryIO) -> str:
         filename = EHRStorage.ehr_zip_filename(data)
-        key = self._cdn_client.generate_key(FileScopeEnum.EHR, base_path, filename)
+        key = f"{storage_path}/{filename}"
 
         self._cdn_client.download(key, file_buffer)
 


### PR DESCRIPTION
Addresses an issue where the EHR zip download was not correctly utilizing the storage path. This change ensures the correct path is used when downloading the zip file.

Changes include:

- Modifies the `download_ehr_zip` function to accept a `storage_path` parameter.
- Updates the function call in `applet_ehr_answers_export` and test cases to include the `ehr_storage_uri`.
- Uses storage path to generate key for download

🔗 [Jira Ticket M2-9443](https://mindlogger.atlassian.net/browse/M2-9443)