### PR TITLE
feat : instrument data access audit logs (M2-10700)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -475,7 +475,7 @@ async def applet_flow_answer_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_VIEW,
                 curious_applet_id=[applet_id],
-                curious_answer_id=[submit_id],
+                curious_submit_id=[submit_id],
                 **http_audit_fields(request, e),
             )
         )
@@ -486,7 +486,7 @@ async def applet_flow_answer_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
-            curious_answer_id=[submit_id],
+            curious_submit_id=[submit_id],
             **http_audit_fields(request),
         )
     )
@@ -635,7 +635,7 @@ async def applet_submission_assessment_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
                 curious_applet_id=[applet_id],
-                curious_answer_id=[submission_id],
+                curious_submit_id=[submission_id],
                 **http_audit_fields(request, e),
             )
         )
@@ -645,7 +645,7 @@ async def applet_submission_assessment_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
             curious_applet_id=[applet_id],
-            curious_answer_id=[submission_id],
+            curious_submit_id=[submission_id],
             **http_audit_fields(request),
         )
     )
@@ -825,7 +825,7 @@ async def submission_note_list(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
                 curious_applet_id=[applet_id],
-                curious_answer_id=[submission_id],
+                curious_submit_id=[submission_id],
                 **http_audit_fields(request, e),
             )
         )
@@ -835,7 +835,7 @@ async def submission_note_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
             curious_applet_id=[applet_id],
-            curious_answer_id=[submission_id],
+            curious_submit_id=[submission_id],
             **http_audit_fields(request),
         )
     )
@@ -1175,7 +1175,7 @@ async def applet_submission_reviews_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
                 curious_applet_id=[applet_id],
-                curious_answer_id=[submission_id],
+                curious_submit_id=[submission_id],
                 **http_audit_fields(request, e),
             )
         )
@@ -1185,7 +1185,7 @@ async def applet_submission_reviews_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
             curious_applet_id=[applet_id],
-            curious_answer_id=[submission_id],
+            curious_submit_id=[submission_id],
             **http_audit_fields(request),
         )
     )

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -987,6 +987,7 @@ async def answer_note_delete(
 
 async def applet_answers_export(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(AnswerExportFilters)),
     activities_last_version: bool = Query(False, alias="activitiesLastVersion"),
@@ -994,11 +995,22 @@ async def applet_answers_export(
     answer_session=Depends(get_answer_session),
     i18n: I18N = Depends(get_i18n),
 ) -> PublicAnswerExportResponse:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answers_export_access(applet_id)
-    data: AnswerExport = await AnswerService(session, user.id, answer_session).get_export_data(
-        applet_id, query_params, activities_last_version
-    )
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answers_export_access(applet_id)
+        data: AnswerExport = await AnswerService(session, user.id, answer_session).get_export_data(
+            applet_id, query_params, activities_last_version
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_EXPORT,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
     total_answers = data.total_answers
     for answer in data.answers:
         if answer.is_manager:
@@ -1008,6 +1020,15 @@ async def applet_answers_export(
         applet = await AppletService(session, user.id).get(applet_id)
         activities = await ActivityHistoryService(session, applet.id, applet.version).get_full()
         data.activities = activities
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_EXPORT,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[answer.id for answer in data.answers],
+            **http_audit_fields(request),
+        )
+    )
     return PublicAnswerExportResponse(
         result=PublicAnswerExport.model_validate(data).translate(i18n),
         count=total_answers,

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -338,6 +338,7 @@ async def applet_flow_submissions_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
+            curious_submit_id=[s.submit_id for s in submissions.submissions] or None,
             curious_answer_id=[a.id for s in submissions.submissions for a in s.answers] or None,
             **http_audit_fields(request),
         )
@@ -666,8 +667,8 @@ async def applet_activity_identifiers_retrieve(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[Identifier]:
+    filters = IdentifiersQueryParams(**query_params.filters)
     try:
-        filters = IdentifiersQueryParams(**query_params.filters)
         await AppletService(session, user.id).exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_answer_access(applet_id, **filters.model_dump())
         identifiers = await AnswerService(session, user.id, answer_session).get_activity_identifiers(
@@ -679,6 +680,8 @@ async def applet_activity_identifiers_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=[filters.target_subject_id] if filters.target_subject_id else None,
+                curious_answer_id=[filters.answer_id] if filters.answer_id else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -688,6 +691,7 @@ async def applet_activity_identifiers_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
             curious_applet_id=[applet_id],
+            curious_subject_id=[filters.target_subject_id] if filters.target_subject_id else None,
             curious_answer_id=[filters.answer_id] if filters.answer_id else None,
             **http_audit_fields(request),
         )
@@ -704,8 +708,8 @@ async def applet_flow_identifiers_retrieve(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[Identifier]:
+    filters = IdentifiersQueryParams(**query_params.filters)
     try:
-        filters = IdentifiersQueryParams(**query_params.filters)
         applet_service = AppletService(session, user.id)
         await applet_service.exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
@@ -720,6 +724,7 @@ async def applet_flow_identifiers_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=[filters.target_subject_id] if filters.target_subject_id else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -729,6 +734,7 @@ async def applet_flow_identifiers_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
             curious_applet_id=[applet_id],
+            curious_subject_id=[filters.target_subject_id] if filters.target_subject_id else None,
             **http_audit_fields(request),
         )
     )
@@ -1030,6 +1036,16 @@ async def applet_answers_export(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_EXPORT,
             curious_applet_id=[applet_id],
+            curious_subject_id=list(
+                {
+                    subject_id
+                    for answer in data.answers
+                    for subject_id in (answer.target_subject_id, answer.source_subject_id, answer.input_subject_id)
+                    if subject_id is not None
+                }
+            )
+            or None,
+            curious_submit_id=list({answer.submit_id for answer in data.answers}) or None,
             curious_answer_id=[answer.id for answer in data.answers],
             **http_audit_fields(request),
         )

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -628,11 +628,11 @@ async def applet_submission_assessment_retrieve(
     try:
         await AppletService(session, user.id).exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-        answer = await AnswerService(session, user.id, answer_session).get_assessment_by_submit_id(
-            applet_id, submission_id
-        )
+        service = AnswerService(session, user.id, answer_session)
+        answer = await service.get_assessment_by_submit_id(applet_id, submission_id)
         if not answer:
             raise NotFoundError()
+        last_answer = await service.get_submission_last_answer(submission_id)
     except BaseError as e:
         await log(
             AuditEvent(
@@ -650,6 +650,7 @@ async def applet_submission_assessment_retrieve(
             event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
             curious_applet_id=[applet_id],
             curious_submit_id=[submission_id],
+            curious_answer_id=[last_answer.id] if last_answer else None,
             **http_audit_fields(request),
         )
     )

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -7,7 +7,7 @@ import uuid
 import zipfile
 from typing import Annotated
 
-from fastapi import Body, Depends, Header, Query
+from fastapi import Body, Depends, Header, Query, Request
 from fastapi import Response as FastAPIResponse
 from fastapi.responses import Response as FastApiResponse
 
@@ -59,6 +59,7 @@ from apps.applets.db.schemas import AppletSchema
 from apps.applets.domain.applet_history import VersionPublic
 from apps.applets.errors import InvalidVersionError, NotValidAppletHistory
 from apps.applets.service import AppletHistoryService, AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.integrations.oneup_health.service.domain import EHRData
 from apps.integrations.oneup_health.service.ehr_storage import create_ehr_storage
@@ -67,7 +68,7 @@ from apps.schedule.crud.user_device_events_history import UserDeviceEventsHistor
 from apps.schedule.service.schedule_history import ScheduleHistoryService
 from apps.shared.deps import get_client_ip, get_i18n
 from apps.shared.domain import Response, ResponseMulti, TruncatedDate, parse_obj_as
-from apps.shared.exception import AccessDeniedError, NotFoundError, ValidationError
+from apps.shared.exception import AccessDeniedError, BaseError, NotFoundError, ValidationError
 from apps.shared.locale import I18N
 from apps.shared.query_params import BaseQueryParams, QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
@@ -255,46 +256,90 @@ async def summary_activity_flow_list(
 async def applet_activity_answers_list(
     applet_id: uuid.UUID,
     activity_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     query_params: QueryParams = Depends(parse_query_params(AppletSubmissionsFilter)),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AppletActivityAnswerPublic]:
-    filters = query_params.filters
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_access(applet_id, **filters)
-    service = AnswerService(session, user.id, answer_session)
-    answers = await service.get_activity_answers(applet_id, activity_id, **filters)
+    try:
+        filters = query_params.filters
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_access(applet_id, **filters)
+        service = AnswerService(session, user.id, answer_session)
+        answers = await service.get_activity_answers(applet_id, activity_id, **filters)
 
-    answers_ids = [answer.answer_id for answer in answers if answer.answer_id is not None]
-    answer_reviews = await service.get_answer_assessments_count(answers_ids)
-    result = []
-    for answer in answers:
-        review_count = answer_reviews.get(answer.answer_id, ReviewsCount())
-        result.append(parse_obj_as(AppletActivityAnswerPublic, {**answer.model_dump(), "review_count": review_count}))
+        answers_ids = [answer.answer_id for answer in answers if answer.answer_id is not None]
+        answer_reviews = await service.get_answer_assessments_count(answers_ids)
+        result = []
+        for answer in answers:
+            review_count = answer_reviews.get(answer.answer_id, ReviewsCount())
+            result.append(
+                parse_obj_as(AppletActivityAnswerPublic, {**answer.model_dump(), "review_count": review_count})
+            )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_VIEW,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
     return ResponseMulti(result=result, count=len(answers))
 
 
 async def applet_flow_submissions_list(
     applet_id: uuid.UUID,
     flow_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(AppletSubmissionsFilter)),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> PublicFlowSubmissionsResponse:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    submissions, total = await AnswerService(session, user.id, answer_session).get_flow_submissions(
-        applet_id, flow_id, query_params
-    )
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        submissions, total = await AnswerService(session, user.id, answer_session).get_flow_submissions(
+            applet_id, flow_id, query_params
+        )
 
-    answer_service = AnswerService(session, user.id, answer_session)
-    submission_ids = [s.submit_id for s in submissions.submissions]
-    submission_reviews = await answer_service.get_submission_assessment_count(submission_ids)
-    for submission in submissions.submissions:
-        review_count = submission_reviews.get(submission.submit_id, ReviewsCount())
-        submission.review_count = review_count
+        answer_service = AnswerService(session, user.id, answer_session)
+        submission_ids = [s.submit_id for s in submissions.submissions]
+        submission_reviews = await answer_service.get_submission_assessment_count(submission_ids)
+        for submission in submissions.submissions:
+            review_count = submission_reviews.get(submission.submit_id, ReviewsCount())
+            submission.review_count = review_count
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_VIEW,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
     return PublicFlowSubmissionsResponse(result=submissions, count=total)
 
 
@@ -372,16 +417,39 @@ async def applet_activity_answer_retrieve(
     applet_id: uuid.UUID,
     activity_id: uuid.UUID,
     answer_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> Response[ActivitySubmissionResponse]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    submission = await AnswerService(session, user.id, answer_session).get_activity_answer(
-        applet_id, activity_id, answer_id
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        submission = await AnswerService(session, user.id, answer_session).get_activity_answer(
+            applet_id, activity_id, answer_id
+        )
+        result = ActivitySubmissionResponse.model_validate(submission)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[answer_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[answer_id],
+            **http_audit_fields(request),
+        )
     )
-    result = ActivitySubmissionResponse.model_validate(submission)
     return Response(result=result)
 
 
@@ -389,16 +457,39 @@ async def applet_flow_answer_retrieve(
     applet_id: uuid.UUID,
     flow_id: uuid.UUID,
     submit_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> Response[FlowSubmissionResponse]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    submission = await AnswerService(session, user.id, answer_session).get_flow_submission(
-        applet_id, flow_id, submit_id
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        submission = await AnswerService(session, user.id, answer_session).get_flow_submission(
+            applet_id, flow_id, submit_id
+        )
+        result = FlowSubmissionResponse.model_validate(submission)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[submit_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[submit_id],
+            **http_audit_fields(request),
+        )
     )
-    result = FlowSubmissionResponse.model_validate(submission)
     return Response(result=result)
 
 

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -293,6 +293,7 @@ async def applet_activity_answers_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
+            curious_answer_id=[a.answer_id for a in answers if a.answer_id] or None,
             **http_audit_fields(request),
         )
     )
@@ -337,6 +338,7 @@ async def applet_flow_submissions_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
+            curious_answer_id=[a.id for s in submissions.submissions for a in s.answers] or None,
             **http_audit_fields(request),
         )
     )
@@ -487,6 +489,7 @@ async def applet_flow_answer_retrieve(
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
             curious_submit_id=[submit_id],
+            curious_answer_id=[a.id for a in result.submission.answers] or None,
             **http_audit_fields(request),
         )
     )
@@ -685,6 +688,7 @@ async def applet_activity_identifiers_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
             curious_applet_id=[applet_id],
+            curious_answer_id=[filters.answer_id] if filters.answer_id else None,
             **http_audit_fields(request),
         )
     )
