### PR TITLE
feat: `user:session:invalid` audit event (M2-10698)

### DIFF
--- a/src/apps/audit/fields.py
+++ b/src/apps/audit/fields.py
@@ -2,13 +2,14 @@ from asgi_correlation_id.context import correlation_id
 from ddtrace.trace import tracer
 from fastapi import Request
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from apps.shared.exception import BaseError
 
 from .enums import EventOutcome
 
 
-def http_audit_fields(request: Request, error: BaseError | None = None) -> dict:
+def http_audit_fields(request: Request, error: BaseError | StarletteHTTPException | None = None) -> dict:
     """Audit fields derived from HTTP request/error."""
     route = request.scope.get("route")
     span = tracer.current_span()

--- a/src/apps/authentication/deps.py
+++ b/src/apps/authentication/deps.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+import uuid
 
 import jwt
 from fastapi import Depends, HTTPException, status
@@ -21,6 +21,20 @@ from infrastructure.database.deps import get_session
 oauth2_oauth = OAuth2PasswordBearer(tokenUrl="/auth/openapi", scheme_name="Bearer")
 
 
+def _expired_token_sub(token: str, key: str) -> uuid.UUID | None:
+    """Extract expired token subject. For audit logging only."""
+    try:
+        payload = jwt.decode(
+            token,
+            key,
+            algorithms=[settings.authentication.algorithm],
+            options={"verify_exp": False},
+        )
+        return TokenPayload(**payload).sub
+    except (jwt.PyJWTError, ValidationError):
+        return None
+
+
 async def get_current_user_for_ws(websocket: WebSocket, session=Depends(get_session)):
     authorization = websocket.headers.get("sec-websocket-protocol")
     try:
