### PR TITLE
 feat: User auth audit events (M2-10698)

### DIFF
--- a/src/apps/audit/__init__.py
+++ b/src/apps/audit/__init__.py
@@ -1,6 +1,6 @@
 from .domain import AuditEvent
 from .enums import EventAction, EventOutcome
+from .fields import http_error_fields, http_request_fields
 from .service import log
-from .tasks import send_audit_event
 
-__all__ = ["AuditEvent", "EventAction", "EventOutcome", "log", "send_audit_event"]
+__all__ = ["AuditEvent", "EventAction", "EventOutcome", "http_error_fields", "http_request_fields", "log"]

--- a/src/apps/audit/__init__.py
+++ b/src/apps/audit/__init__.py
@@ -1,6 +1,6 @@
 from .domain import AuditEvent
 from .enums import EventAction, EventOutcome
-from .fields import http_error_fields, http_request_fields
+from .fields import http_audit_fields
 from .service import log
 
-__all__ = ["AuditEvent", "EventAction", "EventOutcome", "http_error_fields", "http_request_fields", "log"]
+__all__ = ["AuditEvent", "EventAction", "EventOutcome", "http_audit_fields", "log"]

--- a/src/apps/audit/constants.py
+++ b/src/apps/audit/constants.py
@@ -1,0 +1,87 @@
+from .enums import EventAction, EventCategory, EventType
+
+EVENT_ACTION_TO_EVENT_CATEGORY: dict[EventAction, tuple[EventCategory, ...]] = {
+    # User auth
+    EventAction.USER_SESSION_LOGIN: (EventCategory.SESSION, EventCategory.AUTHENTICATION),
+    EventAction.USER_SESSION_LOGOUT: (EventCategory.SESSION,),
+    EventAction.USER_SESSION_REFRESH: (EventCategory.SESSION, EventCategory.AUTHENTICATION),
+    EventAction.USER_SESSION_INVALID: (EventCategory.SESSION, EventCategory.AUTHENTICATION),
+    # User IAM
+    EventAction.USER_CREATE: (EventCategory.IAM,),
+    EventAction.USER_DELETE: (EventCategory.IAM,),
+    EventAction.USER_PASSWORD_CHANGE: (EventCategory.IAM,),
+    EventAction.USER_PASSWORD_RECOVERY_INITIATE: (EventCategory.IAM,),
+    EventAction.USER_PASSWORD_RECOVERY_APPROVE: (EventCategory.IAM,),
+    EventAction.USER_MFA_ENABLE: (EventCategory.IAM,),
+    EventAction.USER_MFA_DISABLE: (EventCategory.IAM,),
+    EventAction.USER_MFA_RECOVERY_VIEW: (EventCategory.IAM,),
+    EventAction.USER_MFA_RECOVERY_DOWNLOAD: (EventCategory.IAM,),
+    EventAction.USER_MFA_RECOVERY_USE: (EventCategory.IAM,),
+    # Workspace IAM
+    EventAction.WORKSPACE_ACCESS_GRANT: (EventCategory.IAM,),
+    EventAction.WORKSPACE_ACCESS_REVOKE: (EventCategory.IAM,),
+    # Applet IAM
+    EventAction.APPLET_CREATE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_DELETE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_ENCRYPTION_UPDATE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_TRANSFER_INITIATE: (EventCategory.IAM,),
+    EventAction.APPLET_TRANSFER_ACCEPT: (EventCategory.IAM,),
+    EventAction.APPLET_TRANSFER_DECLINE: (EventCategory.IAM,),
+    EventAction.APPLET_INVITE_INITIATE: (EventCategory.IAM,),
+    EventAction.APPLET_INVITE_ACCEPT: (EventCategory.IAM,),
+    EventAction.APPLET_INVITE_DECLINE: (EventCategory.IAM,),
+    # Applet data access
+    EventAction.APPLET_SUBJECT_VIEW: (EventCategory.DATABASE,),
+    EventAction.APPLET_ANSWER_VIEW: (EventCategory.DATABASE,),
+    EventAction.APPLET_ANSWER_IDENTIFIER_VIEW: (EventCategory.DATABASE,),
+    EventAction.APPLET_ANSWER_ASSESSMENT_VIEW: (EventCategory.DATABASE,),
+    EventAction.APPLET_ANSWER_NOTE_VIEW: (EventCategory.DATABASE,),
+    EventAction.APPLET_ANSWER_EXPORT: (EventCategory.DATABASE,),
+    # Applet file download
+    EventAction.APPLET_ANSWER_EHR_DOWNLOAD: (EventCategory.FILE,),
+    EventAction.APPLET_ANSWER_FILE_DOWNLOAD: (EventCategory.FILE,),
+    EventAction.APPLET_ANSWER_REPORT_DOWNLOAD: (EventCategory.FILE,),
+}
+
+EVENT_ACTION_TO_EVENT_TYPE: dict[EventAction, tuple[EventType, ...]] = {
+    # User auth
+    EventAction.USER_SESSION_LOGIN: (EventType.START,),
+    EventAction.USER_SESSION_LOGOUT: (EventType.END,),
+    EventAction.USER_SESSION_REFRESH: (EventType.INFO,),
+    EventAction.USER_SESSION_INVALID: (EventType.INFO,),
+    # User IAM
+    EventAction.USER_CREATE: (EventType.CREATION,),
+    EventAction.USER_DELETE: (EventType.DELETION,),
+    EventAction.USER_PASSWORD_CHANGE: (EventType.CHANGE,),
+    EventAction.USER_PASSWORD_RECOVERY_INITIATE: (EventType.INFO,),
+    EventAction.USER_PASSWORD_RECOVERY_APPROVE: (EventType.CHANGE,),
+    EventAction.USER_MFA_ENABLE: (EventType.CHANGE,),
+    EventAction.USER_MFA_DISABLE: (EventType.CHANGE,),
+    EventAction.USER_MFA_RECOVERY_VIEW: (EventType.ACCESS,),
+    EventAction.USER_MFA_RECOVERY_DOWNLOAD: (EventType.ACCESS,),
+    EventAction.USER_MFA_RECOVERY_USE: (EventType.CHANGE,),
+    # Workspace IAM
+    EventAction.WORKSPACE_ACCESS_GRANT: (EventType.CHANGE,),
+    EventAction.WORKSPACE_ACCESS_REVOKE: (EventType.CHANGE,),
+    # Applet IAM
+    EventAction.APPLET_CREATE: (EventType.CREATION,),
+    EventAction.APPLET_DELETE: (EventType.DELETION,),
+    EventAction.APPLET_ENCRYPTION_UPDATE: (EventType.CHANGE,),
+    EventAction.APPLET_TRANSFER_INITIATE: (EventType.INFO,),
+    EventAction.APPLET_TRANSFER_ACCEPT: (EventType.CHANGE,),
+    EventAction.APPLET_TRANSFER_DECLINE: (EventType.INFO,),
+    EventAction.APPLET_INVITE_INITIATE: (EventType.INFO,),
+    EventAction.APPLET_INVITE_ACCEPT: (EventType.CHANGE,),
+    EventAction.APPLET_INVITE_DECLINE: (EventType.INFO,),
+    # Applet data access
+    EventAction.APPLET_SUBJECT_VIEW: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_VIEW: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_IDENTIFIER_VIEW: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_ASSESSMENT_VIEW: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_NOTE_VIEW: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_EXPORT: (EventType.ACCESS,),
+    # Applet file download
+    EventAction.APPLET_ANSWER_EHR_DOWNLOAD: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_FILE_DOWNLOAD: (EventType.ACCESS,),
+    EventAction.APPLET_ANSWER_REPORT_DOWNLOAD: (EventType.ACCESS,),
+}

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -83,7 +83,8 @@ class AuditEvent(PublicModel):
     service_environment: Annotated[str, Field(alias="service.environment", default=settings.env)]
 
     # User performing the action
-    user_id: Annotated[UUID | None, Field(alias="user.id")]
+    user_id: Annotated[UUID | None, Field(alias="user.id")]  # prefer ID if available
+    user_email: Annotated[str | None, Field(alias="user.email")] = None  # email only if ID unavailable
     user_roles: Annotated[list[str] | None, Field(alias="user.roles")] = None
 
     # User being acted upon (if applicable)

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -44,6 +44,7 @@ class AuditEvent(PublicModel):
     - http_response_status_code
     - url_path
     - url_query
+    - user_agent
 
     Applicable to HTTP requests if Datadog is enabled:
     - trace_id

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -2,12 +2,13 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID, uuid4
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, computed_field
 
 from apps.shared.domain import PublicModel
 from config import settings
 
-from .enums import EventAction, EventKind, EventOutcome
+from .constants import EVENT_ACTION_TO_EVENT_CATEGORY, EVENT_ACTION_TO_EVENT_TYPE
+from .enums import EventAction, EventCategory, EventKind, EventOutcome, EventType
 
 
 class AuditEvent(PublicModel):
