### PR TITLE
feat: `AuditEvent` data model (M2-10698)

### DIFF
--- a/src/apps/audit/__init__.py
+++ b/src/apps/audit/__init__.py
@@ -1,5 +1,5 @@
-from apps.audit.domain import AuditEvent
-from apps.audit.enums import EventAction, EventOutcome
-from apps.audit.service import log
+from .domain import AuditEvent
+from .enums import EventAction, EventOutcome
+from .service import log
 
 __all__ = ["AuditEvent", "EventAction", "EventOutcome", "log"]

--- a/src/apps/audit/__init__.py
+++ b/src/apps/audit/__init__.py
@@ -1,4 +1,5 @@
-from apps.audit.domain import AuditEvent, EventAction, EventOutcome
+from apps.audit.domain import AuditEvent
+from apps.audit.enums import EventAction, EventOutcome
 from apps.audit.service import log
 
 __all__ = ["AuditEvent", "EventAction", "EventOutcome", "log"]

--- a/src/apps/audit/__init__.py
+++ b/src/apps/audit/__init__.py
@@ -1,0 +1,4 @@
+from apps.audit.domain import AuditEvent, EventAction, EventOutcome
+from apps.audit.service import log
+
+__all__ = ["AuditEvent", "EventAction", "EventOutcome", "log"]

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -1,0 +1,190 @@
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Annotated, Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+from config import settings
+
+
+class EventAction(StrEnum):
+    """event.action values defined for Curious"""
+
+    # User auth
+    USER_SESSION_LOGIN = "user:session:login"
+    USER_SESSION_LOGOUT = "user:session:logout"
+    USER_SESSION_REFRESH = "user:session:refresh"
+    USER_SESSION_INVALID = "user:session:invalid"
+
+    # User IAM
+    USER_CREATE = "user:create"
+    USER_DELETE = "user:delete"
+    USER_PASSWORD_CHANGE = "user:password:change"
+    USER_PASSWORD_RECOVERY_INITIATE = "user:password:recovery:initiate"
+    USER_PASSWORD_RECOVERY_APPROVE = "user:password:recovery:approve"
+    USER_MFA_ENABLE = "user:mfa:enable"
+    USER_MFA_DISABLE = "user:mfa:disable"
+    USER_MFA_RECOVERY_VIEW = "user:mfa:recovery:view"
+    USER_MFA_RECOVERY_DOWNLOAD = "user:mfa:recovery:download"
+    USER_MFA_RECOVERY_USE = "user:mfa:recovery:use"
+
+    # Workspace IAM
+    WORKSPACE_ACCESS_GRANT = "workspace:access:grant"
+    WORKSPACE_ACCESS_REVOKE = "workspace:access:revoke"
+
+    # Applet IAM
+    APPLET_CREATE = "applet:create"
+    APPLET_DELETE = "applet:delete"
+    APPLET_ENCRYPTION_UPDATE = "applet:encryption:update"
+    APPLET_TRANSFER_INITIATE = "applet:transfer:initiate"
+    APPLET_TRANSFER_ACCEPT = "applet:transfer:accept"
+    APPLET_TRANSFER_DECLINE = "applet:transfer:decline"
+    APPLET_INVITE_INITIATE = "applet:invite:initiate"
+    APPLET_INVITE_ACCEPT = "applet:invite:accept"
+    APPLET_INVITE_DECLINE = "applet:invite:decline"
+
+    # Applet data access
+    APPLET_SUBJECT_VIEW = "applet:subject:view"
+    APPLET_ANSWER_VIEW = "applet:answer:view"
+    APPLET_ANSWER_IDENTIFIER_VIEW = "applet:answer:identifier:view"
+    APPLET_ANSWER_ASSESSMENT_VIEW = "applet:answer:assessment:view"
+    APPLET_ANSWER_NOTE_VIEW = "applet:answer:note:view"
+    APPLET_ANSWER_EXPORT = "applet:answer:export"
+
+    # Applet data download
+    APPLET_ANSWER_EHR_DOWNLOAD = "applet:answer:ehr:download"
+    APPLET_ANSWER_FILE_DOWNLOAD = "applet:answer:file:download"
+    APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"
+
+
+class EventOutcome(StrEnum):
+    """event.outcome values defined by ECS"""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
+
+
+class EventCategory(StrEnum):
+    """event.category values defined by ECS"""
+
+    AUTHENTICATION = "authentication"
+    SESSION = "session"
+    DATABASE = "database"
+    FILE = "file"
+    IAM = "iam"
+    CONFIGURATION = "configuration"
+    WEB = "web"
+
+
+class EventType(StrEnum):
+    """event.type values defined by ECS"""
+
+    START = "start"
+    END = "end"
+    INFO = "info"
+    ACCESS = "access"
+    CHANGE = "change"
+    CREATION = "creation"
+    DELETION = "deletion"
+    DENIED = "denied"
+
+
+class AuditEvent(BaseModel):
+    """Audit event
+
+    Required for all events:
+    - user_id
+    - event_action
+
+    Automatically populated fields:
+    - timestamp
+    - event_id
+    - event_kind
+    - event_module
+    - event_dataset
+    - service_name
+    - service_environment
+
+    Applicable to IAM events:
+    - user_roles
+    - user_target_id
+    - user_target_email
+    - user_target_roles
+
+    Applicable to failures:
+    - event_outcome
+    - error_type
+
+    Applicable to HTTP requests:
+    - client_ip
+    - http_request_id
+    - http_request_method,
+    - http_response_status_code
+    - url_path
+    - url_query
+
+    Applicable to HTTP requests if Datadog is enabled:
+    - trace_id
+
+    Applicable to file downloads:
+    - file_path
+
+    Applicable to Curious database records:
+    - curious_applet_id
+    - curious_subject_id
+    - curious_flow_id
+    - curious_activity_id
+    - curious_submit_id
+    - curious_answer_id
+
+    Notes:
+    - Set user_id=None if there is no authenticated user.
+    - Set event_outcome="failure" for failures.
+
+    """
+
+    timestamp: Annotated[
+        datetime,
+        Field(alias="@timestamp", default_factory=lambda: datetime.now(timezone.utc)),
+    ]
+    error_type: Annotated[str | None, Field(alias="error.type")] = None  # if event_outcome="failure"
+    event_action: Annotated[EventAction, Field(alias="event.action")]
+    event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
+    event_id: Annotated[UUID, Field(alias="event.id", default_factory=uuid4)]
+    event_kind: Annotated[Literal["event"], Field(alias="event.kind")] = "event"
+    event_module: Annotated[str, Field(alias="event.module")] = "curious"
+    event_dataset: Annotated[str, Field(alias="event.dataset")] = "curious.audit"
+    service_name: Annotated[str, Field(alias="service.name")] = "mindlogger-backend"
+    service_environment: Annotated[str, Field(alias="service.environment", default=settings.env)]
+
+    # User performing the action
+    user_id: Annotated[UUID | None, Field(alias="user.id")]
+    user_roles: Annotated[list[str] | None, Field(alias="user.roles")] = None
+
+    # User being acted upon (if applicable)
+    user_target_id: Annotated[UUID | None, Field(alias="user.target.id")] = None  # prefer ID if available
+    user_target_email: Annotated[str | None, Field(alias="user.target.email")] = None  # email only if ID unavailable
+    user_target_roles: Annotated[list[str] | None, Field(alias="user.target.roles")] = None
+
+    # For HTTP requests
+    client_ip: Annotated[str | None, Field(alias="client.ip")] = None
+    http_request_id: Annotated[str | None, Field(alias="http.request.id")] = None  # from asgi-correlation-id
+    http_request_method: Annotated[str | None, Field(alias="http.request.method")] = None
+    http_response_status_code: Annotated[int | None, Field(alias="http.response.status_code")] = None
+    trace_id: Annotated[str | None, Field(alias="trace.id")] = None  # from Datadog if enabled
+    url_path: Annotated[str | None, Field(alias="url.path")] = None
+    url_query: Annotated[str | None, Field(alias="url.query")] = None
+    user_agent: Annotated[str | None, Field(alias="user_agent.original")] = None
+
+    # For file downloads
+    file_path: Annotated[str | None, Field(alias="file.path")] = None  # file download path
+
+    # For Curious database records
+    curious_applet_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.applet_id")] = None
+    curious_subject_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.subject_id")] = None
+    curious_flow_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.flow_id")] = None
+    curious_activity_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.activity_id")] = None
+    curious_submit_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.submit_id")] = None
+    curious_answer_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.answer_id")] = None

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -3,8 +3,9 @@ from enum import StrEnum
 from typing import Annotated, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from apps.shared.domain import PublicModel
 from config import settings
 
 
