### PR TITLE
feat: add Portuguese email templates and backend support

### DIFF
--- a/src/apps/invitations/domain.py
+++ b/src/apps/invitations/domain.py
@@ -20,6 +20,7 @@ class InvitationLanguage(StrEnum):
     FR = "fr"  # French
     EL = "el"  # Greek
     ES = "es"  # Spanish
+    PT = "pt"  # Portuguese
 
 
 class InvitationRequest(InternalModel):

--- a/src/apps/mailing/static/templates/blocks/team_info_pt.html
+++ b/src/apps/mailing/static/templates/blocks/team_info_pt.html
@@ -1,0 +1,5 @@
+<tr>
+  <td style="padding-top: 24px; padding-bottom: 1%">
+    – A equipe Curious
+  </td>
+</tr>

--- a/src/apps/mailing/static/templates/footers/footer_info_pt.html
+++ b/src/apps/mailing/static/templates/footers/footer_info_pt.html
@@ -1,0 +1,44 @@
+<table border="0" cellpadding="0" cellspacing="0" style="width: 100%; text-align: center">
+  <tr>
+    <td>
+      <table border="0" cellpadding="0" cellspacing="0" style="
+          width: 100%;
+          background: #eff4fa;
+          padding: 26px;
+          border-radius: 8px;
+          text-align: center;
+        ">
+        <tr>
+          <td colspan="2" style="padding-bottom: 14px; font-size: 14px"> Baixe o aplicativo móvel Curious: </td>
+        </tr>
+        <tr>
+          <td width="50%" align="right" style="padding-right: 4px">
+            <a href="https://apps.apple.com/br/app/mindlogger/id1299242097">
+              <img src="https://media.mindlogger.org/apple-store.png" style="height: 44px" alt="Baixe o aplicativo para iOS">
+            </a>
+          </td>
+          <td width="50%" align="left" style="padding-left: 4px">
+            <a href="https://play.google.com/store/apps/details?id=lab.childmindinstitute.data&pli=1">
+              <img src="https://media.mindlogger.org/google-play.png" style="height: 44px" alt="Baixe o aplicativo para Android">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="padding-top: 23px; font-size: 14px">
+            Precisa de ajuda? <a href="https://mindlogger.atlassian.net/servicedesk/customer/portals" style="color: black">Visite nossa Central de Ajuda</a>.
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="padding-top: 32px">
+      <img src="https://media.mindlogger.org/cmi-logo.png" style="width: 106px" alt="Child Mind Institute">
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="color: #51606f; padding-top: 12px; font-size: 12px">
+      O Child Mind Institute é o criador do Curious, mas não é responsável pelo conteúdo criado por terceiros.
+    </td>
+  </tr>
+</table>

--- a/src/apps/mailing/static/templates/invitation_new_user_pt.html
+++ b/src/apps/mailing/static/templates/invitation_new_user_pt.html
@@ -1,0 +1,28 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body>
+  {% include 'header.html' %}
+  <table style="padding: 0">
+    <tr>
+      <td style="padding-bottom: 1%"> Olá {{ first_name }}, </td>
+    </tr>
+    <tr>
+      <td style="padding-bottom: 1%">
+        Você foi convidado a se tornar
+        {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %} an {% else %} a {% endif %}
+        {{ role }} de <b>"{{ applet_name }}"</b> no Curious, uma plataforma de coleta de dados sobre saúde mental e desafios de aprendizagem.
+      </td>
+    </tr>
+    <tr>
+      <td style="padding-top: 2%; padding-bottom: 1%;">
+        <a href="{{ link }}/{{ key }}?lang={{ language }}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;">
+          Crie sua conta e comece a usar
+        </a>
+      </td>
+    </tr>
+    {% include 'blocks/team_info_pt.html' %}
+  </table>
+  {% include 'footers/footer_info_pt.html' %}
+</body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_registered_user_pt.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_pt.html
@@ -1,0 +1,28 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body>
+  {% include 'header.html' %}
+  <table style="padding: 0">
+    <tr>
+      <td style="padding-bottom: 1%"> Olá {{ first_name }}, </td>
+    </tr>
+    <tr>
+      <td style="padding-bottom: 1%">
+        Você foi convidado a se tornar
+        {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %} an {% else %} a {% endif %}
+        {{ role }} de <b>"{{ applet_name }}"</b> no Curious.
+      </td>
+    </tr>
+    <tr>
+      <td style="padding-top: 2%; padding-bottom: 1%;">
+        <a href="{{ link }}/{{ key }}?lang={{ language }}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;">
+          Comece a usar
+        </a>
+      </td>
+    </tr>
+    {% include 'blocks/team_info_pt.html' %}
+  </table>
+  {% include 'footers/footer_info_pt.html' %}
+</body>
+
+</html>

