### PR TITLE
fix: Caseless in passwords validates as upper and lower (M2-10505)

### DIFF
--- a/src/apps/users/password_validation.py
+++ b/src/apps/users/password_validation.py
@@ -31,11 +31,13 @@ class PasswordValidator:
         unicodecategories = {unicodedata.category(ch) for ch in normalized}
 
         # Reject control characters
-        if any(cat.startswith("C") for cat in unicodecategories):
+        has_control = any(cat.startswith("C") for cat in unicodecategories)
+        if has_control:
             raise PasswordContainsInvalidCharactersError()
 
         # Reject any whitespace or blank characters that Unicode classifies as visible
-        if any(ch.isspace() or ch in "\u2800\u3164\u115f\u1160\uffa0" for ch in normalized):
+        has_whitespace = any(ch.isspace() or ch in "\u2800\u3164\u115f\u1160\uffa0" for ch in normalized)
+        if has_whitespace:
             raise PasswordHasSpacesError()
 
         # Minimum length as counted by '\X' graphemes
@@ -43,13 +45,17 @@ class PasswordValidator:
             raise PasswordTooShortError(chars=config.min_length)
 
         # At least N of the following character types
+        has_caseless = "Lo" in unicodecategories or "Lm" in unicodecategories  # CJK, Arabic, Hebrew, etc.
+        has_lowercase = "Ll" in unicodecategories
+        has_uppercase = "Lu" in unicodecategories
+        has_digit = "Nd" in unicodecategories
+        has_symbol = any(not cat.startswith("L") and cat != "Nd" for cat in unicodecategories)
         types_present = sum(
             (
-                "Ll" in unicodecategories,  # lowercase
-                "Lu" in unicodecategories,  # uppercase
-                "Lo" in unicodecategories or "Lm" in unicodecategories,  # caseless (Arabic, CJK, Hebrew, etc.)
-                "Nd" in unicodecategories,  # digit
-                any(not cat.startswith("L") and cat != "Nd" for cat in unicodecategories),  # symbol
+                has_lowercase or has_caseless,  # lowercase or caseless (CJK, Arabic, Hebrew, etc.)
+                has_uppercase or has_caseless,  # uppercase or caseless (CJK, Arabic, Hebrew, etc.)
+                has_digit,  # digit
+                has_symbol,  # symbol
             )
         )
         if types_present < config.min_character_types:

--- a/src/apps/users/tests/unit/test_user_domain.py
+++ b/src/apps/users/tests/unit/test_user_domain.py
@@ -93,7 +93,7 @@ def test_public_user_from_user_model(base_data: BaseData):
         "Abcdefgh!@",  # 3 types: lower + upper + symbol
         "abcdefg12!",  # 3 types: lower + digit + symbol
         "ABCDEFG12!",  # 3 types: upper + digit + symbol
-        "abcdefg12\u65e5",  # 3 types: lower + digit + caseless (CJK ideograph)
+        "\u65e5123456789",  # 3 types: lower (via caseless CJK) + upper (via caseless CJK) + digit
         "TestPass1!",  # 4 types: lower + upper + digit + symbol
         "TestPass1!n\u0303",  # 4 types: NFKC normalizes n + combining ~ to ñ
         "Abcdefgh!\U0001f1fa\U0001f1f3",  # 9 chars + flag emoji (2 code points / 1 grapheme)


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10505](https://mindlogger.atlassian.net/browse/M2-10505)

Changes include:

- Validate caseless characters in passwords as both uppercase and lowercase.

This is a follow-up to pull request #2036. After thinking through @jodybrookover’s comments, seems to make sense to allow caseless characters in passwords to validate as both uppercase and lowercase letters. There tend to be more caseless characters than uppercase or lowercase letters, and this matches the behavior already implemented on the frontend with:

- ChildMindInstitute/mindlogger-admin#2207
- ChildMindInstitute/mindlogger-app-refactor#1089
- ChildMindInstitute/mindlogger-web-refactor#719