### PR TITLE
feat: Make RabbitMQ exchange and queues durable (M2-10734)

### DIFF
--- a/src/broker.py
+++ b/src/broker.py
@@ -13,6 +13,8 @@ from infrastructure.logger import logger
 broker: AsyncBroker = (
     AioPikaBroker(
         settings.rabbitmq.url,
+        exchange_name="curious",
+        queue_name="curious",
         declare_exchange_kwargs={"durable": True},
         declare_queues_kwargs={"durable": True},
     )

--- a/src/broker.py
+++ b/src/broker.py
@@ -11,7 +11,11 @@ from config import settings
 from infrastructure.logger import logger
 
 broker: AsyncBroker = (
-    AioPikaBroker(settings.rabbitmq.url)
+    AioPikaBroker(
+        settings.rabbitmq.url,
+        declare_exchange_kwargs={"durable": True},
+        declare_queues_kwargs={"durable": True},
+    )
     .with_result_backend(RedisAsyncResultBackend(settings.redis.url))
     .with_formatter(JSONFormatter())
 )


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to
  Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10734](https://mindlogger.atlassian.net/browse/M2-10734)

The taskiq exchange and its three queues (`taskiq`, `taskiq.dead_letter`, `taskiq.delay`) were being declared non-durable. Any Amazon MQ restart or failover wipes them, dropping every in-flight task - audit events, MFA emails, report generation, OneUp Health ingestion, password re-encryption.

Messages themselves are already persistent (taskiq-aio-pika hardcodes `delivery_mode=PERSISTENT`), but persistent messages on a non-durable queue still die with the queue.

Changes include:

- Pass `declare_exchange_kwargs={"durable": True}` and `declare_queues_kwargs={"durable": True}` to `AioPikaBroker(...)` in `src/broker.py`. One queues-kwarg covers all three queues.
- No taskiq-aio-pika upgrade needed - 0.4.2 already supports both kwargs.
- Local and test environments are unaffected (they use `InMemoryBroker` via the `env in {"testing","local"}` branch).