--- a/src/apps/mailing/static/templates/new_activity_assignments_pt.html
+++ b/src/apps/mailing/static/templates/new_activity_assignments_pt.html
@@ -1,0 +1,36 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body>
+  {% include 'header.html' %}
+  <table style="padding: 0">
+    <tr>
+      <td style="padding-bottom: 1%"> Olá {{ first_name }}, </td>
+    </tr>
+    <tr>
+      <td style="padding-bottom: 1%">
+        Você recebeu uma ou mais atividades em <b>"{{ applet_name }}"</b>.
+      </td>
+    </tr>
+  </table>
+  <ul>
+    {% for name in activity_or_flows_names %}
+      <li>{{ name }}</li>
+    {% endfor %}
+  </ul>
+  <table style="padding: 0">
+    <tr>
+      <td> Faça login para revisar os detalhes da tarefa no Curious. </td>
+    </tr>
+    <tr>
+      <td style="padding-top: 2%; padding-bottom: 1%;">
+        <a href="{{ link }}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;">
+          Comece a usar
+        </a>
+      </td>
+    </tr>
+  {% include 'blocks/team_info_pt.html' %}
+  </table>
+  {% include 'footers/footer_info_pt.html' %}
+</body>
+
+</html>

--- a/src/apps/mailing/static/templates/reset_password_pt.html
+++ b/src/apps/mailing/static/templates/reset_password_pt.html
@@ -1,0 +1,31 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body>
+    {% include 'header.html' %}
+    <table style="padding: 0; font-size: 1.4rem">
+      <tr>
+        <td style="padding-bottom: 16px">
+          Recebemos uma solicitação para redefinir sua senha.
+        </td>
+      </tr>
+      <tr>
+        <td style="padding-bottom: 16px">
+          <a href="{{ url }}">Clique neste link</a> para redefinir sua senha agora. O link irá expirar em 15 minutos.
+        </td>
+      </tr>
+      <tr>
+        <td style="padding-bottom: 16px">
+          Se você não fez essa solicitação, você pode ignorar este e-mail.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <i>
+            Após atualizar sua senha, você não verá seus dados anteriores no aplicativo. Mas não se preocupe, nós ainda temos acesso a eles.
+          </i>
+        </td>
+      </tr>
+    {% include 'blocks/team_info_pt.html' %}
+    </table>
+    {% include 'footers/footer_info_pt.html' %}
+  </body>
+</html>


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to
  Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8806](https://mindlogger.atlassian.net/browse/M2-8806)

<!-- Uncomment if this PR includes a breaking change to the API -->
<!-- ##### ❗BREAKING CHANGE! -->

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Added Portuguese (pt) email templates for invitations, password reset, team info, and footer.
- Updated backend logic in domain.py to handle new pt language key.
- Ensured fallback to English when localized template is not found.

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `pipenv shell`**     -->
<!-- **Requires `pipenv sync --dev`**        -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

Steps to verify:

- Trigger an email notification (e.g., invite a new user).
-     Expected outcome: Portuguese email template is used when language = pt.
- Trigger password reset email.
-     Expected outcome: Portuguese version is sent when pt is set.
- Change language to en or es and repeat above steps.
-     Expected outcome: English/Spanish templates are still used correctly.

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
Images - 
<img width="808" height="601" alt="Screenshot 2025-08-29 at 4 48 21 PM" src="https://github.com/user-attachments/assets/7cd1b3b9-4c46-44fc-8fb1-5a537adcecf4" />
<img width="646" height="694" alt="Screenshot 2025-08-29 at 4 47 09 PM" src="https://github.com/user-attachments/assets/5ef7cf11-a534-461b-8f87-1b81f7c07d37" />
<img width="825" height="681" alt="Screenshot 2025-08-29 at 4 46 38 PM" src="https://github.com/user-attachments/assets/ebc3811b-4ded-49cc-bd56-7434ae94de3b" />
- Region code (pt-BR) handling will be added in a follow-up if needed.
- No API changes.