@@ -91,7 +92,7 @@ class EventType(StrEnum):
     DENIED = "denied"
 
 
-class AuditEvent(BaseModel):
+class AuditEvent(PublicModel):
     """Audit event
 
     Required for all events:

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -75,8 +75,8 @@ class AuditEvent(PublicModel):
     event_id: Annotated[UUID, Field(alias="event.id", default_factory=uuid4)]
     event_kind: Annotated[EventKind, Field(alias="event.kind")] = EventKind.EVENT
     event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
-    event_module: Annotated[str, Field(alias="event.module")] = "mindlogger"
-    event_dataset: Annotated[str, Field(alias="event.dataset")] = "mindlogger.audit"
+    event_module: Annotated[str, Field(alias="event.module")] = "curious"
+    event_dataset: Annotated[str, Field(alias="event.dataset")] = "curious.audit"
     service_name: Annotated[str, Field(alias="service.name", default=settings.service.name)]
     service_environment: Annotated[str, Field(alias="service.environment", default=settings.env)]
 

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -77,7 +77,7 @@ class AuditEvent(PublicModel):
     event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
     event_module: Annotated[str, Field(alias="event.module")] = "mindlogger"
     event_dataset: Annotated[str, Field(alias="event.dataset")] = "mindlogger.audit"
-    service_name: Annotated[str, Field(alias="service.name")] = "mindlogger-backend"
+    service_name: Annotated[str, Field(alias="service.name", default=settings.service.name)]
     service_environment: Annotated[str, Field(alias="service.environment", default=settings.env)]
 
     # User performing the action

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -52,7 +52,7 @@ class EventAction(StrEnum):
     APPLET_ANSWER_NOTE_VIEW = "applet:answer:note:view"
     APPLET_ANSWER_EXPORT = "applet:answer:export"
 
-    # Applet data download
+    # Applet file download
     APPLET_ANSWER_EHR_DOWNLOAD = "applet:answer:ehr:download"
     APPLET_ANSWER_FILE_DOWNLOAD = "applet:answer:file:download"
     APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -4,9 +4,10 @@ from uuid import UUID, uuid4
 
 from pydantic import Field
 
-from apps.audit.enums import EventAction, EventKind, EventOutcome
 from apps.shared.domain import PublicModel
 from config import settings
+
+from .enums import EventAction, EventKind, EventOutcome
 
 
 class AuditEvent(PublicModel):

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -103,9 +103,9 @@ class AuditEvent(PublicModel):
     file_path: Annotated[str | None, Field(alias="file.path")] = None  # file download path
 
     # For Curious database records
-    curious_applet_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.applet_id")] = None
-    curious_subject_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.subject_id")] = None
-    curious_flow_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.flow_id")] = None
-    curious_activity_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.activity_id")] = None
-    curious_submit_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.submit_id")] = None
-    curious_answer_id: Annotated[UUID | list[UUID] | None, Field(alias="curious.answer_id")] = None
+    curious_applet_id: Annotated[list[UUID] | None, Field(alias="curious.applet_id")] = None
+    curious_subject_id: Annotated[list[UUID] | None, Field(alias="curious.subject_id")] = None
+    curious_flow_id: Annotated[list[UUID] | None, Field(alias="curious.flow_id")] = None
+    curious_activity_id: Annotated[list[UUID] | None, Field(alias="curious.activity_id")] = None
+    curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
+    curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID, uuid4
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from apps.shared.domain import PublicModel
 from config import settings
@@ -63,6 +63,8 @@ class AuditEvent(PublicModel):
     - Set event_outcome="failure" for failures.
 
     """
