### PR TITLE
  fix: add backward compatibility for notification logs API (M2-8994)

### DIFF
--- a/src/apps/logs/domain/notification.py
+++ b/src/apps/logs/domain/notification.py
@@ -39,7 +39,7 @@ class NotificationLogCreate(_NotificationLogBase, InternalModel):
     )
     def convert_string_to_list(cls, v):
         """Convert legacy JSON string format to array format for backward compatibility.
-        
+
         Mobile apps < v1.0.8 send notification fields as JSON strings.
         This validator ensures compatibility by converting strings to arrays.
         """


### PR DESCRIPTION
 ### 📝 Description

  🔗 [Jira Ticket M2-8994](https://mindlogger.atlassian.net/browse/M2-8994)

  Changes include:

  - Added Pydantic pre-validator to `NotificationLogCreate` schema
  - Converts JSON string fields to arrays for backward compatibility
  - Handles edge cases (null values, malformed JSON) gracefully

  ### 🪤 Peer Testing

  Test the backward compatibility with these curl commands:

  1. **Old mobile format (JSON strings)**:
  ```bash
  curl -X POST "http://localhost:8000/logs/notification" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer YOUR_TOKEN" \
    -d '{
      "action_type": "trigger-notification",
      "user_id": "test@example.com",
      "device_id": "old-mobile-001",
      "notification_descriptions": "[{\"id\": \"1\", \"title\": \"Test\"}]",
      "notification_in_queue": "[]",
      "scheduled_notifications": null
    }'
  Expected outcome: HTTP 200 - Fields converted to arrays

  2. New mobile format (native arrays):
  curl -X POST "http://localhost:8000/logs/notification" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer YOUR_TOKEN" \
    -d '{
      "action_type": "trigger-notification",
      "user_id": "test@example.com",
      "device_id": "new-mobile-002",
      "notification_descriptions": [{"id": "2", "title": "Test"}],
      "notification_in_queue": [],
      "scheduled_notifications": null
    }'
  Expected outcome: HTTP 200 - Arrays pass through unchanged

  ✏️ Notes

  - No mobile app updates required - all versions will work
  - The fix is in src/apps/logs/domain/notification.py
