### PR TITLE
fix: Require sigv4 for S3 client configuration

### DIFF
--- a/src/infrastructure/storage/storage_client.py
+++ b/src/infrastructure/storage/storage_client.py
@@ -64,6 +64,8 @@ class StorageClient:
         assert config, "set CDN"
         client_config = Config(
             max_pool_connections=25,
+            signature_version="s3v4",
+            s3={"addressing_style": "virtual"},
         )
 
         # TODO This is only done for arbitrary???


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

Changes include:

- Require Sigv4 for signed URL uploads with KMS

