### PR TITLE
 fix:/ M2-9520-ownership-invitations-sent-to-emails-with-capital-letters

### DIFF
--- a/src/apps/transfer_ownership/domain.py
+++ b/src/apps/transfer_ownership/domain.py
@@ -1,6 +1,6 @@
 import uuid
 
-from pydantic import EmailStr
+from pydantic import EmailStr,validator 
 
 from apps.shared.domain import InternalModel
 from apps.transfer_ownership.constants import TransferOwnershipStatus
@@ -21,6 +21,16 @@ class Transfer(InternalModel):
     from_user_id: uuid.UUID
     to_user_id: uuid.UUID | None = None
 
+    @validator("email",pre=True)
+    def normalize_email(cls, v: str) -> str:
+        """Normalize email to lowercase and strip whitespace."""
+        return v.lower().strip()
+
 
 class InitiateTransfer(InternalModel):
     email: EmailStr
+
+    @validator("email",pre=True)
+    def normalize_email(cls, v: str) -> str:
+        """Normalize email to lowercase and strip whitespace."""
+        return v.lower().strip()


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9520](https://mindlogger.atlassian.net/browse/M2-9520)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Added input validation to normalize email addresses to lowercase during transfer ownership operations. This ensures consistent email formatting and avoids potential mismatches due to case differences.

Changes include:

Added Pydantic validators in InitiateTransfer and Transfer domain models to enforce lowercase email input.


### 🪤 Peer Testing

Trigger a transfer ownership to an email with uppercase letters.

Expected outcome: Invitation is saved and processed with email in lowercase.