+
+    model_config = ConfigDict(serialize_by_alias=True)
 
     timestamp: Annotated[
         datetime,

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -59,17 +59,17 @@ class EventAction(StrEnum):
     APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"
 
 
-class EventOutcome(StrEnum):
-    """event.outcome values defined by ECS"""
+class EventKind(StrEnum):
+    """event.kind valudes defined by ECS"""
 
-    SUCCESS = "success"
-    FAILURE = "failure"
-    UNKNOWN = "unknown"
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-kind
+    EVENT = "event"
 
 
 class EventCategory(StrEnum):
     """event.category values defined by ECS"""
 
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-category
     AUTHENTICATION = "authentication"
     SESSION = "session"
     DATABASE = "database"
@@ -82,6 +82,7 @@ class EventCategory(StrEnum):
 class EventType(StrEnum):
     """event.type values defined by ECS"""
 
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-type
     START = "start"
     END = "end"
     INFO = "info"
@@ -90,6 +91,15 @@ class EventType(StrEnum):
     CREATION = "creation"
     DELETION = "deletion"
     DENIED = "denied"
+
+
+class EventOutcome(StrEnum):
+    """event.outcome values defined by ECS"""
+
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-outcome
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
 
 
 class AuditEvent(PublicModel):
@@ -152,9 +162,9 @@ class AuditEvent(PublicModel):
     ]
     error_type: Annotated[str | None, Field(alias="error.type")] = None  # if event_outcome="failure"
     event_action: Annotated[EventAction, Field(alias="event.action")]