@@ -109,3 +110,18 @@ class AuditEvent(PublicModel):
     curious_activity_id: Annotated[list[UUID] | None, Field(alias="curious.activity_id")] = None
     curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
     curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None
+
+    # Derive event.category from event.action
+    @computed_field(alias="event.category")  # type: ignore[prop-decorator]
+    @property
+    def event_category(self) -> tuple[EventCategory, ...]:
+        return EVENT_ACTION_TO_EVENT_CATEGORY[self.event_action]
+
+    # Derive event.type from event.action (extend with "denied" for 403 Forbidden authorization denials)
+    @computed_field(alias="event.type")  # type: ignore[prop-decorator]
+    @property
+    def event_type(self) -> tuple[EventType, ...]:
+        event_type = EVENT_ACTION_TO_EVENT_TYPE[self.event_action]
+        if self.event_outcome == EventOutcome.FAILURE and self.http_response_status_code == 403:
+            event_type += (EventType.DENIED,)
+        return event_type

--- a/src/apps/audit/fields.py
+++ b/src/apps/audit/fields.py
@@ -1,28 +1,29 @@
 from asgi_correlation_id.context import correlation_id
 from ddtrace.trace import tracer
 from fastapi import Request
+from fastapi.routing import APIRoute
 
 from apps.shared.exception import BaseError
 
 from .enums import EventOutcome
 
 
