### PR TITLE
fix: Include `.python-version` in Docker container (M2-10532)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 docker-compose.yaml
 .devcontainer
 *.code-workspace
-.python-version
 .pre-commit-config.yaml
 .env
 *.md


### PR DESCRIPTION
🔗 [Jira Ticket M2-10532](https://mindlogger.atlassian.net/browse/M2-10532)

This is a follow-up to #2032. I forgot to push this small fix to include `.python-version` for Docker.