@@ -37,16 +51,12 @@ async def get_current_user_for_ws(websocket: WebSocket, session=Depends(get_sess
         )
 
     async with atomic(session):
+        key = settings.authentication.access_token.secret_key
         try:
-            payload = jwt.decode(
-                token,
-                settings.authentication.access_token.secret_key,
-                algorithms=[settings.authentication.algorithm],
-            )
+            payload = jwt.decode(token, key, algorithms=[settings.authentication.algorithm])
             token_data = TokenPayload(**payload)
-
-            if datetime.fromtimestamp(token_data.exp, timezone.utc) < datetime.now(timezone.utc):
-                raise SessionTokenInvalidError(user_id=token_data.sub)
+        except jwt.ExpiredSignatureError:
+            raise SessionTokenInvalidError(user_id=_expired_token_sub(token, key))
         except (jwt.PyJWTError, ValidationError):
             raise SessionTokenInvalidError()
 
@@ -67,20 +77,14 @@ def get_current_token(type_: TokenPurpose = TokenPurpose.ACCESS):
     async def _get_current_token(
         token: str = Depends(oauth2_oauth),
     ) -> InternalToken:
+        key = settings.authentication.access_token.secret_key
+        if type_ == TokenPurpose.REFRESH:
+            key = settings.authentication.refresh_token.secret_key
         try:
-            key = settings.authentication.access_token.secret_key
-            if type_ == TokenPurpose.REFRESH:
-                key = settings.authentication.refresh_token.secret_key
-            payload = jwt.decode(
-                token,
-                key,
-                algorithms=[settings.authentication.algorithm],
-            )
-
+            payload = jwt.decode(token, key, algorithms=[settings.authentication.algorithm])
             token_payload = TokenPayload(**payload)
-
-            if datetime.fromtimestamp(token_payload.exp, timezone.utc) < datetime.now(timezone.utc):
-                raise SessionTokenInvalidError(user_id=token_payload.sub)
+        except jwt.ExpiredSignatureError:
+            raise SessionTokenInvalidError(user_id=_expired_token_sub(token, key))
         except (jwt.PyJWTError, ValidationError):
             raise SessionTokenInvalidError()
 

--- a/src/apps/authentication/deps.py
+++ b/src/apps/authentication/deps.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 
 from apps.authentication.domain.login import UserLoginRequest
 from apps.authentication.domain.token import InternalToken, JWTClaim, TokenPayload, TokenPurpose
-from apps.authentication.errors import AuthenticationError
+from apps.authentication.errors import SessionTokenInvalidError
 from apps.authentication.services import AuthenticationService
 from apps.users.cruds.user import UsersCRUD
 from apps.users.domain import User
@@ -45,14 +45,14 @@ async def get_current_user_for_ws(websocket: WebSocket, session=Depends(get_sess
             token_data = TokenPayload(**payload)
 
             if datetime.fromtimestamp(token_data.exp, timezone.utc) < datetime.now(timezone.utc):
-                raise AuthenticationError
+                raise SessionTokenInvalidError(user_id=token_data.sub)
         except (jwt.PyJWTError, ValidationError):
-            raise AuthenticationError
+            raise SessionTokenInvalidError()
 
         # Check if the token is in the blacklist
         revoked = await AuthenticationService(session).is_revoked(InternalToken(payload=token_data, raw_token=token))
         if revoked:
-            raise AuthenticationError
+            raise SessionTokenInvalidError(user_id=token_data.sub)
 
         user = await UsersCRUD(session).get_by_id(id_=token_data.sub)
 
@@ -76,9 +76,9 @@ def get_current_token(type_: TokenPurpose = TokenPurpose.ACCESS):
             token_payload = TokenPayload(**payload)
 
             if datetime.fromtimestamp(token_payload.exp, timezone.utc) < datetime.now(timezone.utc):
-                raise AuthenticationError
+                raise SessionTokenInvalidError(user_id=token_payload.sub)
         except (jwt.PyJWTError, ValidationError):
-            raise AuthenticationError
+            raise SessionTokenInvalidError()
 
         return InternalToken(payload=token_payload, raw_token=token)
 
@@ -93,7 +93,7 @@ async def get_current_user(
         # Check if the token is in the blacklist
         revoked = await AuthenticationService(session).is_revoked(token)
         if revoked:
-            raise AuthenticationError
+            raise SessionTokenInvalidError(user_id=token.payload.sub)
 
         user = await UsersCRUD(session).get_by_id(id_=token.payload.sub)
         await AuthenticationService(session).update_last_seen_at(user)

--- a/src/apps/authentication/deps.py
+++ b/src/apps/authentication/deps.py
@@ -13,6 +13,7 @@ from apps.authentication.errors import SessionTokenInvalidError
 from apps.authentication.services import AuthenticationService
 from apps.users.cruds.user import UsersCRUD
 from apps.users.domain import User
+from apps.users.errors import UserIsDeletedError, UserNotFound
 from config import settings
 from infrastructure.database import atomic
 from infrastructure.database.deps import get_session
@@ -54,7 +55,10 @@ async def get_current_user_for_ws(websocket: WebSocket, session=Depends(get_sess
         if revoked:
             raise SessionTokenInvalidError(user_id=token_data.sub)
 
-        user = await UsersCRUD(session).get_by_id(id_=token_data.sub)
+        try:
+            user = await UsersCRUD(session).get_by_id(id_=token_data.sub)
+        except (UserNotFound, UserIsDeletedError):
+            raise SessionTokenInvalidError(user_id=token_data.sub)
 
     return user
 
@@ -95,7 +99,10 @@ async def get_current_user(
         if revoked:
             raise SessionTokenInvalidError(user_id=token.payload.sub)
 
-        user = await UsersCRUD(session).get_by_id(id_=token.payload.sub)
+        try:
+            user = await UsersCRUD(session).get_by_id(id_=token.payload.sub)
+        except (UserNotFound, UserIsDeletedError):
+            raise SessionTokenInvalidError(user_id=token.payload.sub)
         await AuthenticationService(session).update_last_seen_at(user)
 
     return user

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -34,9 +34,8 @@ class EmailDoesNotExist(AccessDeniedError):
     error_code = AuthErrorCode.EMAIL_DOES_NOT_EXIST
 
 
-class InvalidCredentials(AccessDeniedError):
+class InvalidCredentials(AuthenticationError):
     message = _("Incorrect email or password")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.INVALID_CREDENTIALS
 
 

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -3,7 +3,7 @@ from gettext import gettext as _
 from starlette import status
 
 from apps.authentication.constants import AuthErrorCode
-from apps.shared.exception import AccessDeniedError, BaseError, ValidationError
+from apps.shared.exception import AccessDeniedError, UnauthorizedError, ValidationError
 
 
 class BadCredentials(ValidationError):
@@ -19,9 +19,8 @@ class WeakPassword(ValidationError):
     message = _("Weak password.")
 
 
-class AuthenticationError(BaseError):
+class AuthenticationError(UnauthorizedError):
     message = _("Could not validate credentials.")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.AUTHENTICATION_ERROR
 
 
@@ -41,33 +40,32 @@ class InvalidCredentials(AccessDeniedError):
     error_code = AuthErrorCode.INVALID_CREDENTIALS
 
 
+class SessionTokenInvalidError(AuthenticationError):
+    """Indicates auth error due to invalid session token."""
+
+
 class MFATokenInvalidError(AuthenticationError):
     message = _("MFA token is invalid or expired")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.MFA_TOKEN_INVALID
 
 
 class MFATokenExpiredError(AuthenticationError):
     message = _("MFA token has expired. Please log in again.")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.MFA_TOKEN_EXPIRED
 
 
 class MFATokenMalformedError(AuthenticationError):
     message = _("MFA token is malformed or invalid.")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.MFA_TOKEN_MALFORMED
 
 
 class MFASessionNotFoundError(AuthenticationError):
     message = _("MFA session not found or expired")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.MFA_SESSION_NOT_FOUND
 
 
 class InvalidTOTPCodeError(AuthenticationError):
     message = _("Invalid TOTP code")
-    status_code = status.HTTP_401_UNAUTHORIZED
     error_code = AuthErrorCode.MFA_INVALID_TOTP_CODE
 
     def __init__(

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -1,3 +1,4 @@
+import uuid
 from gettext import gettext as _
 
 from starlette import status
@@ -31,6 +32,10 @@ class InvalidCredentials(AuthenticationError):
 
 class SessionTokenInvalidError(AuthenticationError):
     """Indicates auth error due to invalid session token."""
+
+    def __init__(self, user_id: uuid.UUID | None = None, **kwargs) -> None:
+        self.user_id = user_id
+        super().__init__(**kwargs)
 
 
 class MFATokenInvalidError(AuthenticationError):

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -29,11 +29,6 @@ class PermissionsError(AccessDeniedError):
     error_code = AuthErrorCode.PERMISSIONS_ERROR
 
 
-class EmailDoesNotExist(AccessDeniedError):
-    message = _("That email is not associated with a Curious account.")
-    error_code = AuthErrorCode.EMAIL_DOES_NOT_EXIST
-
-
 class InvalidCredentials(AuthenticationError):
     message = _("Incorrect email or password")
     error_code = AuthErrorCode.INVALID_CREDENTIALS

--- a/src/apps/authentication/errors.py
+++ b/src/apps/authentication/errors.py
@@ -24,11 +24,6 @@ class AuthenticationError(UnauthorizedError):
     error_code = AuthErrorCode.AUTHENTICATION_ERROR
 
 
-class PermissionsError(AccessDeniedError):
-    message = _("Not enough permissions.")
-    error_code = AuthErrorCode.PERMISSIONS_ERROR
-
-
 class InvalidCredentials(AuthenticationError):
     message = _("Incorrect email or password")
     error_code = AuthErrorCode.INVALID_CREDENTIALS
@@ -74,6 +69,11 @@ class InvalidTOTPCodeError(AuthenticationError):
         if global_attempts_remaining is not None:
             metadata["global_attempts_remaining"] = global_attempts_remaining
         super().__init__(metadata=metadata if metadata else None, **kwargs)
+
+
+class PermissionsError(AccessDeniedError):
+    message = _("Not enough permissions.")
+    error_code = AuthErrorCode.PERMISSIONS_ERROR
 
 
 class TooManyTOTPAttemptsError(AuthenticationError):

--- a/src/apps/authentication/tests/test_auth.py
+++ b/src/apps/authentication/tests/test_auth.py
@@ -74,11 +74,8 @@ class TestAuthentication(BaseTest):
         assert resp.json()["result"][0]["message"] == SessionTokenInvalidError.message
 
     async def test_expired_token(self, client: TestClient, user: User, mocker: MockerFixture):
-        settings.authentication.access_token.expiration = -1
-        try:
-            client.login(user)
-        finally:
-            settings.authentication.access_token.expiration = 30
+        mocker.patch.object(settings.authentication.access_token, "expiration", -1)
+        client.login(user)
         audit_log = mocker.patch("infrastructure.http.exceptions.log")
         resp = await client.post(self.delete_token_url)
         audit_log.assert_awaited_once()

--- a/src/apps/authentication/tests/test_auth.py
+++ b/src/apps/authentication/tests/test_auth.py
@@ -11,7 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from apps.audit import EventAction, EventOutcome
 from apps.authentication.domain.login import UserLoginRequest
 from apps.authentication.domain.token import RefreshAccessTokenRequest, TokenPayload
-from apps.authentication.errors import AuthenticationError, InvalidCredentials, InvalidRefreshToken
+from apps.authentication.errors import (
+    AuthenticationError,
+    InvalidCredentials,
+    InvalidRefreshToken,
+    SessionTokenInvalidError,
+)
 from apps.authentication.router import router as auth_router
 from apps.authentication.services import AuthenticationService
 from apps.authentication.tests.factories import UserLogoutRequestFactory
@@ -53,6 +58,63 @@ class TestAuthentication(BaseTest):
         data = response.json()["result"]
         assert set(data.keys()) == {"user", "token"}
         assert data["user"]["id"] == str(user.id)
+
+    async def test_malformed_token(self, client: TestClient, mocker: MockerFixture):
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+        resp = await client.post(
+            self.delete_token_url,
+            headers={"Authorization": f"{settings.authentication.token_type} not-a-jwt"},
+        )
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id is None
+        assert event.event_action == EventAction.USER_SESSION_INVALID
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert resp.status_code == http.HTTPStatus.UNAUTHORIZED
+        assert resp.json()["result"][0]["message"] == SessionTokenInvalidError.message
+
+    async def test_expired_token(self, client: TestClient, user: User, mocker: MockerFixture):
+        settings.authentication.access_token.expiration = -1
+        try:
+            client.login(user)
+        finally:
+            settings.authentication.access_token.expiration = 30
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+        resp = await client.post(self.delete_token_url)
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_INVALID
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert resp.status_code == http.HTTPStatus.UNAUTHORIZED
+        assert resp.json()["result"][0]["message"] == SessionTokenInvalidError.message
+
+    async def test_revoked_token(self, client: TestClient, user: User, mocker: MockerFixture):
+        client.login(user)
+        logout_resp = await client.post(self.delete_token_url)
+        assert logout_resp.status_code == http.HTTPStatus.OK
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+        resp = await client.post(self.delete_token_url)
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == user.id
+        assert event.event_action == EventAction.USER_SESSION_INVALID
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert resp.status_code == http.HTTPStatus.UNAUTHORIZED
+        assert resp.json()["result"][0]["message"] == SessionTokenInvalidError.message
+
+    async def test_user_not_found(self, client: TestClient, mocker: MockerFixture):
+        unknown_user_id = uuid.uuid4()
+        client.login(unknown_user_id)
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+        resp = await client.post(self.delete_token_url)
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == unknown_user_id
+        assert event.event_action == EventAction.USER_SESSION_INVALID
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert resp.status_code == http.HTTPStatus.UNAUTHORIZED
+        assert resp.json()["result"][0]["message"] == SessionTokenInvalidError.message
 
     async def test_delete_access_token(self, client: TestClient, user: User, mocker: MockerFixture):
         audit_log = mocker.patch("apps.authentication.api.auth.log")

--- a/src/apps/shared/exception.py
+++ b/src/apps/shared/exception.py
@@ -46,19 +46,10 @@ class ValidationError(BaseError):
     code: str | None = None
 
 
-class FieldError(BaseError):
-    message = _("Invalid value.")
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    type = ExceptionTypes.INVALID_VALUE
-    zero_path: str | None = "body"
-
-    def __init__(self, path=None, **kwargs):
-        if path is None:
-            path = []
-        if self.zero_path:
-            path.insert(0, self.zero_path)
-        self.path = path
-        super().__init__(**kwargs)
+class UnauthorizedError(BaseError):
+    message = _("Unauthorized.")
+    status_code = status.HTTP_401_UNAUTHORIZED
+    type = ExceptionTypes.ACCESS_DENIED
 
 
 class AccessDeniedError(BaseError):
@@ -73,10 +64,19 @@ class NotFoundError(BaseError):
     type = ExceptionTypes.NOT_FOUND
 
 
-class UnauthorizedError(BaseError):
-    message = _("Unauthorized.")
-    status_code = status.HTTP_401_UNAUTHORIZED
-    type = ExceptionTypes.ACCESS_DENIED
+class FieldError(BaseError):
+    message = _("Invalid value.")
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    type = ExceptionTypes.INVALID_VALUE
+    zero_path: str | None = "body"
+
+    def __init__(self, path=None, **kwargs):
+        if path is None:
+            path = []
+        if self.zero_path:
+            path.insert(0, self.zero_path)
+        self.path = path
+        super().__init__(**kwargs)
 
 
 class InternalServerError(BaseError):

--- a/src/apps/users/tests/test_mfa.py
+++ b/src/apps/users/tests/test_mfa.py
@@ -1,8 +1,10 @@
 import pyotp
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
+from apps.audit import EventAction, EventOutcome
 from apps.shared.test.client import TestClient
 from apps.users import UsersCRUD
 from apps.users.domain import User
@@ -209,14 +211,24 @@ class TestMFAEndpoints:
         result = response.json()["result"]
         assert result["mfaEnabled"] is True
 
-    async def test_mfa_totp_verify_requires_authentication(self, client: TestClient):
+    async def test_mfa_totp_verify_requires_authentication(self, client: TestClient, mocker: MockerFixture):
         """Test that MFA endpoints require authentication."""
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+
         # Try without login
         response = await client.post(self.totp_initiate_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
         response = await client.post(self.totp_verify_url, data={"code": "123456"})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # Each unauthenticated request emits user:session:invalid
+        assert audit_log.await_count == 2
+        for call in audit_log.await_args_list:
+            event = call.args[0]
+            assert event.user_id is None
+            assert event.event_action == EventAction.USER_SESSION_INVALID
+            assert event.event_outcome == EventOutcome.FAILURE
 
     async def test_mfa_encrypted_secret_storage(self, client: TestClient, user: User, session: AsyncSession):
         """Test that secrets are stored encrypted in database."""

--- a/src/apps/users/tests/test_mfa_disable_security.py
+++ b/src/apps/users/tests/test_mfa_disable_security.py
@@ -1,9 +1,11 @@
 """Tests for security aspects of MFA disable flow."""
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
+from apps.audit import EventAction, EventOutcome
 from apps.authentication.services.mfa_session import MFASessionService
 from apps.shared.test.client import TestClient
 from apps.users import UsersCRUD
@@ -44,8 +46,10 @@ class TestMFADisableSecurity:
     disable_initiate_url = "/users/me/mfa/totp/disable/initiate"
     disable_verify_url = "/users/me/mfa/totp/disable/verify"
 
-    async def test_disable_requires_authentication(self, client: TestClient):
+    async def test_disable_requires_authentication(self, client: TestClient, mocker: MockerFixture):
         """Unauthenticated requests to disable endpoints are rejected."""
+        audit_log = mocker.patch("infrastructure.http.exceptions.log")
+
         # Try to initiate without authentication
         response = await client.post(self.disable_initiate_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -54,6 +58,14 @@ class TestMFADisableSecurity:
         verify_data = {"mfaToken": "fake-token", "code": "123456"}
         response = await client.post(self.disable_verify_url, data=verify_data)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # Each unauthenticated request emits user:session:invalid
+        assert audit_log.await_count == 2
+        for call in audit_log.await_args_list:
+            event = call.args[0]
+            assert event.user_id is None
+            assert event.event_action == EventAction.USER_SESSION_INVALID
+            assert event.event_outcome == EventOutcome.FAILURE
 
     async def test_cannot_disable_another_users_mfa(
         self, client: TestClient, user_with_mfa: User, session: AsyncSession

--- a/src/infrastructure/app.py
+++ b/src/infrastructure/app.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import ORJSONResponse  # Fast, efficient JSON response
 from fastapi.routing import APIRouter
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 import apps.activities.router as activities
 import apps.activity_assignments.router as activity_assignments
@@ -43,6 +44,7 @@ from infrastructure.http.exceptions import (
     python_base_error_handler,
     session_token_invalid_error_handler,
     sqlalchemy_database_error_handler,
+    starlette_http_exception_handler,
 )
 from infrastructure.lifespan import shutdown, startup
 from infrastructure.logger import logger
@@ -121,6 +123,7 @@ def create_app():
         app.add_middleware(middleware, **options)
 
     app.add_exception_handler(RequestValidationError, pydantic_validation_errors_handler)
+    app.add_exception_handler(StarletteHTTPException, starlette_http_exception_handler)
     app.add_exception_handler(SessionTokenInvalidError, session_token_invalid_error_handler)
     app.add_exception_handler(BaseError, custom_base_errors_handler)
     app.add_exception_handler(TimeoutError, sqlalchemy_database_error_handler)

--- a/src/infrastructure/app.py
+++ b/src/infrastructure/app.py
@@ -33,6 +33,7 @@ import apps.transfer_ownership.router as transfer_ownership
 import apps.users.router as users
 import apps.workspaces.router as workspaces
 import middlewares as middlewares_
+from apps.authentication.errors import SessionTokenInvalidError
 from apps.shared.exception import BaseError
 from config import settings
 from infrastructure.dependency.structured_logs import StructuredLoggingMiddleware
@@ -40,6 +41,7 @@ from infrastructure.http.exceptions import (
     custom_base_errors_handler,
     pydantic_validation_errors_handler,
     python_base_error_handler,
+    session_token_invalid_error_handler,
     sqlalchemy_database_error_handler,
 )
 from infrastructure.lifespan import shutdown, startup
@@ -119,6 +121,7 @@ def create_app():
         app.add_middleware(middleware, **options)
 
     app.add_exception_handler(RequestValidationError, pydantic_validation_errors_handler)
+    app.add_exception_handler(SessionTokenInvalidError, session_token_invalid_error_handler)
     app.add_exception_handler(BaseError, custom_base_errors_handler)
     app.add_exception_handler(TimeoutError, sqlalchemy_database_error_handler)
     app.add_exception_handler(ConnectionRefusedError, sqlalchemy_database_error_handler)

--- a/src/infrastructure/http/exceptions.py
+++ b/src/infrastructure/http/exceptions.py
@@ -1,9 +1,11 @@
 from asyncpg import InvalidPasswordError
 from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
 from starlette import status
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 
 from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.errors import SessionTokenInvalidError
@@ -53,6 +55,19 @@ async def session_token_invalid_error_handler(request: Request, error: SessionTo
         )
     )
     return custom_base_errors_handler(request, error)
+
+
+async def starlette_http_exception_handler(request: Request, exc: StarletteHTTPException) -> Response:
+    """user:session:invalid audit event on 401 from missing session token in `Authorization` header."""
+    if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+        await log(
+            AuditEvent(
+                event_action=EventAction.USER_SESSION_INVALID,
+                user_id=None,
+                **http_audit_fields(request, exc),
+            )
+        )
+    return await http_exception_handler(request, exc)
 
 
 def python_base_error_handler(_: Request, error: Exception) -> JSONResponse:

--- a/src/infrastructure/http/exceptions.py
+++ b/src/infrastructure/http/exceptions.py
@@ -50,7 +50,7 @@ async def session_token_invalid_error_handler(request: Request, error: SessionTo
     await log(
         AuditEvent(
             event_action=EventAction.USER_SESSION_INVALID,
-            user_id=error.kwargs.get("user_id"),
+            user_id=error.user_id,
             **http_audit_fields(request, error),
         )
     )

--- a/src/infrastructure/http/exceptions.py
+++ b/src/infrastructure/http/exceptions.py
@@ -5,6 +5,8 @@ from starlette import status
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
+from apps.authentication.errors import SessionTokenInvalidError
 from apps.shared.domain import ErrorResponse, ErrorResponseMulti
 from apps.shared.exception import BaseError
 from infrastructure.logger import logger
@@ -39,6 +41,18 @@ def custom_base_errors_handler(_: Request, error: BaseError) -> JSONResponse:
         response_dict,
         status_code=error.status_code,
     )
+
+
+async def session_token_invalid_error_handler(request: Request, error: SessionTokenInvalidError) -> JSONResponse:
+    """user:session:invalid audit event on 401 from invalid session token in `Authorization` header."""
+    await log(
+        AuditEvent(
+            event_action=EventAction.USER_SESSION_INVALID,
+            user_id=error.kwargs.get("user_id"),
+            **http_audit_fields(request, error),
+        )
+    )
+    return custom_base_errors_handler(request, error)
 
 
 def python_base_error_handler(_: Request, error: Exception) -> JSONResponse:


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10698](https://mindlogger.atlassian.net/browse/M2-10698)

Changes include:

- `SessionTokenInvalidError` for invalid session token
- `user:session:invalid` (invalid session token) events on `SessionTokenInvalidError`
- `user:session:invalid` (missing session token) events on Starlette `401 Unauthenticated`

### ✏️ Notes

This is a follow-up to #2049. All `user:session:*` audit events are now implemented.