-def http_request_fields(request: Request) -> dict:
-    """Audit fields derived from HTTP request."""
-    return {
+def http_audit_fields(request: Request, error: BaseError | None = None) -> dict:
+    """Audit fields derived from HTTP request/error."""
+    route = request.scope.get("route")
+    span = tracer.current_span()
+    fields = {
         "client_ip": request.client and request.client.host,
         "http_request_id": correlation_id.get(),
         "http_request_method": request.method,
+        "http_response_status_code": isinstance(route, APIRoute) and route.status_code or 200,
         "url_path": request.url.path,
+        "url_query": request.url.query or None,
         "user_agent": request.headers.get("user-agent"),
-        "trace_id": (span := tracer.current_span()) and str(span.trace_id),
+        "trace_id": span and str(span.trace_id),
     }
-
-
-def http_error_fields(error: BaseError) -> dict:
-    """Audit fields derived from HTTP error."""
-    return {
-        "event_outcome": EventOutcome.FAILURE,
-        "error_type": type(error).__name__,
-        "http_response_status_code": error.status_code,
-    }
+    if error is not None:
+        fields["event_outcome"] = EventOutcome.FAILURE
+        fields["error_type"] = type(error).__name__
+        fields["http_response_status_code"] = error.status_code
+    return fields

--- a/src/apps/audit/fields.py
+++ b/src/apps/audit/fields.py
@@ -1,0 +1,28 @@
+from asgi_correlation_id.context import correlation_id
+from ddtrace.trace import tracer
+from fastapi import Request
+
+from apps.shared.exception import BaseError
+
+from .enums import EventOutcome
+
+
+def http_request_fields(request: Request) -> dict:
+    """Audit fields derived from HTTP request."""
+    return {
+        "client_ip": request.client and request.client.host,
+        "http_request_id": correlation_id.get(),
+        "http_request_method": request.method,
+        "url_path": request.url.path,
+        "user_agent": request.headers.get("user-agent"),
+        "trace_id": (span := tracer.current_span()) and str(span.trace_id),
+    }
+
+
+def http_error_fields(error: BaseError) -> dict:
+    """Audit fields derived from HTTP error."""
+    return {
+        "event_outcome": EventOutcome.FAILURE,
+        "error_type": type(error).__name__,
+        "http_response_status_code": error.status_code,
+    }

--- a/src/apps/audit/tests.py
+++ b/src/apps/audit/tests.py
@@ -1,0 +1,29 @@
+"""Unit tests for the audit module.
+
+These are pure-Python tests that don't need DB / HTTP fixtures, so they
+don't inherit from `BaseTest` and don't need pytest fixtures.
+"""
+
+import pytest
+
+from apps.audit.constants import EVENT_ACTION_TO_EVENT_CATEGORY, EVENT_ACTION_TO_EVENT_TYPE
+from apps.audit.enums import EventAction
+
+
+@pytest.mark.parametrize(
+    "constant_name,constant",
+    [
+        ("EVENT_ACTION_TO_EVENT_CATEGORY", EVENT_ACTION_TO_EVENT_CATEGORY),
+        ("EVENT_ACTION_TO_EVENT_TYPE", EVENT_ACTION_TO_EVENT_TYPE),
+    ],
+)
+def test_constant_covers_all_event_actions(constant_name: str, constant: dict) -> None:
+    """Every `EventAction` member must have an entry in the lookup constant.
+
+    Guards against forgetting to add a new action's mapping when extending
+    the `EventAction` enum.
+    """
+    missing = set(EventAction) - set(constant)
+    extra = set(constant) - set(EventAction)
+    assert not missing, f"{constant_name} is missing entries for: {sorted(m.value for m in missing)}"
+    assert not extra, f"{constant_name} has extra entries not in EventAction: {extra}"

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -80,6 +80,7 @@ async def get_token(
         await log(
             AuditEvent(
                 user_id=None,
+                user_email=user_login_schema.email,
                 event_action=EventAction.USER_SESSION_LOGIN,
                 **http_audit_fields(request, e),
             )

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -588,63 +588,85 @@ async def verify_mfa_recovery_code(
 
 
 async def refresh_access_token(
+    request: Request,
     schema: RefreshAccessTokenRequest = Body(...),
     session=Depends(get_session),
 ) -> Response[Token]:
     """Refresh access token."""
-    async with atomic(session):
-        try:
-            regenerate_refresh_token = False
+    user_id: uuid.UUID | None = None
+    try:
+        async with atomic(session):
             try:
-                payload = jwt.decode(
-                    schema.refresh_token,
-                    settings.authentication.refresh_token.secret_key,
-                    algorithms=[settings.authentication.algorithm],
+                regenerate_refresh_token = False
+                try:
+                    payload = jwt.decode(
+                        schema.refresh_token,
+                        settings.authentication.refresh_token.secret_key,
+                        algorithms=[settings.authentication.algorithm],
+                    )
+                except jwt.PyJWTError:
+                    # check transition key
+                    transition_key = settings.authentication.refresh_token.transition_key
+                    transition_expire_date = settings.authentication.refresh_token.transition_expire_date
+                    today = datetime.now(timezone.utc).date()
+
+                    if not (transition_key and transition_expire_date and transition_expire_date > today):
+                        raise
+                    payload = jwt.decode(
+                        schema.refresh_token,
+                        str(transition_key),
+                        algorithms=[settings.authentication.algorithm],
+                    )
+                    regenerate_refresh_token = True
+
+                token_data = TokenPayload(**payload)
+
+            except (jwt.PyJWTError, ValidationError) as e:
+                raise InvalidRefreshToken() from e
+
+            user_id = token_data.sub
+
+            # Check if the token is in the blacklist
+            revoked = await AuthenticationService(session).is_revoked(InternalToken(payload=token_data))
+            if revoked:
+                raise AuthenticationError
+
+            rjti = token_data.jti
+            refresh_token = schema.refresh_token
+            if regenerate_refresh_token:
+                # blacklist current refresh token
+                await AuthenticationService(session).revoke_token(
+                    InternalToken(payload=token_data), TokenPurpose.REFRESH
                 )
-            except jwt.PyJWTError:
-                # check transition key
-                transition_key = settings.authentication.refresh_token.transition_key
-                transition_expire_date = settings.authentication.refresh_token.transition_expire_date
-                today = datetime.now(timezone.utc).date()
 
-                if not (transition_key and transition_expire_date and transition_expire_date > today):
-                    raise
-                payload = jwt.decode(
-                    schema.refresh_token,
-                    str(transition_key),
-                    algorithms=[settings.authentication.algorithm],
+                rjti = str(uuid.uuid4())
+                refresh_token = AuthenticationService.create_refresh_token(
+                    {JWTClaim.sub: str(user_id), JWTClaim.jti: rjti, JWTClaim.exp: token_data.exp}
                 )
-                regenerate_refresh_token = True
 
-            token_data = TokenPayload(**payload)
-
-        except (jwt.PyJWTError, ValidationError) as e:
-            raise InvalidRefreshToken() from e
-
-        # Check if the token is in the blacklist
-        revoked = await AuthenticationService(session).is_revoked(InternalToken(payload=token_data))
-        if revoked:
-            raise AuthenticationError
-
-        rjti = token_data.jti
-        user_id = token_data.sub
-        refresh_token = schema.refresh_token
-        if regenerate_refresh_token:
-            # blacklist current refresh token
-            await AuthenticationService(session).revoke_token(InternalToken(payload=token_data), TokenPurpose.REFRESH)
-
-            rjti = str(uuid.uuid4())
-            refresh_token = AuthenticationService.create_refresh_token(
-                {JWTClaim.sub: str(user_id), JWTClaim.jti: rjti, JWTClaim.exp: token_data.exp}
+            access_token = AuthenticationService.create_access_token(
+                {
+                    JWTClaim.sub: str(user_id),
+                    JWTClaim.rjti: rjti,
+                }
             )
-
-        access_token = AuthenticationService.create_access_token(
-            {
-                JWTClaim.sub: str(user_id),
-                JWTClaim.rjti: rjti,
-            }
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.USER_SESSION_REFRESH,
+                user_id=user_id,
+                **http_audit_fields(request, e),
+            )
         )
+        raise
 
+    await log(
+        AuditEvent(
+            event_action=EventAction.USER_SESSION_REFRESH,
+            user_id=user_id,
+            **http_audit_fields(request),
+        )
+    )
     return Response(result=Token(access_token=access_token, refresh_token=refresh_token))
 
 

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -141,6 +141,7 @@ async def get_token(
 
 
 async def verify_mfa_totp(
+    request: Request,
     verify_request: MFATOTPVerifyRequest = Body(...),
     session=Depends(get_session),
     os_name: Annotated[str | None, Header()] = None,
@@ -148,169 +149,198 @@ async def verify_mfa_totp(
     app_version: Annotated[str | None, Header()] = None,
 ) -> Response[UserLogin]:
     """Verify TOTP code during MFA and return tokens."""
-    # Validate MFA token and get session info
-    mfa_service = MFASessionService()
+    user_id: uuid.UUID | None = None
     try:
-        mfa_session_id, user_id, purpose = await mfa_service.validate_and_get_session(verify_request.mfa_token)
-    except (
-        MFATokenExpiredError,
-        MFATokenMalformedError,
-        MFATokenInvalidError,
-        MFASessionNotFoundError,
-    ) as e:
-        # Re-raise specific MFA token/session errors with detailed feedback
-        raise e
-
-    # Check global lockout FIRST (prevents bypassing per-session limits)
-    is_locked = await mfa_service.is_globally_locked_out(user_id)
-    if is_locked:
-        logger.warning(f"User globally locked out from MFA attempts user_id={user_id}")
-        await mfa_service.delete_session(mfa_session_id)
-        raise MFAGlobalLockoutError(
-            global_attempts_remaining=0,
-        )
-
-    # Check if max attempts exceeded BEFORE attempting verification
-    session_data = await mfa_service.get_session(mfa_session_id)
-    if session_data and session_data.has_exceeded_max_attempts(settings.redis.mfa_max_attempts):
-        global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
-        logger.warning(
-            f"MFA max attempts exceeded user_id={user_id} "
-            f"failed_attempts={session_data.failed_totp_attempts} max_attempts={settings.redis.mfa_max_attempts}"
-        )
-        # Delete session to force re-login
-        await mfa_service.delete_session(mfa_session_id)
-        raise TooManyTOTPAttemptsError(
-            session_attempts_remaining=0,
-            global_attempts_remaining=global_remaining,
-            lockout_reason="session_limit",
-        )
-
-    # Get user from DB
-    async with atomic(session):
-        user: User = await UsersCRUD(session).get_by_id(user_id)
-
-        if not user.mfa_secret:
-            # Edge case: user disabled MFA between login and verification
-            raise MFATokenInvalidError()
-
-        totp_service = TOTPService()
-
-        # Verify TOTP code with replay protection
+        # Validate MFA token and get session info
+        mfa_service = MFASessionService()
         try:
-            decrypted_secret = totp_service.decrypt_secret(user.mfa_secret)
-        except Exception:
-            raise InvalidTOTPCodeError()
+            mfa_session_id, user_id, purpose = await mfa_service.validate_and_get_session(verify_request.mfa_token)
+        except (
+            MFATokenExpiredError,
+            MFATokenMalformedError,
+            MFATokenInvalidError,
+            MFASessionNotFoundError,
+        ) as e:
+            # Re-raise specific MFA token/session errors with detailed feedback
+            raise e
 
-        # Get user's last used time step for replay protection
-        last_step = user.last_totp_time_step
+        # Check global lockout FIRST (prevents bypassing per-session limits)
+        is_locked = await mfa_service.is_globally_locked_out(user_id)
+        if is_locked:
+            logger.warning(f"User globally locked out from MFA attempts user_id={user_id}")
+            await mfa_service.delete_session(mfa_session_id)
+            raise MFAGlobalLockoutError(
+                global_attempts_remaining=0,
+            )
 
-        # Verify with replay protection
-        is_valid, time_step_used = totp_service.verify_with_replay_check(
-            secret=decrypted_secret, code=verify_request.totp_code, last_used_step=last_step
-        )
-
-        if not is_valid:
-            # Increment both per-session and global failed attempts counters
-            new_attempt_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
-            global_attempt_count = await mfa_service.increment_global_failed_attempts(user.id)
-
-            # Calculate remaining attempts using service methods
-            session_remaining = await mfa_service.get_remaining_session_attempts(mfa_session_id)
-            global_remaining = await mfa_service.get_remaining_global_attempts(user.id)
-
+        # Check if max attempts exceeded BEFORE attempting verification
+        session_data = await mfa_service.get_session(mfa_session_id)
+        if session_data and session_data.has_exceeded_max_attempts(settings.redis.mfa_max_attempts):
+            global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
             logger.warning(
-                f"Invalid TOTP code provided user_id={user.id} email={user.email_encrypted} "
-                f"failed_attempts={new_attempt_count} global_failed_attempts={global_attempt_count}"
+                f"MFA max attempts exceeded user_id={user_id} "
+                f"failed_attempts={session_data.failed_totp_attempts} max_attempts={settings.redis.mfa_max_attempts}"
             )
-
-            # Send warning email if global attempts hit threshold
-            if global_attempt_count == settings.mfa.failed_attempts_warning_threshold:
-                notification_service = MFANotificationService()
-                global_remaining = settings.redis.mfa_global_lockout_attempts - global_attempt_count
-                await notification_service.send_failed_attempts_warning(
-                    user=user,
-                    failed_attempts=global_attempt_count,
-                    max_attempts=settings.redis.mfa_global_lockout_attempts,
-                    remaining_attempts=global_remaining,
-                )
-
-            # Check if global lockout threshold reached
-            if global_attempt_count >= settings.redis.mfa_global_lockout_attempts:
-                logger.warning(
-                    f"User globally locked out after max failed attempts user_id={user.id} "
-                    f"email={user.email_encrypted} global_failed_attempts={global_attempt_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-
-                # Send account locked notification
-                notification_service = MFANotificationService()
-                await notification_service.send_account_locked_email(
-                    user=user,
-                    lockout_reason="Too many failed MFA verification attempts",
-                    failed_attempts=global_attempt_count,
-                    lockout_ttl_seconds=settings.redis.mfa_global_lockout_ttl,
-                )
-
-                raise MFAGlobalLockoutError(
-                    global_attempts_remaining=0,
-                )
-
-            # If this was the last allowed attempt for this session, delete session
-            if new_attempt_count is not None and new_attempt_count >= settings.redis.mfa_max_attempts:
-                logger.warning(
-                    f"User locked out after max failed TOTP attempts for session user_id={user.id} "
-                    f"email={user.email_encrypted} failed_attempts={new_attempt_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-                raise TooManyTOTPAttemptsError(
-                    session_attempts_remaining=0,
-                    global_attempts_remaining=global_remaining,
-                    lockout_reason="session_limit",
-                )
-
-            # Otherwise, raise normal invalid code error with remaining attempts
-            raise InvalidTOTPCodeError(
-                session_attempts_remaining=session_remaining,
+            # Delete session to force re-login
+            await mfa_service.delete_session(mfa_session_id)
+            raise TooManyTOTPAttemptsError(
+                session_attempts_remaining=0,
                 global_attempts_remaining=global_remaining,
+                lockout_reason="session_limit",
             )
 
-        # TOTP is valid - Update last used time step for replay protection
-        assert time_step_used is not None  # Always set when is_valid is True
-        await UsersCRUD(session).update_last_totp_time_step(user.id, time_step_used)
+        # Get user from DB
+        async with atomic(session):
+            user: User = await UsersCRUD(session).get_by_id(user_id)
 
-        # Clear global lockout counter and delete MFA session
-        await mfa_service.clear_global_lockout(user.id)
-        await mfa_service.delete_session(mfa_session_id)
+            if not user.mfa_secret:
+                # Edge case: user disabled MFA between login and verification
+                raise MFATokenInvalidError()
 
-        logger.info(
-            f"MFA verification successful user_id={user.id} email={user.email_encrypted} "
-            f"device_id={verify_request.device_id}"
-        )
+            totp_service = TOTPService()
 
-        # Register device if device_id provided
-        if verify_request.device_id:
-            await UserDeviceService(session, user.id).add_device(
-                UserDeviceCreate(
-                    device_id=verify_request.device_id,
-                    os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
-                    app_version=app_version,
+            # Verify TOTP code with replay protection
+            try:
+                decrypted_secret = totp_service.decrypt_secret(user.mfa_secret)
+            except Exception:
+                raise InvalidTOTPCodeError()
+
+            # Get user's last used time step for replay protection
+            last_step = user.last_totp_time_step
+
+            # Verify with replay protection
+            is_valid, time_step_used = totp_service.verify_with_replay_check(
+                secret=decrypted_secret, code=verify_request.totp_code, last_used_step=last_step
+            )
+
+            if not is_valid:
+                # Increment both per-session and global failed attempts counters
+                new_attempt_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
+                global_attempt_count = await mfa_service.increment_global_failed_attempts(user.id)
+
+                # Calculate remaining attempts using service methods
+                session_remaining = await mfa_service.get_remaining_session_attempts(mfa_session_id)
+                global_remaining = await mfa_service.get_remaining_global_attempts(user.id)
+
+                logger.warning(
+                    f"Invalid TOTP code provided user_id={user.id} email={user.email_encrypted} "
+                    f"failed_attempts={new_attempt_count} global_failed_attempts={global_attempt_count}"
                 )
+
+                # Send warning email if global attempts hit threshold
+                if global_attempt_count == settings.mfa.failed_attempts_warning_threshold:
+                    notification_service = MFANotificationService()
+                    global_remaining = settings.redis.mfa_global_lockout_attempts - global_attempt_count
+                    await notification_service.send_failed_attempts_warning(
+                        user=user,
+                        failed_attempts=global_attempt_count,
+                        max_attempts=settings.redis.mfa_global_lockout_attempts,
+                        remaining_attempts=global_remaining,
+                    )
+
+                # Check if global lockout threshold reached
+                if global_attempt_count >= settings.redis.mfa_global_lockout_attempts:
+                    logger.warning(
+                        f"User globally locked out after max failed attempts user_id={user.id} "
+                        f"email={user.email_encrypted} global_failed_attempts={global_attempt_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
+
+                    # Send account locked notification
+                    notification_service = MFANotificationService()
+                    await notification_service.send_account_locked_email(
+                        user=user,
+                        lockout_reason="Too many failed MFA verification attempts",
+                        failed_attempts=global_attempt_count,
+                        lockout_ttl_seconds=settings.redis.mfa_global_lockout_ttl,
+                    )
+
+                    raise MFAGlobalLockoutError(
+                        global_attempts_remaining=0,
+                    )
+
+                # If this was the last allowed attempt for this session, delete session
+                if new_attempt_count is not None and new_attempt_count >= settings.redis.mfa_max_attempts:
+                    logger.warning(
+                        f"User locked out after max failed TOTP attempts for session user_id={user.id} "
+                        f"email={user.email_encrypted} failed_attempts={new_attempt_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
+                    raise TooManyTOTPAttemptsError(
+                        session_attempts_remaining=0,
+                        global_attempts_remaining=global_remaining,
+                        lockout_reason="session_limit",
+                    )
+
+                # Otherwise, raise normal invalid code error with remaining attempts
+                raise InvalidTOTPCodeError(
+                    session_attempts_remaining=session_remaining,
+                    global_attempts_remaining=global_remaining,
+                )
+
+            # TOTP is valid - Update last used time step for replay protection
+            assert time_step_used is not None  # Always set when is_valid is True
+            await UsersCRUD(session).update_last_totp_time_step(user.id, time_step_used)
+
+            # Clear global lockout counter and delete MFA session
+            await mfa_service.clear_global_lockout(user.id)
+            await mfa_service.delete_session(mfa_session_id)
+
+            logger.info(
+                f"MFA verification successful user_id={user.id} email={user.email_encrypted} "
+                f"device_id={verify_request.device_id}"
             )
 
-        # Issue refresh and access tokens
-        rjti = str(uuid.uuid4())
-        refresh_token = AuthenticationService.create_refresh_token({JWTClaim.sub: str(user.id), JWTClaim.jti: rjti})
+            # Register device if device_id provided
+            if verify_request.device_id:
+                await UserDeviceService(session, user.id).add_device(
+                    UserDeviceCreate(
+                        device_id=verify_request.device_id,
+                        os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
+                        app_version=app_version,
+                    )
+                )
 
-        access_token = AuthenticationService.create_access_token(
-            {
-                JWTClaim.sub: str(user.id),
-                JWTClaim.rjti: rjti,
-            }
+            # Issue refresh and access tokens
+            rjti = str(uuid.uuid4())
+            refresh_token = AuthenticationService.create_refresh_token({JWTClaim.sub: str(user.id), JWTClaim.jti: rjti})
+
+            access_token = AuthenticationService.create_access_token(
+                {
+                    JWTClaim.sub: str(user.id),
+                    JWTClaim.rjti: rjti,
+                }
+            )
+    except AuthenticationError as e:
+        await log(
+            AuditEvent(
+                user_id=user_id,
+                event_action=EventAction.USER_SESSION_LOGIN,
+                event_outcome=EventOutcome.FAILURE,
+                error_type=type(e).__name__,
+                client_ip=request.client and request.client.host,
+                http_request_method=request.method,
+                http_response_status_code=e.status_code,
+                url_path=request.url.path,
+                user_agent=request.headers.get("user-agent"),
+            )
         )
+        raise
 
     token = Token(access_token=access_token, refresh_token=refresh_token)
     public_user = PublicUser.from_user(user)
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.USER_SESSION_LOGIN,
+            client_ip=request.client and request.client.host,
+            http_request_method=request.method,
+            http_response_status_code=200,
+            url_path=request.url.path,
+            user_agent=request.headers.get("user-agent"),
+        )
+    )
 
     return Response(
         result=UserLogin(

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -649,17 +649,36 @@ async def refresh_access_token(
 
 
 async def delete_access_token(
+    request: Request,
     schema: UserLogoutRequest | None = Body(default=None),
     token: InternalToken = Depends(get_current_token()),
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ) -> EmptyResponse:
     """Add token to the blacklist."""
-    async with atomic(session):
-        await AuthenticationService(session).revoke_token(token, TokenPurpose.ACCESS)
-    async with atomic(session):
-        if schema and schema.device_id:
-            await UserDeviceService(session, user.id).remove_device(schema.device_id)
+    try:
+        async with atomic(session):
+            await AuthenticationService(session).revoke_token(token, TokenPurpose.ACCESS)
+        async with atomic(session):
+            if schema and schema.device_id:
+                await UserDeviceService(session, user.id).remove_device(schema.device_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.USER_SESSION_LOGOUT,
+                user_id=user.id,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.USER_SESSION_LOGOUT,
+            user_id=user.id,
+            **http_audit_fields(request),
+        )
+    )
     return EmptyResponse()
 
 

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -339,225 +339,244 @@ async def verify_mfa_recovery_code(
     app_version: Annotated[str | None, Header()] = None,
 ) -> Response[UserLogin]:
     """Verify recovery code during MFA and return tokens."""
-    # Validate MFA token and get session info
-    mfa_service = MFASessionService()
+    user_id: uuid.UUID | None = None
     try:
-        mfa_session_id, user_id, purpose = await mfa_service.validate_and_get_session(verify_request.mfa_token)
-    except (
-        MFATokenExpiredError,
-        MFATokenMalformedError,
-        MFATokenInvalidError,
-        MFASessionNotFoundError,
-    ) as e:
-        # Re-raise specific MFA token/session errors with detailed feedback
-        raise e
-
-    # Check global lockout FIRST (prevents bypassing per-session limits)
-    is_locked = await mfa_service.is_globally_locked_out(user_id)
-    if is_locked:
-        logger.warning(f"User globally locked out from MFA attempts user_id={user_id}")
-        raise MFAGlobalLockoutError(
-            global_attempts_remaining=0,
-        )
-
-    # Check if max per-session attempts exceeded BEFORE attempting verification
-    session_data = await mfa_service.get_session(mfa_session_id)
-    if session_data and session_data.has_exceeded_max_attempts(settings.redis.mfa_max_attempts):
-        global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
-        logger.warning(
-            f"MFA max attempts exceeded user_id={user_id} "
-            f"failed_attempts={session_data.failed_totp_attempts} max_attempts={settings.redis.mfa_max_attempts}"
-        )
-        # Delete session to force re-login
-        await mfa_service.delete_session(mfa_session_id)
-        raise TooManyTOTPAttemptsError(
-            session_attempts_remaining=0,
-            global_attempts_remaining=global_remaining,
-            lockout_reason="session_limit",
-        )
-
-    # Get user and verify recovery code
-    async with atomic(session):
-        user: User = await UsersCRUD(session).get_by_id(user_id)
-
-        # Verify and mark recovery code as used
+        # Validate MFA token and get session info
+        mfa_service = MFASessionService()
         try:
-            await verify_recovery_code_service(session, user_id, verify_request.code)
+            mfa_session_id, user_id, purpose = await mfa_service.validate_and_get_session(verify_request.mfa_token)
+        except (
+            MFATokenExpiredError,
+            MFATokenMalformedError,
+            MFATokenInvalidError,
+            MFASessionNotFoundError,
+        ) as e:
+            # Re-raise specific MFA token/session errors with detailed feedback
+            raise e
 
-            # Extract request metadata for security notification
-            request_metadata = extract_request_metadata(request)
-
-            # Send recovery code notifications (used + warning if needed)
-            await send_recovery_code_notifications(
-                session=session,
-                user=user,
-                used_at=datetime.now(timezone.utc),
-                request_info=request_metadata,
+        # Check global lockout FIRST (prevents bypassing per-session limits)
+        is_locked = await mfa_service.is_globally_locked_out(user_id)
+        if is_locked:
+            logger.warning(f"User globally locked out from MFA attempts user_id={user_id}")
+            raise MFAGlobalLockoutError(
+                global_attempts_remaining=0,
             )
 
-        except RecoveryCodeNotFoundError:
-            # No unused codes exist - increment both counters
-            session_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
-            global_count = await mfa_service.increment_global_failed_attempts(user_id)
-
-            # Calculate remaining attempts using service methods
+        # Check if max per-session attempts exceeded BEFORE attempting verification
+        session_data = await mfa_service.get_session(mfa_session_id)
+        if session_data and session_data.has_exceeded_max_attempts(settings.redis.mfa_max_attempts):
             global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
-
             logger.warning(
-                f"Recovery code verification failed - no unused codes user_id={user_id} "
-                f"email={user.email_encrypted} failed_attempts={session_count} "
-                f"global_failed_attempts={global_count} "
-                f"warning_threshold={settings.mfa.failed_attempts_warning_threshold}"
+                f"MFA max attempts exceeded user_id={user_id} "
+                f"failed_attempts={session_data.failed_totp_attempts} max_attempts={settings.redis.mfa_max_attempts}"
+            )
+            # Delete session to force re-login
+            await mfa_service.delete_session(mfa_session_id)
+            raise TooManyTOTPAttemptsError(
+                session_attempts_remaining=0,
+                global_attempts_remaining=global_remaining,
+                lockout_reason="session_limit",
             )
 
-            # Send warning email if global attempts hit threshold
-            if global_count == settings.mfa.failed_attempts_warning_threshold:
-                logger.info(
-                    f"Sending failed attempts warning email user_id={user_id} "
-                    f"global_count={global_count} threshold={settings.mfa.failed_attempts_warning_threshold}"
-                )
-                notification_service = MFANotificationService()
-                global_remaining = settings.redis.mfa_global_lockout_attempts - global_count
-                await notification_service.send_failed_attempts_warning(
+        # Get user and verify recovery code
+        async with atomic(session):
+            user: User = await UsersCRUD(session).get_by_id(user_id)
+
+            # Verify and mark recovery code as used
+            try:
+                await verify_recovery_code_service(session, user_id, verify_request.code)
+
+                # Extract request metadata for security notification
+                request_metadata = extract_request_metadata(request)
+
+                # Send recovery code notifications (used + warning if needed)
+                await send_recovery_code_notifications(
+                    session=session,
                     user=user,
-                    failed_attempts=global_count,
-                    max_attempts=settings.redis.mfa_global_lockout_attempts,
-                    remaining_attempts=global_remaining,
+                    used_at=datetime.now(timezone.utc),
+                    request_info=request_metadata,
                 )
-                logger.info(f"Failed attempts warning email sent user_id={user_id}")
 
-            # Check if global lockout threshold reached
-            if global_count >= settings.redis.mfa_global_lockout_attempts:
+            except RecoveryCodeNotFoundError:
+                # No unused codes exist - increment both counters
+                session_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
+                global_count = await mfa_service.increment_global_failed_attempts(user_id)
+
+                # Calculate remaining attempts using service methods
+                global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
+
                 logger.warning(
-                    f"User globally locked out after max failed attempts user_id={user_id} "
-                    f"email={user.email_encrypted} global_failed_attempts={global_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-                raise MFAGlobalLockoutError(
-                    global_attempts_remaining=0,
+                    f"Recovery code verification failed - no unused codes user_id={user_id} "
+                    f"email={user.email_encrypted} failed_attempts={session_count} "
+                    f"global_failed_attempts={global_count} "
+                    f"warning_threshold={settings.mfa.failed_attempts_warning_threshold}"
                 )
 
-            # Check if per-session lockout threshold reached
-            if session_count is not None and session_count >= settings.redis.mfa_max_attempts:
+                # Send warning email if global attempts hit threshold
+                if global_count == settings.mfa.failed_attempts_warning_threshold:
+                    logger.info(
+                        f"Sending failed attempts warning email user_id={user_id} "
+                        f"global_count={global_count} threshold={settings.mfa.failed_attempts_warning_threshold}"
+                    )
+                    notification_service = MFANotificationService()
+                    global_remaining = settings.redis.mfa_global_lockout_attempts - global_count
+                    await notification_service.send_failed_attempts_warning(
+                        user=user,
+                        failed_attempts=global_count,
+                        max_attempts=settings.redis.mfa_global_lockout_attempts,
+                        remaining_attempts=global_remaining,
+                    )
+                    logger.info(f"Failed attempts warning email sent user_id={user_id}")
+
+                # Check if global lockout threshold reached
+                if global_count >= settings.redis.mfa_global_lockout_attempts:
+                    logger.warning(
+                        f"User globally locked out after max failed attempts user_id={user_id} "
+                        f"email={user.email_encrypted} global_failed_attempts={global_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
+                    raise MFAGlobalLockoutError(
+                        global_attempts_remaining=0,
+                    )
+
+                # Check if per-session lockout threshold reached
+                if session_count is not None and session_count >= settings.redis.mfa_max_attempts:
+                    logger.warning(
+                        f"User locked out after max failed recovery code attempts for session "
+                        f"user_id={user_id} email={user.email_encrypted} failed_attempts={session_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
+                    raise TooManyTOTPAttemptsError(
+                        session_attempts_remaining=0,
+                        global_attempts_remaining=global_remaining,
+                        lockout_reason="session_limit",
+                    )
+
+                raise
+
+            except RecoveryCodeInvalidError:
+                # Invalid code - increment both per-session and global counters
+                session_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
+                global_count = await mfa_service.increment_global_failed_attempts(user_id)
+
+                # Calculate remaining attempts using service methods
+                global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
+                session_remaining = await mfa_service.get_remaining_session_attempts(mfa_session_id)
+
                 logger.warning(
-                    f"User locked out after max failed recovery code attempts for session "
-                    f"user_id={user_id} email={user.email_encrypted} failed_attempts={session_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-                raise TooManyTOTPAttemptsError(
-                    session_attempts_remaining=0,
-                    global_attempts_remaining=global_remaining,
-                    lockout_reason="session_limit",
+                    f"Invalid recovery code provided user_id={user_id} email={user.email_encrypted} "
+                    f"failed_attempts={session_count} global_failed_attempts={global_count} "
+                    f"warning_threshold={settings.mfa.failed_attempts_warning_threshold}"
                 )
 
-            raise
+                # Send warning email if global attempts hit threshold
+                if global_count == settings.mfa.failed_attempts_warning_threshold:
+                    logger.info(
+                        f"Sending failed attempts warning email user_id={user_id} "
+                        f"global_count={global_count} threshold={settings.mfa.failed_attempts_warning_threshold}"
+                    )
+                    notification_service = MFANotificationService()
+                    global_remaining = settings.redis.mfa_global_lockout_attempts - global_count
+                    await notification_service.send_failed_attempts_warning(
+                        user=user,
+                        failed_attempts=global_count,
+                        max_attempts=settings.redis.mfa_global_lockout_attempts,
+                        remaining_attempts=global_remaining,
+                    )
+                    logger.info(f"Failed attempts warning email sent user_id={user_id}")
 
-        except RecoveryCodeInvalidError:
-            # Invalid code - increment both per-session and global counters
-            session_count = await mfa_service.increment_failed_totp_attempts(mfa_session_id)
-            global_count = await mfa_service.increment_global_failed_attempts(user_id)
+                # Check if global lockout threshold reached
+                if global_count >= settings.redis.mfa_global_lockout_attempts:
+                    logger.warning(
+                        f"User globally locked out after max failed recovery code attempts "
+                        f"user_id={user_id} email={user.email_encrypted} global_failed_attempts={global_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
 
-            # Calculate remaining attempts using service methods
-            global_remaining = await mfa_service.get_remaining_global_attempts(user_id)
-            session_remaining = await mfa_service.get_remaining_session_attempts(mfa_session_id)
+                    # Send account locked notification
+                    notification_service = MFANotificationService()
+                    await notification_service.send_account_locked_email(
+                        user=user,
+                        lockout_reason="Too many failed recovery code attempts",
+                        failed_attempts=global_count,
+                        lockout_ttl_seconds=settings.redis.mfa_global_lockout_ttl,
+                    )
 
-            logger.warning(
-                f"Invalid recovery code provided user_id={user_id} email={user.email_encrypted} "
-                f"failed_attempts={session_count} global_failed_attempts={global_count} "
-                f"warning_threshold={settings.mfa.failed_attempts_warning_threshold}"
+                    raise MFAGlobalLockoutError(
+                        global_attempts_remaining=0,
+                    )
+
+                # Check if per-session lockout threshold reached
+                if session_count is not None and session_count >= settings.redis.mfa_max_attempts:
+                    logger.warning(
+                        f"User locked out after max failed recovery code attempts for session "
+                        f"user_id={user_id} email={user.email_encrypted} failed_attempts={session_count}"
+                    )
+                    await mfa_service.delete_session(mfa_session_id)
+                    raise TooManyTOTPAttemptsError(
+                        session_attempts_remaining=0,
+                        global_attempts_remaining=global_remaining,
+                        lockout_reason="session_limit",
+                    )
+
+                # Re-raise with metadata to inform frontend of remaining attempts
+                raise RecoveryCodeInvalidError(
+                    metadata={
+                        "session_attempts_remaining": session_remaining if session_remaining is not None else 0,
+                        "global_attempts_remaining": global_remaining if global_remaining is not None else 0,
+                    }
+                )
+
+            # Recovery code valid - clear lockout and delete MFA session
+            await mfa_service.clear_global_lockout(user_id)
+            await mfa_service.delete_session(mfa_session_id)
+
+            logger.info(
+                f"MFA recovery code verification successful user_id={user_id} email={user.email_encrypted} "
+                f"device_id={verify_request.device_id}"
             )
 
-            # Send warning email if global attempts hit threshold
-            if global_count == settings.mfa.failed_attempts_warning_threshold:
-                logger.info(
-                    f"Sending failed attempts warning email user_id={user_id} "
-                    f"global_count={global_count} threshold={settings.mfa.failed_attempts_warning_threshold}"
-                )
-                notification_service = MFANotificationService()
-                global_remaining = settings.redis.mfa_global_lockout_attempts - global_count
-                await notification_service.send_failed_attempts_warning(
-                    user=user,
-                    failed_attempts=global_count,
-                    max_attempts=settings.redis.mfa_global_lockout_attempts,
-                    remaining_attempts=global_remaining,
-                )
-                logger.info(f"Failed attempts warning email sent user_id={user_id}")
-
-            # Check if global lockout threshold reached
-            if global_count >= settings.redis.mfa_global_lockout_attempts:
-                logger.warning(
-                    f"User globally locked out after max failed recovery code attempts "
-                    f"user_id={user_id} email={user.email_encrypted} global_failed_attempts={global_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-
-                # Send account locked notification
-                notification_service = MFANotificationService()
-                await notification_service.send_account_locked_email(
-                    user=user,
-                    lockout_reason="Too many failed recovery code attempts",
-                    failed_attempts=global_count,
-                    lockout_ttl_seconds=settings.redis.mfa_global_lockout_ttl,
+            # Step 5: Register device if device_id provided
+            if verify_request.device_id:
+                await UserDeviceService(session, user_id).add_device(
+                    UserDeviceCreate(
+                        device_id=verify_request.device_id,
+                        os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
+                        app_version=app_version,
+                    )
                 )
 
-                raise MFAGlobalLockoutError(
-                    global_attempts_remaining=0,
-                )
+            # Step 6: Issue refresh and access tokens
+            rjti = str(uuid.uuid4())
+            refresh_token = AuthenticationService.create_refresh_token({JWTClaim.sub: str(user_id), JWTClaim.jti: rjti})
 
-            # Check if per-session lockout threshold reached
-            if session_count is not None and session_count >= settings.redis.mfa_max_attempts:
-                logger.warning(
-                    f"User locked out after max failed recovery code attempts for session "
-                    f"user_id={user_id} email={user.email_encrypted} failed_attempts={session_count}"
-                )
-                await mfa_service.delete_session(mfa_session_id)
-                raise TooManyTOTPAttemptsError(
-                    session_attempts_remaining=0,
-                    global_attempts_remaining=global_remaining,
-                    lockout_reason="session_limit",
-                )
-
-            # Re-raise with metadata to inform frontend of remaining attempts
-            raise RecoveryCodeInvalidError(
-                metadata={
-                    "session_attempts_remaining": session_remaining if session_remaining is not None else 0,
-                    "global_attempts_remaining": global_remaining if global_remaining is not None else 0,
+            access_token = AuthenticationService.create_access_token(
+                {
+                    JWTClaim.sub: str(user_id),
+                    JWTClaim.rjti: rjti,
                 }
             )
-
-        # Recovery code valid - clear lockout and delete MFA session
-        await mfa_service.clear_global_lockout(user_id)
-        await mfa_service.delete_session(mfa_session_id)
-
-        logger.info(
-            f"MFA recovery code verification successful user_id={user_id} email={user.email_encrypted} "
-            f"device_id={verify_request.device_id}"
-        )
-
-        # Step 5: Register device if device_id provided
-        if verify_request.device_id:
-            await UserDeviceService(session, user_id).add_device(
-                UserDeviceCreate(
-                    device_id=verify_request.device_id,
-                    os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
-                    app_version=app_version,
-                )
+    except (AuthenticationError, RecoveryCodeNotFoundError, RecoveryCodeInvalidError) as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.USER_SESSION_LOGIN,
+                user_id=user_id,
+                **http_audit_fields(request, e),
             )
-
-        # Step 6: Issue refresh and access tokens
-        rjti = str(uuid.uuid4())
-        refresh_token = AuthenticationService.create_refresh_token({JWTClaim.sub: str(user_id), JWTClaim.jti: rjti})
-
-        access_token = AuthenticationService.create_access_token(
-            {
-                JWTClaim.sub: str(user_id),
-                JWTClaim.rjti: rjti,
-            }
         )
+        raise
 
     # Step 7: Return response
     token = Token(access_token=access_token, refresh_token=refresh_token)
     public_user = PublicUser.from_user(user)
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.USER_SESSION_LOGIN,
+            user_id=user.id,
+            **http_audit_fields(request),
+        )
+    )
 
     return Response(
         result=UserLogin(

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -6,6 +6,7 @@ import jwt
 from fastapi import Body, Depends, Header, Request
 from pydantic import ValidationError
 
+from apps.audit import AuditEvent, EventAction, EventOutcome, log
 from apps.authentication.deps import get_current_token, get_current_user
 from apps.authentication.domain.login import MFARequiredResponse, MFATOTPVerifyRequest, UserLogin, UserLoginRequest
 from apps.authentication.domain.logout import UserLogoutRequest
@@ -49,6 +50,7 @@ from infrastructure.logger import logger
 
 
 async def get_token(
+    request: Request,
     user_login_schema: UserLoginRequest = Body(...),
     session=Depends(get_session),
     os_name: Annotated[str | None, Header()] = None,
@@ -56,26 +58,41 @@ async def get_token(
     app_version: Annotated[str | None, Header()] = None,
 ) -> Response[UserLogin | MFARequiredResponse]:
     """Generate the JWT access token."""
-    async with atomic(session):
-        try:
-            user: User = await AuthenticationService(session).authenticate_user(user_login_schema)
-            if user_login_schema.device_id:
-                await UserDeviceService(session, user.id).add_device(
-                    UserDeviceCreate(
-                        device_id=user_login_schema.device_id,
-                        os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
-                        app_version=app_version,
+    try:
+        async with atomic(session):
+            try:
+                user: User = await AuthenticationService(session).authenticate_user(user_login_schema)
+                if user_login_schema.device_id:
+                    await UserDeviceService(session, user.id).add_device(
+                        UserDeviceCreate(
+                            device_id=user_login_schema.device_id,
+                            os=AppInfoOS(name=os_name, version=os_version) if os_name and os_version else None,
+                            app_version=app_version,
+                        )
                     )
-                )
-        except UserNotFound:
-            raise InvalidCredentials(email=user_login_schema.email)
+            except UserNotFound:
+                raise InvalidCredentials(email=user_login_schema.email)
 
-        if user.email_encrypted != user_login_schema.email:
-            user = await UsersCRUD(session).update_encrypted_email(user, user_login_schema.email)
+            if user.email_encrypted != user_login_schema.email:
+                user = await UsersCRUD(session).update_encrypted_email(user, user_login_schema.email)
+    except InvalidCredentials as e:
+        await log(
+            AuditEvent(
+                user_id=None,
+                event_action=EventAction.USER_SESSION_LOGIN,
+                event_outcome=EventOutcome.FAILURE,
+                error_type=type(e).__name__,
+                client_ip=request.client and request.client.host,
+                http_request_method=request.method,
+                http_response_status_code=e.status_code,
+                url_path=request.url.path,
+                user_agent=request.headers.get("user-agent"),
+            )
+        )
+        raise
 
-    # Check if user has MFA enabled
+    # MFA-required branch returns MFARequiredResponse; user:session:login fires from the MFA verify endpoints.
     if user.mfa_secret:
-        # User has MFA enabled - return requirement response
         mfa_service = MFASessionService()
         mfa_session_id = await mfa_service.create_session(user_id=user.id)
         logger.info(f"MFA required for login user_id={user.id} email={user.email_encrypted}")
@@ -102,6 +119,18 @@ async def get_token(
 
     token = Token(access_token=access_token, refresh_token=refresh_token)
     public_user = PublicUser.from_user(user)
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.USER_SESSION_LOGIN,
+            client_ip=request.client and request.client.host,
+            http_request_method=request.method,
+            http_response_status_code=200,
+            url_path=request.url.path,
+            user_agent=request.headers.get("user-agent"),
+        )
+    )
 
     return Response(
         result=UserLogin(

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -6,7 +6,7 @@ import jwt
 from fastapi import Body, Depends, Header, Request
 from pydantic import ValidationError
 
-from apps.audit import AuditEvent, EventAction, EventOutcome, log
+from apps.audit import AuditEvent, EventAction, EventOutcome, http_error_fields, http_request_fields, log
 from apps.authentication.deps import get_current_token, get_current_user
 from apps.authentication.domain.login import MFARequiredResponse, MFATOTPVerifyRequest, UserLogin, UserLoginRequest
 from apps.authentication.domain.logout import UserLogoutRequest
@@ -80,13 +80,8 @@ async def get_token(
             AuditEvent(
                 user_id=None,
                 event_action=EventAction.USER_SESSION_LOGIN,
-                event_outcome=EventOutcome.FAILURE,
-                error_type=type(e).__name__,
-                client_ip=request.client and request.client.host,
-                http_request_method=request.method,
-                http_response_status_code=e.status_code,
-                url_path=request.url.path,
-                user_agent=request.headers.get("user-agent"),
+                **http_request_fields(request),
+                **http_error_fields(e),
             )
         )
         raise
@@ -124,11 +119,8 @@ async def get_token(
         AuditEvent(
             user_id=user.id,
             event_action=EventAction.USER_SESSION_LOGIN,
-            client_ip=request.client and request.client.host,
-            http_request_method=request.method,
             http_response_status_code=200,
-            url_path=request.url.path,
-            user_agent=request.headers.get("user-agent"),
+            **http_request_fields(request),
         )
     )
 
@@ -316,13 +308,8 @@ async def verify_mfa_totp(
             AuditEvent(
                 user_id=user_id,
                 event_action=EventAction.USER_SESSION_LOGIN,
-                event_outcome=EventOutcome.FAILURE,
-                error_type=type(e).__name__,
-                client_ip=request.client and request.client.host,
-                http_request_method=request.method,
-                http_response_status_code=e.status_code,
-                url_path=request.url.path,
-                user_agent=request.headers.get("user-agent"),
+                **http_request_fields(request),
+                **http_error_fields(e),
             )
         )
         raise
@@ -334,11 +321,8 @@ async def verify_mfa_totp(
         AuditEvent(
             user_id=user.id,
             event_action=EventAction.USER_SESSION_LOGIN,
-            client_ip=request.client and request.client.host,
-            http_request_method=request.method,
             http_response_status_code=200,
-            url_path=request.url.path,
-            user_agent=request.headers.get("user-agent"),
+            **http_request_fields(request),
         )
     )
 

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -37,6 +37,7 @@ from apps.authentication.services.mfa_session import MFASessionService
 from apps.authentication.services.recovery_codes import send_recovery_code_notifications, verify_recovery_code_service
 from apps.authentication.services.security import AuthenticationService
 from apps.shared.domain.response import Response
+from apps.shared.exception import BaseError
 from apps.shared.response import EmptyResponse
 from apps.users import UsersCRUD
 from apps.users.domain import AppInfoOS, PublicUser, User, UserDeviceCreate
@@ -75,7 +76,7 @@ async def get_token(
 
             if user.email_encrypted != user_login_schema.email:
                 user = await UsersCRUD(session).update_encrypted_email(user, user_login_schema.email)
-    except InvalidCredentials as e:
+    except BaseError as e:
         await log(
             AuditEvent(
                 user_id=None,
@@ -301,7 +302,7 @@ async def verify_mfa_totp(
                     JWTClaim.rjti: rjti,
                 }
             )
-    except AuthenticationError as e:
+    except BaseError as e:
         await log(
             AuditEvent(
                 user_id=user_id,
@@ -556,7 +557,7 @@ async def verify_mfa_recovery_code(
                     JWTClaim.rjti: rjti,
                 }
             )
-    except (AuthenticationError, RecoveryCodeNotFoundError, RecoveryCodeInvalidError) as e:
+    except BaseError as e:
         await log(
             AuditEvent(
                 event_action=EventAction.USER_SESSION_LOGIN,

--- a/src/apps/authentication/api/auth.py
+++ b/src/apps/authentication/api/auth.py
@@ -6,7 +6,7 @@ import jwt
 from fastapi import Body, Depends, Header, Request
 from pydantic import ValidationError
 
-from apps.audit import AuditEvent, EventAction, EventOutcome, http_error_fields, http_request_fields, log
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_token, get_current_user
 from apps.authentication.domain.login import MFARequiredResponse, MFATOTPVerifyRequest, UserLogin, UserLoginRequest
 from apps.authentication.domain.logout import UserLogoutRequest
@@ -80,8 +80,7 @@ async def get_token(
             AuditEvent(
                 user_id=None,
                 event_action=EventAction.USER_SESSION_LOGIN,
-                **http_request_fields(request),
-                **http_error_fields(e),
+                **http_audit_fields(request, e),
             )
         )
         raise
@@ -119,8 +118,7 @@ async def get_token(
         AuditEvent(
             user_id=user.id,
             event_action=EventAction.USER_SESSION_LOGIN,
-            http_response_status_code=200,
-            **http_request_fields(request),
+            **http_audit_fields(request),
         )
     )
 
@@ -308,8 +306,7 @@ async def verify_mfa_totp(
             AuditEvent(
                 user_id=user_id,
                 event_action=EventAction.USER_SESSION_LOGIN,
-                **http_request_fields(request),
-                **http_error_fields(e),
+                **http_audit_fields(request, e),
             )
         )
         raise
@@ -321,8 +318,7 @@ async def verify_mfa_totp(
         AuditEvent(
             user_id=user.id,
             event_action=EventAction.USER_SESSION_LOGIN,
-            http_response_status_code=200,
-            **http_request_fields(request),
+            **http_audit_fields(request),
         )
     )
 

--- a/src/apps/authentication/tests/test_auth.py
+++ b/src/apps/authentication/tests/test_auth.py
@@ -192,6 +192,7 @@ class TestAuthentication(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id is None
+        assert event.user_email == data["email"]
         assert event.event_action == EventAction.USER_SESSION_LOGIN
         assert event.event_outcome == EventOutcome.FAILURE
         assert resp.status_code == http.HTTPStatus.UNAUTHORIZED

--- a/src/apps/authentication/tests/test_auth.py
+++ b/src/apps/authentication/tests/test_auth.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.audit import EventAction, EventOutcome
 from apps.authentication.domain.login import UserLoginRequest
 from apps.authentication.domain.token import RefreshAccessTokenRequest, TokenPayload
 from apps.authentication.errors import AuthenticationError, InvalidCredentials, InvalidRefreshToken
@@ -37,22 +38,35 @@ class TestAuthentication(BaseTest):
     )
     create_request_logout_user = UserLogoutRequestFactory.build()
 
-    async def test_get_token(self, client: TestClient, user: User):
+    async def test_get_token(self, client: TestClient, user: User, mocker: MockerFixture):
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         response = await client.post(
             url=self.get_token_url,
             data=dict(email=user.email_encrypted, password=TEST_PASSWORD, deviceId="test#device"),
         )
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.SUCCESS
         assert response.status_code == http.HTTPStatus.OK
         data = response.json()["result"]
         assert set(data.keys()) == {"user", "token"}
         assert data["user"]["id"] == str(user.id)
 
-    async def test_delete_access_token(self, client: TestClient, user: User):
+    async def test_delete_access_token(self, client: TestClient, user: User, mocker: MockerFixture):
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         client.login(user)
         response = await client.post(url=self.delete_token_url)
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_LOGOUT
+        assert event.event_outcome == EventOutcome.SUCCESS
         assert response.status_code == http.HTTPStatus.OK
 
-    async def test_refresh_access_token(self, client: TestClient, user: User):
+    async def test_refresh_access_token(self, client: TestClient, user: User, mocker: MockerFixture):
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         refresh_access_token_request = RefreshAccessTokenRequest(
             refresh_token=AuthenticationService.create_refresh_token(
                 {
@@ -62,6 +76,11 @@ class TestAuthentication(BaseTest):
             )
         )
         response = await client.post(url=self.refresh_access_token_url, data=refresh_access_token_request.model_dump())
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_REFRESH
+        assert event.event_outcome == EventOutcome.SUCCESS
         assert response.status_code == http.HTTPStatus.OK
 
     async def test_login_and_logout_device(self, client: TestClient, user: User):
@@ -164,11 +183,17 @@ class TestAuthentication(BaseTest):
 
     @pytest.mark.parametrize("field_name,value", (("email", "notfound@example.com"), ("password", "1234")))
     async def test_get_token_credentials_are_not_valid(
-        self, client: TestClient, user: User, field_name: str, value: str
+        self, client: TestClient, user: User, field_name: str, value: str, mocker: MockerFixture
     ):
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         data = dict(email=user.email_encrypted, password=TEST_PASSWORD)
         data[field_name] = value
         resp = await client.post(self.get_token_url, data=data)
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id is None
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.FAILURE
         assert resp.status_code == http.HTTPStatus.UNAUTHORIZED
         result = resp.json()["result"]
         assert len(result) == 1
@@ -217,12 +242,20 @@ class TestAuthentication(BaseTest):
         assert resp.status_code == http.HTTPStatus.OK
         mock_.assert_awaited_once_with(device_id)
 
-    async def test_refresh_access_token__refresh_token_is_expired(self, client: TestClient, user: User):
+    async def test_refresh_access_token__refresh_token_is_expired(
+        self, client: TestClient, user: User, mocker: MockerFixture
+    ):
         settings.authentication.refresh_token.expiration = -1
         resp = await client.post(self.get_token_url, data={"email": user.email_encrypted, "password": TEST_PASSWORD})
         assert resp.status_code == http.HTTPStatus.OK
         refresh_token = resp.json()["result"]["token"]["refreshToken"]
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         resp = await client.post(self.refresh_access_token_url, data={"refresh_token": refresh_token})
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id is None
+        assert event.event_action == EventAction.USER_SESSION_REFRESH
+        assert event.event_outcome == EventOutcome.FAILURE
         assert resp.status_code == http.HTTPStatus.BAD_REQUEST
         result = resp.json()["result"]
         assert len(result) == 1

--- a/src/apps/authentication/tests/test_mfa_flow.py
+++ b/src/apps/authentication/tests/test_mfa_flow.py
@@ -6,8 +6,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.audit import EventAction, EventOutcome
 from apps.authentication.router import router as auth_router
 from apps.authentication.services import AuthenticationService
 from apps.shared.test import BaseTest
@@ -209,7 +211,7 @@ class TestMFATOTPVerification(BaseTest):
     verify_mfa_url = auth_router.url_path_for("verify_mfa_totp")
 
     async def test_verify_mfa_with_valid_code_returns_tokens(
-        self, client: TestClient, user_with_mfa: User, session: AsyncSession
+        self, client: TestClient, user_with_mfa: User, session: AsyncSession, mocker: MockerFixture
     ):
         """Test successful MFA verification returns access and refresh tokens."""
         # Step 1: Login to get MFA token
@@ -233,6 +235,7 @@ class TestMFATOTPVerification(BaseTest):
         valid_code = totp_service.get_current_code(decrypted_secret)
 
         # Step 3: Verify TOTP
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         verify_response = await client.post(
             url=self.verify_mfa_url,
             data=dict(
@@ -240,6 +243,12 @@ class TestMFATOTPVerification(BaseTest):
                 totpCode=valid_code,
             ),
         )
+
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user_with_mfa.id
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.SUCCESS
 
         assert verify_response.status_code == http.HTTPStatus.OK
         verify_data = verify_response.json()["result"]
@@ -253,7 +262,9 @@ class TestMFATOTPVerification(BaseTest):
         assert "accessToken" in verify_data["token"]
         assert "refreshToken" in verify_data["token"]
 
-    async def test_verify_mfa_with_invalid_code_fails(self, client: TestClient, user_with_mfa: User):
+    async def test_verify_mfa_with_invalid_code_fails(
+        self, client: TestClient, user_with_mfa: User, mocker: MockerFixture
+    ):
         """Test that invalid TOTP code fails verification."""
         # Step 1: Login to get MFA token
         login_response = await client.post(
@@ -268,6 +279,7 @@ class TestMFATOTPVerification(BaseTest):
         mfa_token = login_data["mfaToken"]
 
         # Step 2: Try with invalid code
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         verify_response = await client.post(
             url=self.verify_mfa_url,
             data=dict(
@@ -275,6 +287,12 @@ class TestMFATOTPVerification(BaseTest):
                 totpCode="000000",  # Invalid code
             ),
         )
+
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user_with_mfa.id
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.FAILURE
 
         # Invalid TOTP code keeps user unauthenticated, expect 401 Unauthorized
         assert verify_response.status_code == http.HTTPStatus.UNAUTHORIZED

--- a/src/apps/authentication/tests/test_recovery_code_verification.py
+++ b/src/apps/authentication/tests/test_recovery_code_verification.py
@@ -6,8 +6,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.audit import EventAction, EventOutcome
 from apps.authentication.cruds.recovery_code import RecoveryCodeCRUD
 from apps.authentication.router import router as auth_router
 from apps.authentication.services.recovery_codes import generate_recovery_codes
@@ -83,7 +85,11 @@ class TestRecoveryCodeVerification(BaseTest):
     verify_recovery_url = auth_router.url_path_for("verify_mfa_recovery_code")
 
     async def test_valid_recovery_code_returns_tokens(
-        self, client: TestClient, user_with_mfa_and_codes: tuple[User, list[str]], session: AsyncSession
+        self,
+        client: TestClient,
+        user_with_mfa_and_codes: tuple[User, list[str]],
+        session: AsyncSession,
+        mocker: MockerFixture,
     ):
         """Test that valid recovery code returns tokens and marks code as used."""
         user, codes = user_with_mfa_and_codes
@@ -102,6 +108,7 @@ class TestRecoveryCodeVerification(BaseTest):
 
         # Step 2: Verify with valid recovery code
         valid_code = codes[0]
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         response = await client.post(
             url=self.verify_recovery_url,
             data=dict(
@@ -110,6 +117,12 @@ class TestRecoveryCodeVerification(BaseTest):
                 deviceId="test-device",
             ),
         )
+
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.SUCCESS
 
         # Assert: Success response
         assert response.status_code == http.HTTPStatus.OK
@@ -128,7 +141,7 @@ class TestRecoveryCodeVerification(BaseTest):
         assert used_codes[0].used_at is not None
 
     async def test_invalid_recovery_code_returns_error(
-        self, client: TestClient, user_with_mfa_and_codes: tuple[User, list[str]]
+        self, client: TestClient, user_with_mfa_and_codes: tuple[User, list[str]], mocker: MockerFixture
     ):
         """Test that invalid recovery code returns 400 Bad Request."""
         user, codes = user_with_mfa_and_codes
@@ -145,6 +158,7 @@ class TestRecoveryCodeVerification(BaseTest):
         mfa_token = login_response.json()["result"]["mfaToken"]
 
         # Verify with invalid code
+        audit_log = mocker.patch("apps.authentication.api.auth.log")
         response = await client.post(
             url=self.verify_recovery_url,
             data=dict(
@@ -153,6 +167,12 @@ class TestRecoveryCodeVerification(BaseTest):
                 deviceId="test-device",
             ),
         )
+
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_LOGIN
+        assert event.event_outcome == EventOutcome.FAILURE
 
         # Assert: Error response (400 Bad Request for invalid code)
         assert response.status_code == http.HTTPStatus.BAD_REQUEST


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10698](https://mindlogger.atlassian.net/browse/M2-10698)

Changes include:

- `AuditEvent.category` computed field
- `AuditEvent.type` computed field
- `http_audit_fields` helper function
- `user:session:login` (password) events
- `user:session:login` (MFA TOTP) events
- `user:session:login` (MFA recovery code) events
- `user:session:refresh` events

### ✏️ Notes

`user:session:invalid` events will be implemented in a follow-up PR.