-    event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
     event_id: Annotated[UUID, Field(alias="event.id", default_factory=uuid4)]
-    event_kind: Annotated[Literal["event"], Field(alias="event.kind")] = "event"
+    event_kind: Annotated[EventKind, Field(alias="event.kind")] = EventKind.EVENT
+    event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
     event_module: Annotated[str, Field(alias="event.module")] = "curious"
     event_dataset: Annotated[str, Field(alias="event.dataset")] = "curious.audit"
     service_name: Annotated[str, Field(alias="service.name")] = "mindlogger-backend"

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -1,105 +1,12 @@
 from datetime import datetime, timezone
-from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated
 from uuid import UUID, uuid4
 
 from pydantic import Field
 
+from apps.audit.enums import EventAction, EventKind, EventOutcome
 from apps.shared.domain import PublicModel
 from config import settings
-
-
-class EventAction(StrEnum):
-    """event.action values defined for Curious"""
-
-    # User auth
-    USER_SESSION_LOGIN = "user:session:login"
-    USER_SESSION_LOGOUT = "user:session:logout"
-    USER_SESSION_REFRESH = "user:session:refresh"
-    USER_SESSION_INVALID = "user:session:invalid"
-
-    # User IAM
-    USER_CREATE = "user:create"
-    USER_DELETE = "user:delete"
-    USER_PASSWORD_CHANGE = "user:password:change"
-    USER_PASSWORD_RECOVERY_INITIATE = "user:password:recovery:initiate"
-    USER_PASSWORD_RECOVERY_APPROVE = "user:password:recovery:approve"
-    USER_MFA_ENABLE = "user:mfa:enable"
-    USER_MFA_DISABLE = "user:mfa:disable"
-    USER_MFA_RECOVERY_VIEW = "user:mfa:recovery:view"
-    USER_MFA_RECOVERY_DOWNLOAD = "user:mfa:recovery:download"
-    USER_MFA_RECOVERY_USE = "user:mfa:recovery:use"
-
-    # Workspace IAM
-    WORKSPACE_ACCESS_GRANT = "workspace:access:grant"
-    WORKSPACE_ACCESS_REVOKE = "workspace:access:revoke"
-
-    # Applet IAM
-    APPLET_CREATE = "applet:create"
-    APPLET_DELETE = "applet:delete"
-    APPLET_ENCRYPTION_UPDATE = "applet:encryption:update"
-    APPLET_TRANSFER_INITIATE = "applet:transfer:initiate"
-    APPLET_TRANSFER_ACCEPT = "applet:transfer:accept"
-    APPLET_TRANSFER_DECLINE = "applet:transfer:decline"
-    APPLET_INVITE_INITIATE = "applet:invite:initiate"
-    APPLET_INVITE_ACCEPT = "applet:invite:accept"
-    APPLET_INVITE_DECLINE = "applet:invite:decline"
-
-    # Applet data access
-    APPLET_SUBJECT_VIEW = "applet:subject:view"
-    APPLET_ANSWER_VIEW = "applet:answer:view"
-    APPLET_ANSWER_IDENTIFIER_VIEW = "applet:answer:identifier:view"
-    APPLET_ANSWER_ASSESSMENT_VIEW = "applet:answer:assessment:view"
-    APPLET_ANSWER_NOTE_VIEW = "applet:answer:note:view"
-    APPLET_ANSWER_EXPORT = "applet:answer:export"
-
-    # Applet file download
-    APPLET_ANSWER_EHR_DOWNLOAD = "applet:answer:ehr:download"
-    APPLET_ANSWER_FILE_DOWNLOAD = "applet:answer:file:download"
-    APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"
-
-
-class EventKind(StrEnum):
-    """event.kind valudes defined by ECS"""
-
-    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-kind
-    EVENT = "event"
-
-
-class EventCategory(StrEnum):
-    """event.category values defined by ECS"""
-
-    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-category
-    AUTHENTICATION = "authentication"
-    SESSION = "session"
-    DATABASE = "database"
-    FILE = "file"
-    IAM = "iam"
-    CONFIGURATION = "configuration"
-    WEB = "web"
-
-
-class EventType(StrEnum):
-    """event.type values defined by ECS"""
-
-    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-type
-    START = "start"
-    END = "end"
-    INFO = "info"
-    ACCESS = "access"
-    CHANGE = "change"
-    CREATION = "creation"
-    DELETION = "deletion"
-    DENIED = "denied"
-
-
-class EventOutcome(StrEnum):
-    """event.outcome values defined by ECS"""
-
-    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-outcome
-    SUCCESS = "success"
-    FAILURE = "failure"
-    UNKNOWN = "unknown"
 
 
 class AuditEvent(PublicModel):

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -75,8 +75,8 @@ class AuditEvent(PublicModel):
     event_id: Annotated[UUID, Field(alias="event.id", default_factory=uuid4)]
     event_kind: Annotated[EventKind, Field(alias="event.kind")] = EventKind.EVENT
     event_outcome: Annotated[EventOutcome, Field(alias="event.outcome")] = EventOutcome.SUCCESS
