### PR TITLE
fix: return 404 for deleted activity in activity_retrieve endpoint

### DIFF
--- a/src/apps/activities/api/activities.py
+++ b/src/apps/activities/api/activities.py
@@ -19,6 +19,7 @@ from apps.activities.domain.activity import (
 from apps.activities.domain.activity_item import (
     ActivityItemSingleLanguageDetail,
 )
+from apps.activities.errors import ActivityDoeNotExist
 from apps.activities.filters import AppletActivityFilter
 from apps.activities.services.activity import ActivityItemService, ActivityService
 from apps.activity_assignments.service import ActivityAssignmentService
@@ -126,6 +127,8 @@ async def activity_retrieve(
             await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
         else:
             schema = await ActivitiesCRUD(session).get_by_id(activity_id)
+            if schema is None:
+                raise ActivityDoeNotExist()
             await CheckAccessService(session, user.id).check_applet_detail_access(schema.applet_id)
             activity = await ActivityService(session, user.id).get_single_language_by_id(activity_id, language)
     result = ActivitySingleLanguageWithItemsDetailPublic.model_validate(activity)

--- a/src/apps/answers/tests/test_cross_version_flow.py
+++ b/src/apps/answers/tests/test_cross_version_flow.py
@@ -232,11 +232,11 @@ class TestVersionAwareActivityEndpoint(BaseTest):
         update_data = AppletUpdate(**data)
         await srv.update(applet_with_flow.id, update_data)
 
-        # Fetching the deleted activity without version should fail
+        # Fetching the deleted activity without version should return 404
         response = await client.get(
             self.activity_url.format(activity_id=original_activity.id),
         )
-        assert response.status_code != http.HTTPStatus.OK
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
 
         # Fetching with the original version should succeed from history
         response = await client.get(


### PR DESCRIPTION
### Changes

- Added null check after `ActivitiesCRUD.get_by_id()` - raises `ActivityDoeNotExist` (404) when activity is not found
- Updated test assertion to expect `HTTP 404` instead of `!= 200`

### Why

Previously, fetching a deleted activity without a version would cause a `NullPointerError` or undefined behavior downstream (attempting `schema.applet_id` on `None`). Now it returns a proper 404.

### Notes

- `ActivityDoeNotExist` already existed in `apps/activities/errors.py`
- Only affects the unversioned code path in `activity_retrieve` (the versioned path was already safe)