### PR TITLE
fix: Reject passwords with emoji (M2-10505)

### DIFF
--- a/src/apps/users/errors.py
+++ b/src/apps/users/errors.py
@@ -20,6 +20,10 @@ class PasswordHasSpacesError(ValidationError):
     message = _("Password must not contain spaces.")
 
 
+class PasswordHasEmojisError(ValidationError):
+    message = _("Password must not contain emojis.")
+
+
 class PasswordContainsInvalidCharactersError(ValidationError):
     message = _("Password must not contain control characters.")
 

--- a/src/apps/users/password_validation.py
+++ b/src/apps/users/password_validation.py
@@ -4,11 +4,18 @@ import regex
 
 from apps.users.errors import (
     PasswordContainsInvalidCharactersError,
+    PasswordHasEmojisError,
     PasswordHasSpacesError,
     PasswordInsufficientTypesError,
     PasswordTooShortError,
 )
 from config import settings
+
+# Regex for emoji (standard emjoi + regional indicators) which are not exposed as a Unicode catgory
+EMOJI_REGEX = regex.compile(r"\p{Extended_Pictographic}|[\U0001F1E6-\U0001F1FF]")
+
+# Regex for grapheme cluster for counting user-perceived characters
+GRAPHEME_REGEX = regex.compile(r"\X")
 
 
 class PasswordValidator:
@@ -40,8 +47,14 @@ class PasswordValidator:
         if has_whitespace:
             raise PasswordHasSpacesError()
 
-        # Minimum length as counted by '\X' graphemes
-        if len(regex.findall(r"\X", normalized)) < config.min_length:
+        # Reject any emoji or regional indicators
+        has_emoji = EMOJI_REGEX.search(normalized) is not None
+        if has_emoji:
+            raise PasswordHasEmojisError()
+
+        # Minimum length as counted by graphemes
+        length = len(GRAPHEME_REGEX.findall(normalized))
+        if length < config.min_length:
             raise PasswordTooShortError(chars=config.min_length)
 
         # At least N of the following character types

--- a/src/apps/users/tests/unit/test_user_domain.py
+++ b/src/apps/users/tests/unit/test_user_domain.py
@@ -96,7 +96,6 @@ def test_public_user_from_user_model(base_data: BaseData):
         "\u65e5123456789",  # 3 types: lower (via caseless CJK) + upper (via caseless CJK) + digit
         "TestPass1!",  # 4 types: lower + upper + digit + symbol
         "TestPass1!n\u0303",  # 4 types: NFKC normalizes n + combining ~ to ñ
-        "Abcdefgh!\U0001f1fa\U0001f1f3",  # 9 chars + flag emoji (2 code points / 1 grapheme)
     ],
 )
 def test_user_create_request_valid_passwords(
@@ -113,7 +112,6 @@ def test_user_create_request_valid_passwords(
         "Short1!aa",  # 9 chars
         "weak",  # 4 chars
         "",  # 0 chars
-        "Abcdefg!\U0001f1fa\U0001f1f3",  # 8 chars + flag emoji (2 code points / 1 grapheme)
     ],
 )
 def test_user_create_request_too_short_password_is_not_allowed(
@@ -162,6 +160,22 @@ def test_user_create_request_control_characters_are_not_allowed_in_password(
 ):
     base_data["password"] = password
     with pytest.raises(errors.PasswordContainsInvalidCharactersError):
+        domain.UserCreateRequest(**base_data)
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "TestPass1!\U0001f600",  # grinning face (standard emoji)
+        "TestPass1!\U0001f1fa\U0001f1f3",  # flag (regional indicator)
+    ],
+)
+def test_user_create_request_emojis_are_not_allowed_in_password(
+    base_data: BaseData,
+    password: str,
+):
+    base_data["password"] = password
+    with pytest.raises(errors.PasswordHasEmojisError):
         domain.UserCreateRequest(**base_data)
 
 


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10505](https://mindlogger.atlassian.net/browse/M2-10505)

Changes include:

- Reject passwords that contain standard emoji or regional indicators.

This is a follow-up to pull requests #2036 and #2038 that brings backend password validation in line with what @adeiji implemented for emojis on the front end in:

- ChildMindInstitute/mindlogger-admin#2207
- ChildMindInstitute/mindlogger-app-refactor#1089
- ChildMindInstitute/mindlogger-web-refactor#719