-    event_module: Annotated[str, Field(alias="event.module")] = "curious"
-    event_dataset: Annotated[str, Field(alias="event.dataset")] = "curious.audit"
+    event_module: Annotated[str, Field(alias="event.module")] = "mindlogger"
+    event_dataset: Annotated[str, Field(alias="event.dataset")] = "mindlogger.audit"
     service_name: Annotated[str, Field(alias="service.name")] = "mindlogger-backend"
     service_environment: Annotated[str, Field(alias="service.environment", default=settings.env)]
 

--- a/src/apps/audit/enums.py
+++ b/src/apps/audit/enums.py
@@ -1,0 +1,94 @@
+from enum import StrEnum
+
+
+class EventAction(StrEnum):
+    """event.action values defined for Curious"""
+
+    # User auth
+    USER_SESSION_LOGIN = "user:session:login"
+    USER_SESSION_LOGOUT = "user:session:logout"
+    USER_SESSION_REFRESH = "user:session:refresh"
+    USER_SESSION_INVALID = "user:session:invalid"
+
+    # User IAM
+    USER_CREATE = "user:create"
+    USER_DELETE = "user:delete"
+    USER_PASSWORD_CHANGE = "user:password:change"
+    USER_PASSWORD_RECOVERY_INITIATE = "user:password:recovery:initiate"
+    USER_PASSWORD_RECOVERY_APPROVE = "user:password:recovery:approve"
+    USER_MFA_ENABLE = "user:mfa:enable"
+    USER_MFA_DISABLE = "user:mfa:disable"
+    USER_MFA_RECOVERY_VIEW = "user:mfa:recovery:view"
+    USER_MFA_RECOVERY_DOWNLOAD = "user:mfa:recovery:download"
+    USER_MFA_RECOVERY_USE = "user:mfa:recovery:use"
+
+    # Workspace IAM
+    WORKSPACE_ACCESS_GRANT = "workspace:access:grant"
+    WORKSPACE_ACCESS_REVOKE = "workspace:access:revoke"
+
+    # Applet IAM
+    APPLET_CREATE = "applet:create"
+    APPLET_DELETE = "applet:delete"
+    APPLET_ENCRYPTION_UPDATE = "applet:encryption:update"
+    APPLET_TRANSFER_INITIATE = "applet:transfer:initiate"
+    APPLET_TRANSFER_ACCEPT = "applet:transfer:accept"
+    APPLET_TRANSFER_DECLINE = "applet:transfer:decline"
+    APPLET_INVITE_INITIATE = "applet:invite:initiate"
+    APPLET_INVITE_ACCEPT = "applet:invite:accept"
+    APPLET_INVITE_DECLINE = "applet:invite:decline"
+
+    # Applet data access
+    APPLET_SUBJECT_VIEW = "applet:subject:view"
+    APPLET_ANSWER_VIEW = "applet:answer:view"
+    APPLET_ANSWER_IDENTIFIER_VIEW = "applet:answer:identifier:view"
+    APPLET_ANSWER_ASSESSMENT_VIEW = "applet:answer:assessment:view"
+    APPLET_ANSWER_NOTE_VIEW = "applet:answer:note:view"
+    APPLET_ANSWER_EXPORT = "applet:answer:export"
+
+    # Applet file download
+    APPLET_ANSWER_EHR_DOWNLOAD = "applet:answer:ehr:download"
+    APPLET_ANSWER_FILE_DOWNLOAD = "applet:answer:file:download"
+    APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"
+
+
+class EventKind(StrEnum):
+    """event.kind values defined by ECS"""
+
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-kind
+    EVENT = "event"
+
+
+class EventCategory(StrEnum):
+    """event.category values defined by ECS"""
+
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-category
+    AUTHENTICATION = "authentication"
+    SESSION = "session"
+    DATABASE = "database"
+    FILE = "file"
+    IAM = "iam"
+    CONFIGURATION = "configuration"
+    WEB = "web"
+
+
+class EventType(StrEnum):
+    """event.type values defined by ECS"""
+
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-type
+    START = "start"
+    END = "end"
+    INFO = "info"
+    ACCESS = "access"
+    CHANGE = "change"
+    CREATION = "creation"
+    DELETION = "deletion"
+    DENIED = "denied"
+
+
+class EventOutcome(StrEnum):
+    """event.outcome values defined by ECS"""
+
+    # https://www.elastic.co/docs/reference/ecs/ecs-allowed-values-event-outcome
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"