@@ -836,6 +840,7 @@ async def submission_note_list(
             event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
             curious_applet_id=[applet_id],
             curious_submit_id=[submission_id],
+            curious_answer_id=[n.answer_id for n in notes] or None,
             **http_audit_fields(request),
         )
     )
@@ -1186,6 +1191,7 @@ async def applet_submission_reviews_retrieve(
             event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
             curious_applet_id=[applet_id],
             curious_submit_id=[submission_id],
+            curious_answer_id=[r.answer_id for r in reviews] or None,
             **http_audit_fields(request),
         )
     )

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -496,13 +496,35 @@ async def applet_flow_answer_retrieve(
 async def applet_answer_reviews_retrieve(
     applet_id: uuid.UUID,
     answer_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AnswerReviewPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    reviews = await AnswerService(session, user.id, answer_session).get_reviews_by_answer_id(applet_id, answer_id)
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        reviews = await AnswerService(session, user.id, answer_session).get_reviews_by_answer_id(applet_id, answer_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[answer_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[answer_id],
+            **http_audit_fields(request),
+        )
+    )
     return ResponseMulti(
         result=[AnswerReviewPublic.model_validate(review) for review in reviews],
         count=len(reviews),
@@ -557,13 +579,35 @@ async def applet_submission_delete(
 async def applet_activity_assessment_retrieve(
     applet_id: uuid.UUID,
     answer_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> Response[AssessmentAnswerPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    answer = await AnswerService(session, user.id, answer_session).get_assessment_by_answer_id(applet_id, answer_id)
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        answer = await AnswerService(session, user.id, answer_session).get_assessment_by_answer_id(applet_id, answer_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[answer_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[answer_id],
+            **http_audit_fields(request),
+        )
+    )
     return Response(
         result=AssessmentAnswerPublic.model_validate(answer),
     )
@@ -572,15 +616,39 @@ async def applet_activity_assessment_retrieve(
 async def applet_submission_assessment_retrieve(
     applet_id: uuid.UUID,
     submission_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> Response[AssessmentAnswerPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    answer = await AnswerService(session, user.id, answer_session).get_assessment_by_submit_id(applet_id, submission_id)
-    if not answer:
-        raise NotFoundError()
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        answer = await AnswerService(session, user.id, answer_session).get_assessment_by_submit_id(
+            applet_id, submission_id
+        )
+        if not answer:
+            raise NotFoundError()
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[submission_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[submission_id],
+            **http_audit_fields(request),
+        )
+    )
     return Response(
         result=AssessmentAnswerPublic.model_validate(answer),
     )
@@ -589,34 +657,76 @@ async def applet_submission_assessment_retrieve(
 async def applet_activity_identifiers_retrieve(
     applet_id: uuid.UUID,
     activity_id: uuid.UUID,
+    request: Request,
     query_params: QueryParams = Depends(parse_query_params(IdentifiersQueryParams)),
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[Identifier]:
-    filters = IdentifiersQueryParams(**query_params.filters)
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_access(applet_id, **filters.model_dump())
-    identifiers = await AnswerService(session, user.id, answer_session).get_activity_identifiers(activity_id, filters)
+    try:
+        filters = IdentifiersQueryParams(**query_params.filters)
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_access(applet_id, **filters.model_dump())
+        identifiers = await AnswerService(session, user.id, answer_session).get_activity_identifiers(
+            activity_id, filters
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
     return ResponseMulti(result=identifiers, count=len(identifiers))
 
 
 async def applet_flow_identifiers_retrieve(
     applet_id: uuid.UUID,
     flow_id: uuid.UUID,
+    request: Request,
     query_params: QueryParams = Depends(parse_query_params(IdentifiersQueryParams)),
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[Identifier]:
-    filters = IdentifiersQueryParams(**query_params.filters)
-    applet_service = AppletService(session, user.id)
-    await applet_service.exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    if not (target_subject_id := filters.target_subject_id):
-        raise ValidationError("targetSubjectId missed")
-    identifiers = await AnswerService(session, user.id, answer_session).get_flow_identifiers(
-        applet_id, flow_id, target_subject_id
+    try:
+        filters = IdentifiersQueryParams(**query_params.filters)
+        applet_service = AppletService(session, user.id)
+        await applet_service.exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        if not (target_subject_id := filters.target_subject_id):
+            raise ValidationError("targetSubjectId missed")
+        identifiers = await AnswerService(session, user.id, answer_session).get_flow_identifiers(
+            applet_id, flow_id, target_subject_id
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_IDENTIFIER_VIEW,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
     )
     return ResponseMulti(result=identifiers, count=len(identifiers))
 
@@ -983,14 +1093,36 @@ async def answers_existence_check(
 async def applet_submission_reviews_retrieve(
     applet_id: uuid.UUID,
     submission_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AnswerReviewPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    reviews = await AnswerService(session, user.id, answer_session).get_reviews_by_submission_id(
-        applet_id, submission_id
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        reviews = await AnswerService(session, user.id, answer_session).get_reviews_by_submission_id(
+            applet_id, submission_id
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[submission_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_ASSESSMENT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[submission_id],
+            **http_audit_fields(request),
+        )
     )
     return ResponseMulti(
         result=[AnswerReviewPublic.model_validate(review) for review in reviews],

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -804,18 +804,40 @@ async def submission_note_list(
     applet_id: uuid.UUID,
     submission_id: uuid.UUID,
     flow_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     query_params: QueryParams = Depends(parse_query_params(BaseQueryParams)),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AnswerNoteDetailPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_note_crud_access(applet_id)
-    notes = await AnswerService(session, user.id, answer_session).get_submission_note_list(
-        applet_id, submission_id, flow_id, query_params.page, query_params.limit
-    )
-    count = await AnswerService(session, user.id, answer_session).get_submission_notes_count(
-        submission_id, flow_id, query_params.page, query_params.limit
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_note_crud_access(applet_id)
+        notes = await AnswerService(session, user.id, answer_session).get_submission_note_list(
+            applet_id, submission_id, flow_id, query_params.page, query_params.limit
+        )
+        count = await AnswerService(session, user.id, answer_session).get_submission_notes_count(
+            submission_id, flow_id, query_params.page, query_params.limit
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[submission_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[submission_id],
+            **http_audit_fields(request),
+        )
     )
     return ResponseMulti(
         result=[AnswerNoteDetailPublic.model_validate(note) for note in notes],
@@ -885,17 +907,39 @@ async def answer_note_list(
     applet_id: uuid.UUID,
     answer_id: uuid.UUID,
     activity_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     query_params: QueryParams = Depends(parse_query_params(BaseQueryParams)),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AnswerNoteDetailPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_note_crud_access(applet_id)
-    notes = await AnswerService(session, user.id, answer_session).get_note_list(
-        applet_id, answer_id, activity_id, query_params.page, query_params.limit
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_note_crud_access(applet_id)
+        notes = await AnswerService(session, user.id, answer_session).get_note_list(
+            applet_id, answer_id, activity_id, query_params.page, query_params.limit
+        )
+        count = await AnswerService(session, user.id, answer_session).get_notes_count(answer_id, activity_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
+                curious_applet_id=[applet_id],
+                curious_answer_id=[answer_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_NOTE_VIEW,
+            curious_applet_id=[applet_id],
+            curious_answer_id=[answer_id],
+            **http_audit_fields(request),
+        )
     )
-    count = await AnswerService(session, user.id, answer_session).get_notes_count(answer_id, activity_id)
     return ResponseMulti(
         result=[AnswerNoteDetailPublic.model_validate(note) for note in notes],
         count=count,

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -1006,6 +1006,15 @@ async def applet_answers_export(
         data: AnswerExport = await AnswerService(session, user.id, answer_session).get_export_data(
             applet_id, query_params, activities_last_version
         )
+        total_answers = data.total_answers
+        for answer in data.answers:
+            if answer.is_manager:
+                answer.respondent_secret_id = f"[admin account] ({answer.respondent_secret_id})"
+
+        if activities_last_version:
+            applet = await AppletService(session, user.id).get(applet_id)
+            activities = await ActivityHistoryService(session, applet.id, applet.version).get_full()
+            data.activities = activities
     except BaseError as e:
         await log(
             AuditEvent(
@@ -1016,15 +1025,6 @@ async def applet_answers_export(
             )
         )
         raise
-    total_answers = data.total_answers
-    for answer in data.answers:
-        if answer.is_manager:
-            answer.respondent_secret_id = f"[admin account] ({answer.respondent_secret_id})"
-
-    if activities_last_version:
-        applet = await AppletService(session, user.id).get(applet_id)
-        activities = await ActivityHistoryService(session, applet.id, applet.version).get_full()
-        data.activities = activities
     await log(
         AuditEvent(
             user_id=user.id,

--- a/src/apps/answers/crud/notes.py
+++ b/src/apps/answers/crud/notes.py
@@ -79,6 +79,7 @@ class AnswerNotesCRUD(BaseCRUD[AnswerNoteSchema]):
             result.append(
                 AnswerNoteDetail(
                     id=note.id,
+                    answer_id=note.answer_id,
                     user=dict(
                         id=note_user.id,
                         first_name=note_user.first_name,

--- a/src/apps/answers/domain/answers.py
+++ b/src/apps/answers/domain/answers.py
@@ -458,6 +458,7 @@ class Reviewer(InternalModel):
 
 class AnswerReview(InternalModel):
     id: uuid.UUID
+    answer_id: uuid.UUID
     reviewer_public_key: str | None = None
     answer: str | None = None
     item_ids: Annotated[list[str], Field(default_factory=list)]
@@ -519,6 +520,7 @@ class NoteOwner(InternalModel):
 
 class AnswerNoteDetail(InternalModel):
     id: uuid.UUID
+    answer_id: uuid.UUID
     user: NoteOwner
     note: str
     created_at: datetime.datetime

--- a/src/apps/answers/service.py
+++ b/src/apps/answers/service.py
@@ -2121,6 +2121,7 @@ class AnswerService:
             results.append(
                 AnswerReview(
                     id=schema.id,
+                    answer_id=schema.answer_id,
                     reviewer_public_key=schema.user_public_key if can_view else None,
                     answer=schema.answer if can_view else None,
                     item_ids=schema.item_ids,

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -613,3 +613,123 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
         assert event.curious_answer_id == [missing_submission_id]
+
+    # --- answer_note_list ---
+
+    answer_notes_url = "/answers/applet/{applet_id}/answers/{answer_id}/activities/{activity_id}/notes"
+
+    async def test_answer_note_list_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        answer: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.answer_notes_url.format(
+                applet_id=applet.id,
+                answer_id=answer.id,
+                activity_id=applet.activities[0].id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_answer_id == [answer.id]
+
+    async def test_answer_note_list_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_answer_id = uuid.uuid4()
+        response = await client.get(
+            self.answer_notes_url.format(
+                applet_id=missing_applet_id,
+                answer_id=missing_answer_id,
+                activity_id=uuid.uuid4(),
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_answer_id]
+
+    # --- submission_note_list ---
+
+    submission_notes_url = "/answers/applet/{applet_id}/submissions/{submission_id}/flows/{flow_id}/notes"
+
+    async def test_submission_note_list_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_answer_activity_flow_audit: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.submission_notes_url.format(
+                applet_id=applet_with_flow.id,
+                submission_id=tom_answer_activity_flow_audit.submit_id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+
+    async def test_submission_note_list_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_submission_id = uuid.uuid4()
+        response = await client.get(
+            self.submission_notes_url.format(
+                applet_id=missing_applet_id,
+                submission_id=missing_submission_id,
+                flow_id=uuid.uuid4(),
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_submission_id]

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -79,6 +79,8 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet.id]
+        assert event.curious_answer_id is not None
+        assert answer.id in event.curious_answer_id
 
     async def test_activity_answers_list_audit_failure(
         self,
@@ -132,6 +134,8 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id is not None
+        assert tom_answer_activity_flow_audit.id in event.curious_answer_id
 
     async def test_flow_submissions_list_audit_failure(
         self,

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -244,7 +244,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+        assert event.curious_submit_id == [tom_answer_activity_flow_audit.submit_id]
 
     async def test_flow_answer_retrieve_audit_failure(
         self,
@@ -272,7 +272,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_VIEW
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_answer_id == [missing_submit_id]
+        assert event.curious_submit_id == [missing_submit_id]
 
     # --- applet_answer_reviews_retrieve ---
 
@@ -417,7 +417,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+        assert event.curious_submit_id == [tom_answer_activity_flow_audit.submit_id]
 
     async def test_submission_assessment_retrieve_audit_failure(
         self,
@@ -444,7 +444,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
-        assert event.curious_answer_id == [missing_submission_id]
+        assert event.curious_submit_id == [missing_submission_id]
 
     # --- applet_activity_identifiers_retrieve ---
 
@@ -585,7 +585,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+        assert event.curious_submit_id == [tom_answer_activity_flow_audit.submit_id]
 
     async def test_submission_reviews_retrieve_audit_failure(
         self,
@@ -612,7 +612,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
-        assert event.curious_answer_id == [missing_submission_id]
+        assert event.curious_submit_id == [missing_submission_id]
 
     # --- answer_note_list ---
 
@@ -704,7 +704,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+        assert event.curious_submit_id == [tom_answer_activity_flow_audit.submit_id]
 
     async def test_submission_note_list_audit_failure(
         self,
@@ -732,7 +732,7 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_NOTE_VIEW
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
-        assert event.curious_answer_id == [missing_submission_id]
+        assert event.curious_submit_id == [missing_submission_id]
 
     # --- applet_answers_export ---
 

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -273,3 +273,343 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet_with_flow.id]
         assert event.curious_answer_id == [missing_submit_id]
+
+    # --- applet_answer_reviews_retrieve ---
+
+    answer_reviews_url = "/answers/applet/{applet_id}/answers/{answer_id}/reviews"
+
+    async def test_answer_reviews_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        answer_reviewable_activity: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.answer_reviews_url.format(
+                applet_id=answer_reviewable_activity.applet_id,
+                answer_id=answer_reviewable_activity.id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [answer_reviewable_activity.applet_id]
+        assert event.curious_answer_id == [answer_reviewable_activity.id]
+
+    async def test_answer_reviews_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_answer_id = uuid.uuid4()
+        response = await client.get(
+            self.answer_reviews_url.format(
+                applet_id=missing_applet_id,
+                answer_id=missing_answer_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_answer_id]
+
+    # --- applet_activity_assessment_retrieve ---
+
+    activity_assessment_url = "/answers/applet/{applet_id}/answers/{answer_id}/assessment"
+
+    async def test_activity_assessment_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        answer_reviewable_activity: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.activity_assessment_url.format(
+                applet_id=answer_reviewable_activity.applet_id,
+                answer_id=answer_reviewable_activity.id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [answer_reviewable_activity.applet_id]
+        assert event.curious_answer_id == [answer_reviewable_activity.id]
+
+    async def test_activity_assessment_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_answer_id = uuid.uuid4()
+        response = await client.get(
+            self.activity_assessment_url.format(
+                applet_id=missing_applet_id,
+                answer_id=missing_answer_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_answer_id]
+
+    # --- applet_submission_assessment_retrieve ---
+
+    submission_assessment_url = "/answers/applet/{applet_id}/submissions/{submission_id}/assessments"
+
+    async def test_submission_assessment_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_answer_activity_flow_audit: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.submission_assessment_url.format(
+                applet_id=applet_with_flow.id,
+                submission_id=tom_answer_activity_flow_audit.submit_id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+
+    async def test_submission_assessment_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_submission_id = uuid.uuid4()
+        response = await client.get(
+            self.submission_assessment_url.format(
+                applet_id=missing_applet_id,
+                submission_id=missing_submission_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_submission_id]
+
+    # --- applet_activity_identifiers_retrieve ---
+
+    activity_identifiers_url = "/answers/applet/{applet_id}/summary/activities/{activity_id}/identifiers"
+
+    async def test_activity_identifiers_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.activity_identifiers_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_IDENTIFIER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+
+    async def test_activity_identifiers_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(
+            self.activity_identifiers_url.format(
+                applet_id=missing_applet_id,
+                activity_id=uuid.uuid4(),
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_IDENTIFIER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    # --- applet_flow_identifiers_retrieve ---
+
+    flow_identifiers_url = "/answers/applet/{applet_id}/flows/{flow_id}/identifiers"
+
+    async def test_flow_identifiers_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.flow_identifiers_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+            ),
+            dict(targetSubjectId=str(uuid.uuid4())),
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_IDENTIFIER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+
+    async def test_flow_identifiers_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(
+            self.flow_identifiers_url.format(
+                applet_id=missing_applet_id,
+                flow_id=uuid.uuid4(),
+            ),
+            dict(targetSubjectId=str(uuid.uuid4())),
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_IDENTIFIER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    # --- applet_submission_reviews_retrieve ---
+
+    submission_reviews_url = "/answers/applet/{applet_id}/submissions/{submission_id}/reviews"
+
+    async def test_submission_reviews_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_answer_activity_flow_audit: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.submission_reviews_url.format(
+                applet_id=applet_with_flow.id,
+                submission_id=tom_answer_activity_flow_audit.submit_id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+
+    async def test_submission_reviews_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        missing_submission_id = uuid.uuid4()
+        response = await client.get(
+            self.submission_reviews_url.format(
+                applet_id=missing_applet_id,
+                submission_id=missing_submission_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_ASSESSMENT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+        assert event.curious_answer_id == [missing_submission_id]

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -733,3 +733,49 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
         assert event.curious_answer_id == [missing_submission_id]
+
+    # --- applet_answers_export ---
+
+    answers_export_url = "/answers/applet/{applet_id}/data"
+
+    async def test_answers_export_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        answer: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(self.answers_export_url.format(applet_id=applet.id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EXPORT
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert answer.id in event.curious_answer_id
+
+    async def test_answers_export_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(self.answers_export_url.format(applet_id=missing_applet_id))
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EXPORT
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -1,0 +1,275 @@
+import datetime
+import http
+import uuid
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.answers.db.schemas import AnswerSchema
+from apps.answers.domain import ClientMeta
+from apps.answers.domain.answers import AppletAnswerCreate, ItemAnswerCreate
+from apps.answers.service import AnswerService
+from apps.applets.domain.applet_full import AppletFull
+from apps.audit import EventAction, EventOutcome
+from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
+from apps.users.domain import User
+
+
+@pytest.fixture
+async def tom_answer_activity_flow_audit(
+    session: AsyncSession, tom: User, applet_with_flow: AppletFull
+) -> AnswerSchema:
+    answer_service = AnswerService(session, tom.id)
+    return await answer_service.create_answer(
+        AppletAnswerCreate(
+            applet_id=applet_with_flow.id,
+            version=applet_with_flow.version,
+            submit_id=uuid.uuid4(),
+            flow_id=applet_with_flow.activity_flows[0].id,
+            is_flow_completed=True,
+            activity_id=applet_with_flow.activities[0].id,
+            answer=ItemAnswerCreate(
+                item_ids=[applet_with_flow.activities[0].items[0].id],
+                start_time=datetime.datetime.now(datetime.UTC),
+                end_time=datetime.datetime.now(datetime.UTC),
+                user_public_key=str(tom.id),
+            ),
+            client=ClientMeta(app_id=f"{uuid.uuid4()}", app_version="1.1", width=984, height=623),
+            consent_to_share=False,
+        )
+    )
+
+
+class TestAnswersAudit(BaseTest):
+    fixtures = [
+        "workspaces/fixtures/workspaces.json",
+    ]
+
+    activity_answers_url = "/answers/applet/{applet_id}/activities/{activity_id}/answers"
+    flow_submissions_url = "/answers/applet/{applet_id}/flows/{flow_id}/submissions"
+    activity_answer_url = "/answers/applet/{applet_id}/activities/{activity_id}/answers/{answer_id}"
+    flow_submission_url = "/answers/applet/{applet_id}/flows/{flow_id}/submissions/{submit_id}"
+
+    # --- applet_activity_answers_list ---
+
+    async def test_activity_answers_list_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        answer: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.activity_answers_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+
+    async def test_activity_answers_list_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(
+            self.activity_answers_url.format(
+                applet_id=missing_applet_id,
+                activity_id=uuid.uuid4(),
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    # --- applet_flow_submissions_list ---
+
+    async def test_flow_submissions_list_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_answer_activity_flow_audit: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.flow_submissions_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+
+    async def test_flow_submissions_list_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(
+            self.flow_submissions_url.format(
+                applet_id=missing_applet_id,
+                flow_id=uuid.uuid4(),
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    # --- applet_activity_answer_retrieve ---
+
+    async def test_activity_answer_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        answer: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.activity_answer_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+                answer_id=answer.id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_answer_id == [answer.id]
+
+    async def test_activity_answer_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_answer_id = uuid.uuid4()
+        response = await client.get(
+            self.activity_answer_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+                answer_id=missing_answer_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_answer_id == [missing_answer_id]
+
+    # --- applet_flow_answer_retrieve ---
+
+    async def test_flow_answer_retrieve_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_answer_activity_flow_audit: AnswerSchema,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.flow_submission_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+                submit_id=tom_answer_activity_flow_audit.submit_id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id == [tom_answer_activity_flow_audit.submit_id]
+
+    async def test_flow_answer_retrieve_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_submit_id = uuid.uuid4()
+        response = await client.get(
+            self.flow_submission_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+                submit_id=missing_submit_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_answer_id == [missing_submit_id]

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -310,6 +310,7 @@ async def get_my_subject(
     session: AsyncSession = Depends(get_session),
     arbitrary_session: AsyncSession | None = Depends(get_answer_session),
 ) -> Response[SubjectReadResponse]:
+    subject: Subject | None = None
     try:
         # Check if applet exists
         await AppletService(session, user.id).exist_by_id(applet_id)
@@ -330,6 +331,7 @@ async def get_my_subject(
                 user_id=user.id,
                 event_action=EventAction.APPLET_SUBJECT_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=subject and [subject.id],
                 **http_audit_fields(request, e),
             )
         )
@@ -437,7 +439,7 @@ async def get_target_subjects_by_respondent(
             user_id=user.id,
             event_action=EventAction.APPLET_SUBJECT_VIEW,
             curious_applet_id=[respondent_subject.applet_id],
-            curious_subject_id=[respondent_subject_id],
+            curious_subject_id=list({respondent_subject_id, *(s.id for s in subjects)}),
             **http_audit_fields(request),
         )
     )

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -2,18 +2,19 @@ import uuid
 from datetime import datetime, timedelta
 from typing import TypedDict
 
-from fastapi import Body, Depends
+from fastapi import Body, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.activity_assignments.service import ActivityAssignmentService
 from apps.answers.deps.preprocess_arbitrary import get_answer_session, get_answer_session_by_subject
 from apps.answers.service import AnswerService
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
 from apps.shared.domain import Response, ResponseMulti
-from apps.shared.exception import NotFoundError, ValidationError
+from apps.shared.exception import BaseError, NotFoundError, ValidationError
 from apps.shared.response import EmptyResponse
 from apps.shared.subjects import is_take_now_relation, is_valid_take_now_relation
 from apps.subjects.domain import (
@@ -225,37 +226,64 @@ async def delete_subject(
 
 async def get_subject(
     subject_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     arbitrary_session: AsyncSession | None = Depends(get_answer_session_by_subject),
 ) -> Response[SubjectReadResponseWithDataAccess]:
-    subjects_service = SubjectsService(session, user.id)
-    subject = await subjects_service.get(subject_id)
-    if not subject:
-        raise NotFoundError()
+    applet_id_for_audit: uuid.UUID | None = None
+    try:
+        subjects_service = SubjectsService(session, user.id)
+        subject = await subjects_service.get(subject_id)
+        if not subject:
+            raise NotFoundError()
+        applet_id_for_audit = subject.applet_id
 
-    user_subject = await subjects_service.get_by_user_and_applet(user.id, subject.applet_id)
-    if not user_subject:
-        await CheckAccessService(session, user.id).check_subject_subject_access(subject.applet_id, subject_id)
-    else:
-        relation = await subjects_service.get_relation(user_subject.id, subject_id)
-        has_relation = relation is not None and (
-            relation.relation != "take-now" or is_valid_take_now_relation(relation)
-        )
-        if not has_relation:
+        user_subject = await subjects_service.get_by_user_and_applet(user.id, subject.applet_id)
+        if not user_subject:
             await CheckAccessService(session, user.id).check_subject_subject_access(subject.applet_id, subject_id)
+        else:
+            relation = await subjects_service.get_relation(user_subject.id, subject_id)
+            has_relation = relation is not None and (
+                relation.relation != "take-now" or is_valid_take_now_relation(relation)
+            )
+            if not has_relation:
+                await CheckAccessService(session, user.id).check_subject_subject_access(subject.applet_id, subject_id)
 
-    answer_dates = await AnswerService(
-        user_id=user.id, session=session, arbitrary_session=arbitrary_session
-    ).get_last_answer_dates([subject.id], subject.applet_id)
+        answer_dates = await AnswerService(
+            user_id=user.id, session=session, arbitrary_session=arbitrary_session
+        ).get_last_answer_dates([subject.id], subject.applet_id)
 
-    roles: list[str] = []
-    if subject.user_id:
-        roles = await UserAppletAccessService(session, subject.user_id, subject.applet_id).get_roles()
+        roles: list[str] = []
+        if subject.user_id:
+            roles = await UserAppletAccessService(session, subject.user_id, subject.applet_id).get_roles()
 
-    accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=[subject.applet_id], user_id=user.id)
-    is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
-    reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+        accesses = await AppletAccessService(session).get_applet_accesses(
+            applet_ids=[subject.applet_id], user_id=user.id
+        )
+        is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
+        reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id_for_audit] if applet_id_for_audit else None,
+                curious_subject_id=[subject_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_SUBJECT_VIEW,
+            curious_applet_id=[subject.applet_id],
+            curious_subject_id=[subject.id],
+            **http_audit_fields(request),
+        )
+    )
 
     return Response(
         result=SubjectReadResponseWithDataAccess(
@@ -277,23 +305,45 @@ async def get_subject(
 
 async def get_my_subject(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     arbitrary_session: AsyncSession | None = Depends(get_answer_session),
 ) -> Response[SubjectReadResponse]:
-    # Check if applet exists
-    await AppletService(session, user.id).exist_by_id(applet_id)
+    try:
+        # Check if applet exists
+        await AppletService(session, user.id).exist_by_id(applet_id)
 
-    # Check if user has access to applet
-    await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
+        # Check if user has access to applet
+        await CheckAccessService(session, user.id).check_applet_detail_access(applet_id)
 
-    subject = await SubjectsService(session, user.id).get_by_user_and_applet(user.id, applet_id)
-    if not subject:
-        raise NotFoundError()
+        subject = await SubjectsService(session, user.id).get_by_user_and_applet(user.id, applet_id)
+        if not subject:
+            raise NotFoundError()
 
-    answer_dates = await AnswerService(
-        user_id=user.id, session=session, arbitrary_session=arbitrary_session
-    ).get_last_answer_dates([subject.id], subject.applet_id)
+        answer_dates = await AnswerService(
+            user_id=user.id, session=session, arbitrary_session=arbitrary_session
+        ).get_last_answer_dates([subject.id], subject.applet_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_SUBJECT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_subject_id=[subject.id],
+            **http_audit_fields(request),
+        )
+    )
     return Response(
         result=SubjectReadResponse(
             id=subject.id,
@@ -312,62 +362,87 @@ async def get_my_subject(
 async def get_target_subjects_by_respondent(
     respondent_subject_id: uuid.UUID,
     activity_or_flow_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[TargetSubjectByRespondentResponse]:
-    subjects_service = SubjectsService(session, user.id)
-    respondent_subject = await subjects_service.exist_by_id(respondent_subject_id)
-    is_limited_respondent = respondent_subject.user_id is None
+    applet_id_for_audit: uuid.UUID | None = None
+    try:
+        subjects_service = SubjectsService(session, user.id)
+        respondent_subject = await subjects_service.exist_by_id(respondent_subject_id)
+        applet_id_for_audit = respondent_subject.applet_id
+        is_limited_respondent = respondent_subject.user_id is None
 
-    # Make sure the authenticated user has access to the subject
-    await CheckAccessService(session, user.id).check_subject_subject_access(
-        respondent_subject.applet_id, respondent_subject.id
-    )
+        # Make sure the authenticated user has access to the subject
+        await CheckAccessService(session, user.id).check_subject_subject_access(
+            respondent_subject.applet_id, respondent_subject.id
+        )
 
-    assignment_service = ActivityAssignmentService(session)
-    assignment_subject_ids = await assignment_service.get_target_subject_ids_by_respondent(
-        respondent_subject_id=respondent_subject_id, activity_or_flow_ids=[activity_or_flow_id]
-    )
+        assignment_service = ActivityAssignmentService(session)
+        assignment_subject_ids = await assignment_service.get_target_subject_ids_by_respondent(
+            respondent_subject_id=respondent_subject_id, activity_or_flow_ids=[activity_or_flow_id]
+        )
 
-    is_auto_assigned = await assignment_service.check_if_auto_assigned(activity_or_flow_id)
-    if is_auto_assigned and not is_limited_respondent:
-        assignment_subject_ids.append(respondent_subject_id)
+        is_auto_assigned = await assignment_service.check_if_auto_assigned(activity_or_flow_id)
+        if is_auto_assigned and not is_limited_respondent:
+            assignment_subject_ids.append(respondent_subject_id)
 
-    submission_data: list[tuple[uuid.UUID, int]] = await AnswerService(
-        user_id=user.id, session=session, arbitrary_session=answer_session
-    ).get_target_subject_ids_by_respondent_and_activity_or_flow(
-        respondent_subject_id=respondent_subject_id, activity_or_flow_id=activity_or_flow_id
-    )
+        submission_data: list[tuple[uuid.UUID, int]] = await AnswerService(
+            user_id=user.id, session=session, arbitrary_session=answer_session
+        ).get_target_subject_ids_by_respondent_and_activity_or_flow(
+            respondent_subject_id=respondent_subject_id, activity_or_flow_id=activity_or_flow_id
+        )
 
-    class SubjectInfo(TypedDict):
-        currently_assigned: bool
-        submission_count: int
+        class SubjectInfo(TypedDict):
+            currently_assigned: bool
+            submission_count: int
 
-    subject_info: dict[uuid.UUID, SubjectInfo] = {}
-    for subject_id, submission_count in submission_data:
-        subject_info[subject_id] = {"currently_assigned": False, "submission_count": submission_count}
+        subject_info: dict[uuid.UUID, SubjectInfo] = {}
+        for subject_id, submission_count in submission_data:
+            subject_info[subject_id] = {"currently_assigned": False, "submission_count": submission_count}
 
-    for subject_id in assignment_subject_ids:
-        if subject_id not in subject_info:
-            subject_info[subject_id] = {"currently_assigned": True, "submission_count": 0}
-        else:
-            subject_info[subject_id]["currently_assigned"] = True
+        for subject_id in assignment_subject_ids:
+            if subject_id not in subject_info:
+                subject_info[subject_id] = {"currently_assigned": True, "submission_count": 0}
+            else:
+                subject_info[subject_id]["currently_assigned"] = True
 
-    subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
-    roles: dict[uuid.UUID, list[Role]] = await UserAppletAccessService(
-        session, user.id, respondent_subject.applet_id
-    ).get_applet_roles_by_priority_for_users(
-        respondent_subject.applet_id, [subject.user_id for subject in subjects if subject.user_id]
+        subjects: list[Subject] = await subjects_service.get_by_ids(list(subject_info.keys()))
+        roles: dict[uuid.UUID, list[Role]] = await UserAppletAccessService(
+            session, user.id, respondent_subject.applet_id
+        ).get_applet_roles_by_priority_for_users(
+            respondent_subject.applet_id, [subject.user_id for subject in subjects if subject.user_id]
+        )
+
+        accesses = await AppletAccessService(session).get_applet_accesses(
+            applet_ids=[respondent_subject.applet_id], user_id=user.id
+        )
+        is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
+        reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id_for_audit] if applet_id_for_audit else None,
+                curious_subject_id=[respondent_subject_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_SUBJECT_VIEW,
+            curious_applet_id=[respondent_subject.applet_id],
+            curious_subject_id=[respondent_subject_id],
+            **http_audit_fields(request),
+        )
     )
 
     result: list[TargetSubjectByRespondentResponse] = []
-
-    accesses = await AppletAccessService(session).get_applet_accesses(
-        applet_ids=[respondent_subject.applet_id], user_id=user.id
-    )
-    is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
-    reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
 
     respondent_target_subject: TargetSubjectByRespondentResponse | None = None
 

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime, timedelta
-from typing import TypedDict
 
 from fastapi import Body, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -396,11 +395,7 @@ async def get_target_subjects_by_respondent(
             respondent_subject_id=respondent_subject_id, activity_or_flow_id=activity_or_flow_id
         )
 
-        class SubjectInfo(TypedDict):
-            currently_assigned: bool
-            submission_count: int
-
-        subject_info: dict[uuid.UUID, SubjectInfo] = {}
+        subject_info: dict[uuid.UUID, dict[str, bool | int]] = {}
         for subject_id, submission_count in submission_data:
             subject_info[subject_id] = {"currently_assigned": False, "submission_count": submission_count}
 

--- a/src/apps/subjects/tests/test_audit.py
+++ b/src/apps/subjects/tests/test_audit.py
@@ -1,0 +1,156 @@
+import http
+import uuid
+
+from pytest_mock import MockerFixture
+
+from apps.applets.domain.applet_full import AppletFull
+from apps.audit import EventAction, EventOutcome
+from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
+from apps.subjects.domain import Subject
+from apps.users import User
+
+
+class TestSubjectsAudit(BaseTest):
+    fixtures = [
+        "workspaces/fixtures/workspaces.json",
+    ]
+
+    my_subject_url = "/users/me/subjects/{applet_id}"
+    subject_detail_url = "/subjects/{subject_id}"
+    subject_target_by_respondent_url = (
+        "/subjects/respondent/{respondent_subject_id}/activity-or-flow/{activity_or_flow_id}"
+    )
+
+    async def test_get_subject_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        response = await client.get(self.subject_detail_url.format(subject_id=tom_applet_one_subject.id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
+        assert event.curious_subject_id == [tom_applet_one_subject.id]
+
+    async def test_get_subject_audit_failure_not_found(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        missing_subject_id = uuid.uuid4()
+        response = await client.get(self.subject_detail_url.format(subject_id=missing_subject_id))
+
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_subject_id == [missing_subject_id]
+
+    async def test_get_my_subject_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        response = await client.get(self.my_subject_url.format(applet_id=tom_applet_one_subject.applet_id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
+        assert event.curious_subject_id == [tom_applet_one_subject.id]
+
+    async def test_get_my_subject_audit_failure_invalid_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(self.my_subject_url.format(applet_id=missing_applet_id))
+
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    async def test_get_target_subjects_by_respondent_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=tom_applet_one_subject.id,
+            activity_or_flow_id=applet_one.activities[0].id,
+        )
+        response = await client.get(url)
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
+        assert event.curious_subject_id == [tom_applet_one_subject.id]
+
+    async def test_get_target_subjects_by_respondent_audit_failure_invalid_respondent(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        missing_respondent_subject_id = uuid.uuid4()
+        url = self.subject_target_by_respondent_url.format(
+            respondent_subject_id=missing_respondent_subject_id,
+            activity_or_flow_id=applet_one.activities[0].id,
+        )
+        response = await client.get(url)
+
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_subject_id == [missing_respondent_subject_id]

--- a/src/apps/subjects/tests/test_audit.py
+++ b/src/apps/subjects/tests/test_audit.py
@@ -128,7 +128,8 @@ class TestSubjectsAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
-        assert event.curious_subject_id == [tom_applet_one_subject.id]
+        assert event.curious_subject_id is not None
+        assert tom_applet_one_subject.id in event.curious_subject_id
 
     async def test_get_target_subjects_by_respondent_audit_failure_invalid_respondent(
         self,

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -1,18 +1,19 @@
 import uuid
 from copy import deepcopy
 
-from fastapi import Body, Depends, Query
+from fastapi import Body, Depends, Query, Request
 
 from apps.answers.deps.preprocess_arbitrary import get_answer_session_by_owner_id
 from apps.answers.service import AnswerService
 from apps.applets.domain.applet_full import PublicAppletFull
 from apps.applets.filters import AppletQueryParams
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
 from apps.shared.domain import Response, ResponseMulti, ResponseMultiOrdering
-from apps.shared.exception import NotFoundError
+from apps.shared.exception import BaseError, NotFoundError
 from apps.shared.query_params import BaseQueryParams, QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
 from apps.users.domain import User
@@ -235,27 +236,50 @@ async def workspace_remove_manager_access(
 
 async def workspace_respondents_list(
     owner_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(WorkspaceUsersQueryParams)),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
-    service = WorkspaceService(session, user.id)
-    await service.exists_by_owner_id(owner_id)
+    try:
+        service = WorkspaceService(session, user.id)
+        await service.exists_by_owner_id(owner_id)
 
-    await CheckAccessService(session, user.id).check_workspace_respondent_list_access(owner_id)
+        await CheckAccessService(session, user.id).check_workspace_respondent_list_access(owner_id)
 
-    data, total, ordering_fields = await service.get_workspace_respondents(owner_id, None, deepcopy(query_params))
-    respondents = await AnswerService(
-        session=session, arbitrary_session=answer_session
-    ).fill_last_activity_workspace_respondent(data)
-    respondents = await InvitationsService(session, user).fill_pending_invitations_respondents(respondents)
+        data, total, ordering_fields = await service.get_workspace_respondents(owner_id, None, deepcopy(query_params))
+        respondents = await AnswerService(
+            session=session, arbitrary_session=answer_session
+        ).fill_last_activity_workspace_respondent(data)
+        respondents = await InvitationsService(session, user).fill_pending_invitations_respondents(respondents)
 
-    applet_ids = [detail.applet_id for respondent in respondents if respondent.details for detail in respondent.details]
+        applet_ids = [
+            detail.applet_id for respondent in respondents if respondent.details for detail in respondent.details
+        ]
 
-    accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=applet_ids, user_id=user.id)
-    is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
-    reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+        accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=applet_ids, user_id=user.id)
+        is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
+        reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    for applet_id in set(applet_ids):
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request),
+            )
+        )
 
     public_respondents: list[PublicWorkspaceRespondent] = []
     for respondent in respondents:
@@ -277,25 +301,48 @@ async def workspace_respondents_list(
 async def workspace_applet_respondents_list(
     owner_id: uuid.UUID,
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     query_params: QueryParams = Depends(parse_query_params(WorkspaceUsersQueryParams)),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
-    service = WorkspaceService(session, user.id)
-    await service.exists_by_owner_id(owner_id)
+    try:
+        service = WorkspaceService(session, user.id)
+        await service.exists_by_owner_id(owner_id)
 
-    await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
+        await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
-    data, total, ordering_fields = await service.get_workspace_respondents(owner_id, applet_id, deepcopy(query_params))
-    respondents = await AnswerService(
-        session=session, arbitrary_session=answer_session
-    ).fill_last_activity_workspace_respondent(data, applet_id)
-    respondents = await InvitationsService(session, user).fill_pending_invitations_respondents(respondents)
+        data, total, ordering_fields = await service.get_workspace_respondents(
+            owner_id, applet_id, deepcopy(query_params)
+        )
+        respondents = await AnswerService(
+            session=session, arbitrary_session=answer_session
+        ).fill_last_activity_workspace_respondent(data, applet_id)
+        respondents = await InvitationsService(session, user).fill_pending_invitations_respondents(respondents)
 
-    accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=[applet_id], user_id=user.id)
-    is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
-    reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+        accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=[applet_id], user_id=user.id)
+        is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
+        reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_SUBJECT_VIEW,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
     public_respondents: list[PublicWorkspaceRespondent] = []
     for respondent in respondents:
@@ -453,21 +500,43 @@ async def workspace_applet_get_respondent(
     owner_id: uuid.UUID,
     applet_id: uuid.UUID,
     respondent_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> Response[RespondentInfoPublic]:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
-    await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
+        await CheckAccessService(session, user.id).check_applet_respondent_list_access(applet_id)
 
-    respondent_info = await UserAppletAccessService(session, user.id, applet_id).get_respondent_info(
-        respondent_id, applet_id, owner_id
+        respondent_info = await UserAppletAccessService(session, user.id, applet_id).get_respondent_info(
+            respondent_id, applet_id, owner_id
+        )
+        # get last activity time
+        result = await AnswerService(session=session, arbitrary_session=answer_session).get_last_answer_dates(
+            [respondent_info.subject_id],
+            applet_id,
+        )
+        respondent_info.last_seen = result.get(respondent_info.subject_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_SUBJECT_VIEW,
+            curious_applet_id=[applet_id],
+            curious_subject_id=[respondent_info.subject_id],
+            **http_audit_fields(request),
+        )
     )
-    # get last activity time
-    result = await AnswerService(session=session, arbitrary_session=answer_session).get_last_answer_dates(
-        [respondent_info.subject_id],
-        applet_id,
-    )
-    respondent_info.last_seen = result.get(respondent_info.subject_id)
     return Response(result=respondent_info)

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -245,6 +245,7 @@ async def workspace_respondents_list(
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
     respondents: list[WorkspaceRespondent] = []
     applet_ids: list[uuid.UUID] = []
+    subjects_by_applet: dict[uuid.UUID, list[uuid.UUID]] = {}
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -268,6 +269,11 @@ async def workspace_respondents_list(
         subject_ids = [
             r_detail.subject_id for respondent in respondents if respondent.details for r_detail in respondent.details
         ]
+        subjects_by_applet = {}
+        for respondent in respondents:
+            if respondent.details:
+                for r_detail in respondent.details:
+                    subjects_by_applet.setdefault(r_detail.applet_id, []).append(r_detail.subject_id)
         if applet_ids:
             for applet_id in set(applet_ids):
                 await log(
@@ -275,7 +281,7 @@ async def workspace_respondents_list(
                         user_id=user.id,
                         event_action=EventAction.APPLET_SUBJECT_VIEW,
                         curious_applet_id=[applet_id],
-                        curious_subject_id=subject_ids or None,
+                        curious_subject_id=subjects_by_applet.get(applet_id),
                         **http_audit_fields(request, e),
                     )
                 )
@@ -290,7 +296,7 @@ async def workspace_respondents_list(
             )
         raise
 
-    subjects_by_applet: dict[uuid.UUID, list[uuid.UUID]] = {}
+    subjects_by_applet = {}
     for respondent in respondents:
         if respondent.details:
             for r_detail in respondent.details:

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -242,6 +242,7 @@ async def workspace_respondents_list(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
+    respondents = []
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -262,14 +263,27 @@ async def workspace_respondents_list(
         is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
         reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
     except BaseError as e:
+        subject_ids = [
+            detail.subject_id
+            for respondent in respondents
+            if respondent.details
+            for detail in respondent.details
+        ]
         await log(
             AuditEvent(
                 user_id=user.id,
                 event_action=EventAction.APPLET_SUBJECT_VIEW,
+                curious_subject_id=subject_ids or None,
                 **http_audit_fields(request, e),
             )
         )
         raise
+
+    subjects_by_applet: dict[uuid.UUID, list[uuid.UUID]] = {}
+    for respondent in respondents:
+        if respondent.details:
+            for detail in respondent.details:
+                subjects_by_applet.setdefault(detail.applet_id, []).append(detail.subject_id)
 
     for applet_id in set(applet_ids):
         await log(
@@ -277,6 +291,7 @@ async def workspace_respondents_list(
                 user_id=user.id,
                 event_action=EventAction.APPLET_SUBJECT_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=subjects_by_applet.get(applet_id),
                 **http_audit_fields(request),
             )
         )
@@ -307,6 +322,7 @@ async def workspace_applet_respondents_list(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
+    respondents = []
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -325,21 +341,36 @@ async def workspace_applet_respondents_list(
         is_super_reviewer = any(access.role in Role.super_reviewers() for access in accesses)
         reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
     except BaseError as e:
+        subject_ids = [
+            detail.subject_id
+            for respondent in respondents
+            if respondent.details
+            for detail in respondent.details
+        ]
         await log(
             AuditEvent(
                 user_id=user.id,
                 event_action=EventAction.APPLET_SUBJECT_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=subject_ids or None,
                 **http_audit_fields(request, e),
             )
         )
         raise
+
+    subject_ids = [
+        detail.subject_id
+        for respondent in respondents
+        if respondent.details
+        for detail in respondent.details
+    ]
 
     await log(
         AuditEvent(
             user_id=user.id,
             event_action=EventAction.APPLET_SUBJECT_VIEW,
             curious_applet_id=[applet_id],
+            curious_subject_id=subject_ids or None,
             **http_audit_fields(request),
         )
     )
@@ -505,6 +536,7 @@ async def workspace_applet_get_respondent(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> Response[RespondentInfoPublic]:
+    respondent_info: RespondentInfoPublic | None = None
     try:
         await AppletService(session, user.id).exist_by_id(applet_id)
         await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
@@ -525,6 +557,7 @@ async def workspace_applet_get_respondent(
                 user_id=user.id,
                 event_action=EventAction.APPLET_SUBJECT_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=respondent_info and [respondent_info.subject_id],
                 **http_audit_fields(request, e),
             )
         )

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -244,6 +244,7 @@ async def workspace_respondents_list(
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
     respondents: list[WorkspaceRespondent] = []
+    applet_ids: list[uuid.UUID] = []
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -267,14 +268,26 @@ async def workspace_respondents_list(
         subject_ids = [
             r_detail.subject_id for respondent in respondents if respondent.details for r_detail in respondent.details
         ]
-        await log(
-            AuditEvent(
-                user_id=user.id,
-                event_action=EventAction.APPLET_SUBJECT_VIEW,
-                curious_subject_id=subject_ids or None,
-                **http_audit_fields(request, e),
+        if applet_ids:
+            for applet_id in set(applet_ids):
+                await log(
+                    AuditEvent(
+                        user_id=user.id,
+                        event_action=EventAction.APPLET_SUBJECT_VIEW,
+                        curious_applet_id=[applet_id],
+                        curious_subject_id=subject_ids or None,
+                        **http_audit_fields(request, e),
+                    )
+                )
+        else:
+            await log(
+                AuditEvent(
+                    user_id=user.id,
+                    event_action=EventAction.APPLET_SUBJECT_VIEW,
+                    curious_subject_id=subject_ids or None,
+                    **http_audit_fields(request, e),
+                )
             )
-        )
         raise
 
     subjects_by_applet: dict[uuid.UUID, list[uuid.UUID]] = {}

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -34,6 +34,7 @@ from apps.workspaces.domain.workspace import (
     PublicWorkspaceRespondent,
     WorkspaceAppletPublic,
     WorkspacePrioritizedRole,
+    WorkspaceRespondent,
     WorkspaceSearchAppletPublic,
 )
 from apps.workspaces.filters import WorkspaceUsersQueryParams
@@ -242,7 +243,7 @@ async def workspace_respondents_list(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
-    respondents = []
+    respondents: list[WorkspaceRespondent] = []
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -256,7 +257,7 @@ async def workspace_respondents_list(
         respondents = await InvitationsService(session, user).fill_pending_invitations_respondents(respondents)
 
         applet_ids = [
-            detail.applet_id for respondent in respondents if respondent.details for detail in respondent.details
+            r_detail.applet_id for respondent in respondents if respondent.details for r_detail in respondent.details
         ]
 
         accesses = await AppletAccessService(session).get_applet_accesses(applet_ids=applet_ids, user_id=user.id)
@@ -264,10 +265,7 @@ async def workspace_respondents_list(
         reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
     except BaseError as e:
         subject_ids = [
-            detail.subject_id
-            for respondent in respondents
-            if respondent.details
-            for detail in respondent.details
+            r_detail.subject_id for respondent in respondents if respondent.details for r_detail in respondent.details
         ]
         await log(
             AuditEvent(
@@ -282,8 +280,8 @@ async def workspace_respondents_list(
     subjects_by_applet: dict[uuid.UUID, list[uuid.UUID]] = {}
     for respondent in respondents:
         if respondent.details:
-            for detail in respondent.details:
-                subjects_by_applet.setdefault(detail.applet_id, []).append(detail.subject_id)
+            for r_detail in respondent.details:
+                subjects_by_applet.setdefault(r_detail.applet_id, []).append(r_detail.subject_id)
 
     for applet_id in set(applet_ids):
         await log(
@@ -322,7 +320,7 @@ async def workspace_applet_respondents_list(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session_by_owner_id),
 ) -> ResponseMultiOrdering[PublicWorkspaceRespondent]:
-    respondents = []
+    respondents: list[WorkspaceRespondent] = []
     try:
         service = WorkspaceService(session, user.id)
         await service.exists_by_owner_id(owner_id)
@@ -342,10 +340,7 @@ async def workspace_applet_respondents_list(
         reviewer_access = next((access for access in accesses if access.role == Role.REVIEWER), None)
     except BaseError as e:
         subject_ids = [
-            detail.subject_id
-            for respondent in respondents
-            if respondent.details
-            for detail in respondent.details
+            r_detail.subject_id for respondent in respondents if respondent.details for r_detail in respondent.details
         ]
         await log(
             AuditEvent(
@@ -359,10 +354,7 @@ async def workspace_applet_respondents_list(
         raise
 
     subject_ids = [
-        detail.subject_id
-        for respondent in respondents
-        if respondent.details
-        for detail in respondent.details
+        r_detail.subject_id for respondent in respondents if respondent.details for r_detail in respondent.details
     ]
 
     await log(

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -1,0 +1,164 @@
+import http
+import uuid
+
+from pytest_mock import MockerFixture
+
+from apps.applets.domain.applet_full import AppletFull
+from apps.audit import EventAction, EventOutcome
+from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
+from apps.subjects.domain import Subject
+from apps.users import User
+
+
+class TestWorkspacesAudit(BaseTest):
+    fixtures = [
+        "folders/fixtures/folders.json",
+        "invitations/fixtures/invitations.json",
+        "workspaces/fixtures/workspaces.json",
+        "folders/fixtures/folders_applet.json",
+    ]
+
+    workspace_respondents_url = "/workspaces/{owner_id}/respondents"
+    workspace_applet_respondents_list = "/workspaces/{owner_id}/applets/{applet_id}/respondents"
+    workspace_get_applet_respondent = "/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}"
+
+    async def test_workspace_respondents_list_audit_success_emits_event_per_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        applet_two: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.get(self.workspace_respondents_url.format(owner_id=tom.id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        assert audit_log.await_count >= 1
+        events = [call.args[0] for call in audit_log.call_args_list]
+        for event in events:
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+            assert event.event_outcome == EventOutcome.SUCCESS
+            assert event.curious_applet_id is not None
+            assert len(event.curious_applet_id) == 1
+
+        applet_ids = {event.curious_applet_id[0] for event in events}
+        assert applet_one.id in applet_ids
+        assert applet_two.id in applet_ids
+
+    async def test_workspace_respondents_list_audit_failure_single_event(
+        self,
+        client: TestClient,
+        lucy: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(lucy)
+
+        missing_owner_id = uuid.uuid4()
+        response = await client.get(self.workspace_respondents_url.format(owner_id=missing_owner_id))
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+
+    async def test_workspace_applet_respondents_list_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.workspace_applet_respondents_list.format(owner_id=tom.id, applet_id=applet_one.id)
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_workspace_applet_respondents_list_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        missing_owner_id = uuid.uuid4()
+        response = await client.get(
+            self.workspace_applet_respondents_list.format(owner_id=missing_owner_id, applet_id=applet_one.id)
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_workspace_applet_get_respondent_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.get(
+            self.workspace_get_applet_respondent.format(owner_id=tom.id, applet_id=applet_one.id, respondent_id=tom.id)
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.curious_subject_id == [tom_applet_one_subject.id]
+
+    async def test_workspace_applet_get_respondent_audit_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        missing_respondent_id = uuid.uuid4()
+        response = await client.get(
+            self.workspace_get_applet_respondent.format(
+                owner_id=tom.id, applet_id=applet_one.id, respondent_id=missing_respondent_id
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -45,6 +45,8 @@ class TestWorkspacesAudit(BaseTest):
             assert event.event_outcome == EventOutcome.SUCCESS
             assert event.curious_applet_id is not None
             assert len(event.curious_applet_id) == 1
+            assert event.curious_subject_id is not None
+            assert len(event.curious_subject_id) > 0
 
         applet_ids = {event.curious_applet_id[0] for event in events}
         assert applet_one.id in applet_ids
@@ -74,6 +76,7 @@ class TestWorkspacesAudit(BaseTest):
         client: TestClient,
         tom: User,
         applet_one: AppletFull,
+        tom_applet_one_subject: Subject,
         mocker: MockerFixture,
     ):
         audit_log = mocker.patch("apps.workspaces.api.log")
@@ -90,6 +93,8 @@ class TestWorkspacesAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_one.id]
+        assert event.curious_subject_id is not None
+        assert tom_applet_one_subject.id in event.curious_subject_id
 
     async def test_workspace_applet_respondents_list_audit_failure(
         self,


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10700](https://mindlogger.atlassian.net/browse/M2-10700)

Instruments audit log events for data access endpoints. Covers subject views, answer views, assessment/identifier views, note views, and answer exports.

Changes include:

- `applet:subject:view` — fired on `GET /subjects/{subject_id}`, `GET /subjects/me`, and `GET /workspaces/{owner_id}/respondents` (and related respondent-detail endpoints)
- `applet:answer:view` — fired on activity answer list, flow submission list, single activity answer retrieve, and single flow submission retrieve
- `applet:answer:assessment:view` — fired on answer reviews, activity assessment, submission assessment, and submission reviews endpoints
- `applet:answer:identifier:view` — fired on activity identifiers and flow identifiers endpoints
- `applet:answer:note:view` — fired on answer note list and submission note list endpoints
- `applet:answer:export` — fired on `GET /answers/applet/{applet_id}/data`; `curious_answer_id` is populated with all exported answer IDs on success

All events include `curious_applet_id`. Where applicable, `curious_answer_id` is included. Failure path logs the event before re-raising the exception so errors are always captured.

Tests added for each handler (success + failure paths), 26 total across `subjects/tests/test_audit.py`, `workspaces/tests/test_audit.py`, and `answers/tests/test_audit.py`.

### ✏️ Notes

Builds on top of `feat/audit-log-export` (the audit infrastructure PR). This branch should be merged after that one.