### PR TITLE
feat: Reuse ECS `"event.id"` as OpenSearch `"_id"` (M2-10698)

### DIFF
--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -110,7 +110,7 @@ class AuditEvent(PublicModel):
     curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
     curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None
 
-    @computed_field(alias="_id")
+    @computed_field(alias="_id")  # type: ignore[prop-decorator]
     @property
     def id(self) -> UUID:
         """Reuse ECS event ID "event.id" as OpenSearch document ID "_id"."""

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID, uuid4
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, computed_field
 
 from apps.shared.domain import PublicModel
 from config import settings
@@ -109,3 +109,9 @@ class AuditEvent(PublicModel):
     curious_activity_id: Annotated[list[UUID] | None, Field(alias="curious.activity_id")] = None
     curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
     curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None
+
+    @computed_field(alias="_id")
+    @property
+    def id(self) -> UUID:
+        """Reuse ECS event ID "event.id" as OpenSearch document ID "_id"."""
+        return self.event_id

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -26,6 +26,9 @@ class AuditEvent(PublicModel):
     - service_name
     - service_environment
 
+    Automatically derived from event_id:
+    - id
+
     Applicable to IAM events:
     - user_roles
     - user_target_id


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10698](https://mindlogger.atlassian.net/browse/M2-10698)

This is a follow-up to #2046. @aweiland noted that OpenSearch also has a document ID `"_id"`.

Changes include:

- Reuse Elastic Common Schema (ECS) [`"event.id"`](https://www.elastic.co/docs/reference/ecs/ecs-event#field-event-id) as OpenSearch [`"_id"`](https://docs.opensearch.org/latest/mappings/metadata-fields/id/).

### ✏️ Notes

Setting `"_id"` instead of letting OpenSearch autogenerate will allow for idempotent writes.