--- a/src/apps/audit/enums.py
+++ b/src/apps/audit/enums.py
@@ -1,8 +1,19 @@
 from enum import StrEnum
+from functools import cached_property
 
 
 class EventAction(StrEnum):
-    """event.action values defined for Curious"""
+    """event.action values defined for Curious
+
+    Uses colon-separated format "{resource}:{subject}:{action}":
+    - "{resource}" all lowercase or underscore
+    - "{subject}" all lowercase or underscore or colon or omitted
+    - "{action}" all lowercase or underscore
+
+    Note that "{subject}" can contain colons or be omitted.
+
+    If omitted, "{subject}" is implied to be the same as "{resource}".
+    """
 
     # User auth
     USER_SESSION_LOGIN = "user:session:login"
@@ -49,6 +60,46 @@ class EventAction(StrEnum):
     APPLET_ANSWER_EHR_DOWNLOAD = "applet:answer:ehr:download"
     APPLET_ANSWER_FILE_DOWNLOAD = "applet:answer:file:download"
     APPLET_ANSWER_REPORT_DOWNLOAD = "applet:answer:report:download"
+
+    @cached_property
+    def _parts(self) -> tuple[str, ...]:
+        """Split into parts by colon ":"
+
+        - ("a", "b", "c", "d") for event "a:b:c:d"
+        - ("foo", "bar", "baz") for event "foo:bar:baz"
+        - ("toto", "tata") for event "toto:tata"
+        """
+        return tuple(self.value.split(":"))
+
+    @cached_property
+    def resource(self) -> str:
+        """First part of enum value
+
+        - "a" for event "a:b:c:d"
+        - "foo" for event "foo:bar:baz"
+        - "toto" for event "toto:tata"
+        """
+        return self._parts[0]
+
+    @cached_property
+    def subject(self) -> str:
+        """Middle part of enum value, or resource if middle part does not exist
+
+        - "b:c" for event "a:b:c:d"
+        - "bar" for event "foo:bar:baz"
+        - "toto" for event "toto:tata"
+        """
+        return ":".join(self._parts[1:-1]) or self.resource
+
+    @cached_property
+    def action(self) -> str:
+        """Last part of enum value
+
+        - "d" for event "a:b:c:d"
+        - "baz" for event "foo:bar:baz"
+        - "tata" for event "toto:tata"
+        """
+        return self._parts[-1]
 
 
 class EventKind(StrEnum):

--- a/src/apps/audit/service.py
+++ b/src/apps/audit/service.py
@@ -4,5 +4,5 @@ from .domain import AuditEvent
 
 
 async def log(event: AuditEvent) -> None:
-    payload = event.model_dump(by_alias=True, mode="json")
+    payload = event.model_dump(mode="json")
     logger.info("audit_event", **payload)  # TODO: Replace with sending event to RabbitMQ/OpenSearch.

--- a/src/apps/audit/service.py
+++ b/src/apps/audit/service.py
@@ -1,0 +1,8 @@
+from infrastructure.logger import logger
+
+from .domain import AuditEvent
+
+
+async def log(event: AuditEvent) -> None:
+    payload = event.model_dump(by_alias=True, mode="json")
+    logger.info("audit_event", **payload)  # TODO: Replace with sending event to RabbitMQ/OpenSearch.

--- a/src/config/service.py
+++ b/src/config/service.py
@@ -28,7 +28,7 @@ class ServiceUrlsSettings(BaseModel):
 class ServiceSettings(BaseModel):
     """Configure public service settings."""
 
-    name: str = "mindlogger-service"
+    name: str = "mindlogger-backend"
     port: int = 8000
     urls: ServiceUrlsSettings = ServiceUrlsSettings()
     result_limit: Annotated[int, Field(gt=0)] = 10000

--- a/src/config/service.py
+++ b/src/config/service.py
@@ -28,7 +28,7 @@ class ServiceUrlsSettings(BaseModel):
 class ServiceSettings(BaseModel):
     """Configure public service settings."""
 
-    name: str = "mindlogger-backend"
+    name: str = "curious-backend"
     port: int = 8000
     urls: ServiceUrlsSettings = ServiceUrlsSettings()
     result_limit: Annotated[int, Field(gt=0)] = 10000


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10698](https://mindlogger.atlassian.net/browse/M2-10698)

Changes include:

- Define `AuditEvent` data model
- Define `audit.log` stub

This provides a common interface that we can work against for M2-10697, M2-10698, M2-10699, and M2-10700.

### ✏️ Notes

We try to use standard [Elastic Common Schema (ECS) fields](https://www.elastic.co/docs/reference/ecs/ecs-field-reference) where possible.