### PR TITLE
feat: Add applet IAM audit event logging

### DIFF
--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -254,7 +254,7 @@ async def applet_set_report_configuration(
     except BaseError as e:
         await log(
             AuditEvent(
-                event_action=EventAction.APPLET_REPORT_CONFIGURATION_CHANGE,
+                event_action=EventAction.APPLET_REPORT_UPDATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
                 **http_audit_fields(request, e),
@@ -264,7 +264,7 @@ async def applet_set_report_configuration(
 
     await log(
         AuditEvent(
-            event_action=EventAction.APPLET_REPORT_CONFIGURATION_CHANGE,
+            event_action=EventAction.APPLET_REPORT_UPDATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
             **http_audit_fields(request),
@@ -514,7 +514,7 @@ async def applet_set_data_retention(
     except BaseError as e:
         await log(
             AuditEvent(
-                event_action=EventAction.APPLET_DATA_RETENTION_CHANGE,
+                event_action=EventAction.APPLET_RETENTION_UPDATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
                 **http_audit_fields(request, e),
@@ -524,7 +524,7 @@ async def applet_set_data_retention(
 
     await log(
         AuditEvent(
-            event_action=EventAction.APPLET_DATA_RETENTION_CHANGE,
+            event_action=EventAction.APPLET_RETENTION_UPDATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
             **http_audit_fields(request),

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -36,9 +36,9 @@ from apps.applets.domain.base import Encryption
 from apps.applets.filters import AppletQueryParams, FlowItemHistoryExportQueryParams
 from apps.applets.service import AppletHistoryService, AppletService
 from apps.applets.service.applet_history import retrieve_applet_by_version, retrieve_versions
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.shared.domain.response import Response, ResponseMulti
-from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.shared.exception import BaseError, NotFoundError
 from apps.shared.link import convert_link_key
 from apps.shared.query_params import QueryParams, parse_query_params

--- a/src/apps/applets/api/applets.py
+++ b/src/apps/applets/api/applets.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 from fastapi import Body, Depends
 from firebase_admin.exceptions import FirebaseError
+from starlette.requests import Request
 from starlette.responses import Response as HTTPResponse
 
 from apps.activities.crud import ActivitiesCRUD
@@ -37,7 +38,8 @@ from apps.applets.service import AppletHistoryService, AppletService
 from apps.applets.service.applet_history import retrieve_applet_by_version, retrieve_versions
 from apps.authentication.deps import get_current_user
 from apps.shared.domain.response import Response, ResponseMulti
-from apps.shared.exception import NotFoundError
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
+from apps.shared.exception import BaseError, NotFoundError
 from apps.shared.link import convert_link_key
 from apps.shared.query_params import QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
@@ -124,17 +126,37 @@ async def applet_retrieve_by_key(
 
 async def applet_create(
     owner_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     schema: AppletCreate = Body(...),
     session=Depends(get_session),
 ) -> Response[public_detail.Applet]:
-    async with atomic(session):
-        await CheckAccessService(session, user.id).check_applet_create_access(owner_id)
-        has_editor = await UserAppletAccessCRUD(session).check_access_by_user_and_owner(
-            user_id=user.id, owner_id=owner_id, roles=[Role.EDITOR]
+    try:
+        async with atomic(session):
+            await CheckAccessService(session, user.id).check_applet_create_access(owner_id)
+            has_editor = await UserAppletAccessCRUD(session).check_access_by_user_and_owner(
+                user_id=user.id, owner_id=owner_id, roles=[Role.EDITOR]
+            )
+            manager_role = Role.EDITOR if has_editor else None
+            applet = await AppletService(session, owner_id).create(schema, user.id, manager_role)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_CREATE,
+                user_id=user.id,
+                **http_audit_fields(request, e),
+            )
         )
-        manager_role = Role.EDITOR if has_editor else None
-        applet = await AppletService(session, owner_id).create(schema, user.id, manager_role)
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_CREATE,
+            user_id=user.id,
+            curious_applet_id=[applet.id],
+            **http_audit_fields(request),
+        )
+    )
     return Response(result=public_detail.Applet.model_validate(applet))
 
 
@@ -165,15 +187,36 @@ async def applet_update(
 
 async def applet_encryption_update(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     schema: Encryption = Body(...),
     session=Depends(get_session),
 ) -> Response[public_detail.Encryption]:
-    async with atomic(session):
-        service = AppletService(session, user.id)
-        await service.exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_edit_access(applet_id)
-        await service.update_encryption(applet_id, schema)
+    try:
+        async with atomic(session):
+            service = AppletService(session, user.id)
+            await service.exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_edit_access(applet_id)
+            await service.update_encryption(applet_id, schema)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_ENCRYPTION_UPDATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_ENCRYPTION_UPDATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
     return Response(result=public_detail.Encryption.model_validate(schema))
 
 
@@ -197,15 +240,36 @@ async def applet_duplicate(
 
 async def applet_set_report_configuration(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     schema: AppletReportConfiguration = Body(...),
     session=Depends(get_session),
 ):
-    async with atomic(session):
-        service = AppletService(session, user.id)
-        await service.exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_edit_access(applet_id)
-        await service.set_report_configuration(applet_id, schema)
+    try:
+        async with atomic(session):
+            service = AppletService(session, user.id)
+            await service.exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_edit_access(applet_id)
+            await service.set_report_configuration(applet_id, schema)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_REPORT_CONFIGURATION_CHANGE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_REPORT_CONFIGURATION_CHANGE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def flow_report_config_update(
@@ -331,15 +395,36 @@ async def applet_version_changes_retrieve(
 
 async def applet_delete(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
-    async with atomic(session):
-        service = AppletService(session, user.id)
-        await service.exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_delete_access(applet_id)
-        respondents_device_ids = await AppletsCRUD(session).get_respondents_device_ids(applet_id)
-        await service.delete_applet_by_id(applet_id)
+    try:
+        async with atomic(session):
+            service = AppletService(session, user.id)
+            await service.exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_delete_access(applet_id)
+            respondents_device_ids = await AppletsCRUD(session).get_respondents_device_ids(applet_id)
+            await service.delete_applet_by_id(applet_id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_DELETE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_DELETE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
     try:
         await service.send_notification_to_applet_respondents(
             applet_id,
@@ -415,15 +500,36 @@ async def applet_link_delete(
 
 async def applet_set_data_retention(
     applet_id: uuid.UUID,
+    request: Request,
     schema: AppletDataRetention,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
-    async with atomic(session):
-        service = AppletService(session, user.id)
-        await service.exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_retention_access(applet_id)
-        await service.set_data_retention(applet_id, schema)
+    try:
+        async with atomic(session):
+            service = AppletService(session, user.id)
+            await service.exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_retention_access(applet_id)
+            await service.set_data_retention(applet_id, schema)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_DATA_RETENTION_CHANGE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_DATA_RETENTION_CHANGE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def applet_retrieve_base_info(

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -34,6 +34,7 @@ from apps.shared.test.client import TestClient
 from apps.subjects.domain import Subject
 from apps.users.domain import User
 from apps.workspaces.domain.constants import Role
+from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.errors import AppletCreationAccessDenied, AppletEncryptionUpdateDenied
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
 from infrastructure.utility.notification_client import FCMNotificationTest
@@ -1366,3 +1367,150 @@ class TestApplet:
         assert response.status_code == http.HTTPStatus.OK, response.json()
         data = response.json()["result"]
         assert data["displayName"] == "Updated Name"
+
+    # ── Audit event tests ──
+
+    async def test_create_applet_audit_event(
+        self, client: TestClient, tom: User, applet_minimal_data: AppletCreate, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        response = await client.post(
+            self.applet_create_url.format(owner_id=tom.id),
+            data=applet_minimal_data,
+        )
+        assert response.status_code == http.HTTPStatus.CREATED
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_CREATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [uuid.UUID(response.json()["result"]["id"])]
+
+    async def test_create_applet_audit_event_failure(
+        self, client: TestClient, lucy: User, bob: User, applet_minimal_data: AppletCreate, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(lucy)
+        response = await client.post(
+            self.applet_create_url.format(owner_id=bob.id),
+            data=applet_minimal_data,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_CREATE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == lucy.id
+
+    async def test_delete_applet_audit_event(
+        self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        response = await client.delete(
+            self.applet_detail_url.format(pk=applet_one.id),
+        )
+        assert response.status_code == http.HTTPStatus.NO_CONTENT
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_DELETE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_delete_applet_audit_event_failure(
+        self, client: TestClient, tom: User, uuid_zero: uuid.UUID, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        response = await client.delete(
+            self.applet_detail_url.format(pk=uuid_zero),
+        )
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_DELETE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id
+
+    async def test_encryption_update_audit_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one_no_encryption: AppletFull,
+        encryption: Encryption,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        response = await client.post(
+            self.applet_set_encryption_url.format(pk=applet_one_no_encryption.id),
+            data=encryption,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_ENCRYPTION_UPDATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one_no_encryption.id]
+
+    async def test_encryption_update_audit_event_failure(
+        self, client: TestClient, tom: User, applet_one: AppletFull, encryption: Encryption, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        response = await client.post(
+            self.applet_set_encryption_url.format(pk=applet_one.id),
+            data=encryption,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_ENCRYPTION_UPDATE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id
+
+    async def test_report_configuration_audit_event(
+        self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        report_configuration = dict(
+            report_server_ip="ipaddress",
+            report_public_key="public key",
+            report_recipients=["recipient1"],
+            report_include_user_id=True,
+            report_include_case_id=True,
+            report_email_body="body",
+        )
+        response = await client.post(
+            self.applet_report_config_url.format(pk=applet_one.id),
+            report_configuration,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_REPORT_CONFIGURATION_CHANGE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_data_retention_audit_event(
+        self, client: TestClient, tom: User, applet_one: AppletFull, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.applets.api.applets.log")
+        client.login(tom)
+        data_retention = dict(period=30, retention="days")
+        response = await client.post(
+            f"{self.applet_list_url}/{applet_one.id}/retentions",
+            data_retention,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_DATA_RETENTION_CHANGE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -1492,7 +1492,7 @@ class TestApplet:
         assert response.status_code == http.HTTPStatus.OK
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_REPORT_CONFIGURATION_CHANGE
+        assert event.event_action == EventAction.APPLET_REPORT_UPDATE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
@@ -1510,7 +1510,7 @@ class TestApplet:
         assert response.status_code == http.HTTPStatus.OK
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_DATA_RETENTION_CHANGE
+        assert event.event_action == EventAction.APPLET_RETENTION_UPDATE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/applets/tests/test_applet.py
+++ b/src/apps/applets/tests/test_applet.py
@@ -28,13 +28,13 @@ from apps.applets.domain.applet_full import AppletFull
 from apps.applets.domain.base import AppletReportConfigurationBase, Encryption
 from apps.applets.errors import AppletAlreadyExist, AppletVersionNotFoundError
 from apps.applets.service.applet import AppletService
+from apps.audit.enums import EventAction, EventOutcome
 from apps.shared.enums import Language
 from apps.shared.exception import NotFoundError
 from apps.shared.test.client import TestClient
 from apps.subjects.domain import Subject
 from apps.users.domain import User
 from apps.workspaces.domain.constants import Role
-from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.errors import AppletCreationAccessDenied, AppletEncryptionUpdateDenied
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
 from infrastructure.utility.notification_client import FCMNotificationTest

--- a/src/apps/audit/constants.py
+++ b/src/apps/audit/constants.py
@@ -30,6 +30,10 @@ EVENT_ACTION_TO_EVENT_CATEGORY: dict[EventAction, tuple[EventCategory, ...]] = {
     EventAction.APPLET_INVITE_INITIATE: (EventCategory.IAM,),
     EventAction.APPLET_INVITE_ACCEPT: (EventCategory.IAM,),
     EventAction.APPLET_INVITE_DECLINE: (EventCategory.IAM,),
+    EventAction.APPLET_MEMBER_REMOVE: (EventCategory.IAM,),
+    EventAction.APPLET_MEMBER_ROLE_CHANGE: (EventCategory.IAM,),
+    EventAction.APPLET_DATA_RETENTION_CHANGE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_REPORT_CONFIGURATION_CHANGE: (EventCategory.IAM, EventCategory.CONFIGURATION),
     # Applet data access
     EventAction.APPLET_SUBJECT_VIEW: (EventCategory.DATABASE,),
     EventAction.APPLET_ANSWER_VIEW: (EventCategory.DATABASE,),
@@ -75,6 +79,10 @@ EVENT_ACTION_TO_EVENT_TYPE: dict[EventAction, tuple[EventType, ...]] = {
     EventAction.APPLET_INVITE_INITIATE: (EventType.INFO,),
     EventAction.APPLET_INVITE_ACCEPT: (EventType.CHANGE,),
     EventAction.APPLET_INVITE_DECLINE: (EventType.INFO,),
+    EventAction.APPLET_MEMBER_REMOVE: (EventType.DELETION,),
+    EventAction.APPLET_MEMBER_ROLE_CHANGE: (EventType.CHANGE,),
+    EventAction.APPLET_DATA_RETENTION_CHANGE: (EventType.CHANGE,),
+    EventAction.APPLET_REPORT_CONFIGURATION_CHANGE: (EventType.CHANGE,),
     # Applet data access
     EventAction.APPLET_SUBJECT_VIEW: (EventType.ACCESS,),
     EventAction.APPLET_ANSWER_VIEW: (EventType.ACCESS,),

--- a/src/apps/audit/constants.py
+++ b/src/apps/audit/constants.py
@@ -17,9 +17,6 @@ EVENT_ACTION_TO_EVENT_CATEGORY: dict[EventAction, tuple[EventCategory, ...]] = {
     EventAction.USER_MFA_RECOVERY_VIEW: (EventCategory.IAM,),
     EventAction.USER_MFA_RECOVERY_DOWNLOAD: (EventCategory.IAM,),
     EventAction.USER_MFA_RECOVERY_USE: (EventCategory.IAM,),
-    # Workspace IAM
-    EventAction.WORKSPACE_ACCESS_GRANT: (EventCategory.IAM,),
-    EventAction.WORKSPACE_ACCESS_REVOKE: (EventCategory.IAM,),
     # Applet IAM
     EventAction.APPLET_CREATE: (EventCategory.IAM, EventCategory.CONFIGURATION),
     EventAction.APPLET_DELETE: (EventCategory.IAM, EventCategory.CONFIGURATION),
@@ -30,10 +27,10 @@ EVENT_ACTION_TO_EVENT_CATEGORY: dict[EventAction, tuple[EventCategory, ...]] = {
     EventAction.APPLET_INVITE_INITIATE: (EventCategory.IAM,),
     EventAction.APPLET_INVITE_ACCEPT: (EventCategory.IAM,),
     EventAction.APPLET_INVITE_DECLINE: (EventCategory.IAM,),
-    EventAction.APPLET_MEMBER_REMOVE: (EventCategory.IAM,),
-    EventAction.APPLET_MEMBER_ROLE_CHANGE: (EventCategory.IAM,),
-    EventAction.APPLET_DATA_RETENTION_CHANGE: (EventCategory.IAM, EventCategory.CONFIGURATION),
-    EventAction.APPLET_REPORT_CONFIGURATION_CHANGE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_ACCESS_GRANT: (EventCategory.IAM,),
+    EventAction.APPLET_ACCESS_REVOKE: (EventCategory.IAM,),
+    EventAction.APPLET_RETENTION_UPDATE: (EventCategory.IAM, EventCategory.CONFIGURATION),
+    EventAction.APPLET_REPORT_UPDATE: (EventCategory.IAM, EventCategory.CONFIGURATION),
     # Applet data access
     EventAction.APPLET_SUBJECT_VIEW: (EventCategory.DATABASE,),
     EventAction.APPLET_ANSWER_VIEW: (EventCategory.DATABASE,),
@@ -66,9 +63,6 @@ EVENT_ACTION_TO_EVENT_TYPE: dict[EventAction, tuple[EventType, ...]] = {
     EventAction.USER_MFA_RECOVERY_VIEW: (EventType.ACCESS,),
     EventAction.USER_MFA_RECOVERY_DOWNLOAD: (EventType.ACCESS,),
     EventAction.USER_MFA_RECOVERY_USE: (EventType.CHANGE,),
-    # Workspace IAM
-    EventAction.WORKSPACE_ACCESS_GRANT: (EventType.CHANGE,),
-    EventAction.WORKSPACE_ACCESS_REVOKE: (EventType.CHANGE,),
     # Applet IAM
     EventAction.APPLET_CREATE: (EventType.CREATION,),
     EventAction.APPLET_DELETE: (EventType.DELETION,),
@@ -79,10 +73,10 @@ EVENT_ACTION_TO_EVENT_TYPE: dict[EventAction, tuple[EventType, ...]] = {
     EventAction.APPLET_INVITE_INITIATE: (EventType.INFO,),
     EventAction.APPLET_INVITE_ACCEPT: (EventType.CHANGE,),
     EventAction.APPLET_INVITE_DECLINE: (EventType.INFO,),
-    EventAction.APPLET_MEMBER_REMOVE: (EventType.DELETION,),
-    EventAction.APPLET_MEMBER_ROLE_CHANGE: (EventType.CHANGE,),
-    EventAction.APPLET_DATA_RETENTION_CHANGE: (EventType.CHANGE,),
-    EventAction.APPLET_REPORT_CONFIGURATION_CHANGE: (EventType.CHANGE,),
+    EventAction.APPLET_ACCESS_GRANT: (EventType.CHANGE,),
+    EventAction.APPLET_ACCESS_REVOKE: (EventType.CHANGE,),
+    EventAction.APPLET_RETENTION_UPDATE: (EventType.CHANGE,),
+    EventAction.APPLET_REPORT_UPDATE: (EventType.CHANGE,),
     # Applet data access
     EventAction.APPLET_SUBJECT_VIEW: (EventType.ACCESS,),
     EventAction.APPLET_ANSWER_VIEW: (EventType.ACCESS,),

--- a/src/apps/audit/enums.py
+++ b/src/apps/audit/enums.py
@@ -33,10 +33,6 @@ class EventAction(StrEnum):
     USER_MFA_RECOVERY_DOWNLOAD = "user:mfa:recovery:download"
     USER_MFA_RECOVERY_USE = "user:mfa:recovery:use"
 
-    # Workspace IAM
-    WORKSPACE_ACCESS_GRANT = "workspace:access:grant"
-    WORKSPACE_ACCESS_REVOKE = "workspace:access:revoke"
-
     # Applet IAM
     APPLET_CREATE = "applet:create"
     APPLET_DELETE = "applet:delete"
@@ -47,10 +43,10 @@ class EventAction(StrEnum):
     APPLET_INVITE_INITIATE = "applet:invite:initiate"
     APPLET_INVITE_ACCEPT = "applet:invite:accept"
     APPLET_INVITE_DECLINE = "applet:invite:decline"
-    APPLET_MEMBER_REMOVE = "applet:member:remove"
-    APPLET_MEMBER_ROLE_CHANGE = "applet:member:role:change"
-    APPLET_DATA_RETENTION_CHANGE = "applet:retention:update"
-    APPLET_REPORT_CONFIGURATION_CHANGE = "applet:report:update"
+    APPLET_ACCESS_GRANT = "applet:access:grant"
+    APPLET_ACCESS_REVOKE = "applet:access:revoke"
+    APPLET_RETENTION_UPDATE = "applet:retention:update"
+    APPLET_REPORT_UPDATE = "applet:report:update"
 
     # Applet data access
     APPLET_SUBJECT_VIEW = "applet:subject:view"

--- a/src/apps/audit/enums.py
+++ b/src/apps/audit/enums.py
@@ -47,6 +47,10 @@ class EventAction(StrEnum):
     APPLET_INVITE_INITIATE = "applet:invite:initiate"
     APPLET_INVITE_ACCEPT = "applet:invite:accept"
     APPLET_INVITE_DECLINE = "applet:invite:decline"
+    APPLET_MEMBER_REMOVE = "applet:member:remove"
+    APPLET_MEMBER_ROLE_CHANGE = "applet:member:role:change"
+    APPLET_DATA_RETENTION_CHANGE = "applet:retention:update"
+    APPLET_REPORT_CONFIGURATION_CHANGE = "applet:report:update"
 
     # Applet data access
     APPLET_SUBJECT_VIEW = "applet:subject:view"

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -274,7 +274,8 @@ async def invitation_accept(
     try:
         invitation_service = InvitationsService(session, user)
         invitation = await invitation_service.get(key)
-        applet_id = invitation.applet_id
+        if invitation:
+            applet_id = invitation.applet_id
 
         try:
             async with atomic(session):
@@ -339,7 +340,8 @@ async def private_invitation_accept(
     try:
         private_service = PrivateInvitationService(session)
         invitation = await private_service.get_invitation(key)
-        applet_id = invitation.applet_id
+        if invitation:
+            applet_id = invitation.applet_id
 
         async with atomic(session):
             await private_service.accept_invitation(user, key)
@@ -375,7 +377,8 @@ async def invitation_decline(
     try:
         invitation_service = InvitationsService(session, user)
         invitation = await invitation_service.get(key)
-        applet_id = invitation.applet_id
+        if invitation:
+            applet_id = invitation.applet_id
 
         async with atomic(session):
             await invitation_service.decline(key)

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -113,6 +113,8 @@ async def invitation_respondent_send(
                 if is_role_exist:
                     raise RespondentInvitationExist()
             except UserNotFound:
+                # Inviting an email that is not yet associated with a user is valid.
+                # Continue flow to create subject and send invitation.
                 pass
 
             subject_service = SubjectsService(session, user.id)
@@ -177,7 +179,9 @@ async def invitation_reviewer_send(
                 if is_role_exist:
                     raise ManagerInvitationExist()
             except UserNotFound:
-                pass
+                # Inviting by email is allowed even if the user does not exist yet.
+                # Continue so the invitation can be created for later acceptance/registration.
+                invited_user = None
 
             invitation: InvitationDetailForReviewer = await invitation_srv.send_reviewer_invitation(
                 applet_id, invitation_schema
@@ -234,6 +238,8 @@ async def invitation_managers_send(
                 if is_role_exist:
                     raise ManagerInvitationExist()
             except UserNotFound:
+                # Inviting emails that are not yet associated with a user is allowed.
+                # In this case there is no existing user-role assignment to validate.
                 pass
 
             invitation = await invitation_srv.send_managers_invitation(applet_id, invitation_schema)
@@ -432,6 +438,7 @@ async def invitation_subject_send(
                 if is_role_exist:
                     raise RespondentInvitationExist()
             except UserNotFound:
+                # Expected: invitee may not have an account yet; proceed with invitation flow.
                 pass
 
             invitation_schema = InvitationRespondentRequest(

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 from apps.answers.deps.preprocess_arbitrary import get_answer_session, preprocess_arbitrary_url
 from apps.answers.service import AnswerService
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.invitations.domain import (
     InvitationDetailForReviewer,
@@ -31,7 +32,6 @@ from apps.invitations.errors import (
 )
 from apps.invitations.filters import InvitationQueryParams
 from apps.invitations.services import InvitationsService, PrivateInvitationService
-from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.shared.domain import Response, ResponseMulti
 from apps.shared.exception import BaseError, NotFoundError, ValidationError
 from apps.shared.query_params import QueryParams, parse_query_params

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 
 from fastapi import Body, Depends
+from starlette.requests import Request
 
 from apps.answers.deps.preprocess_arbitrary import get_answer_session, preprocess_arbitrary_url
 from apps.answers.service import AnswerService
@@ -30,8 +31,9 @@ from apps.invitations.errors import (
 )
 from apps.invitations.filters import InvitationQueryParams
 from apps.invitations.services import InvitationsService, PrivateInvitationService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.shared.domain import Response, ResponseMulti
-from apps.shared.exception import NotFoundError, ValidationError
+from apps.shared.exception import BaseError, NotFoundError, ValidationError
 from apps.shared.query_params import QueryParams, parse_query_params
 from apps.subjects.domain import SubjectCreate
 from apps.subjects.errors import SecretIDUniqueViolationError
@@ -88,6 +90,7 @@ async def private_invitation_retrieve(
 
 async def invitation_respondent_send(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     invitation_schema: InvitationRespondentRequest = Body(...),
     session=Depends(get_session),
@@ -97,33 +100,61 @@ async def invitation_respondent_send(
     for the concrete user giving him a role "respondent".
     """
 
-    async with atomic(session):
-        await AppletService(session, user.id).exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
-        invitation_service = InvitationsService(session, user)
-        try:
-            invited_user = await UserService(session).get_by_email(invitation_schema.email)
-            is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(Role.RESPONDENT)
-            if is_role_exist:
-                raise RespondentInvitationExist()
-        except UserNotFound:
-            pass
+    try:
+        async with atomic(session):
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+            invitation_service = InvitationsService(session, user)
+            try:
+                invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+                    Role.RESPONDENT
+                )
+                if is_role_exist:
+                    raise RespondentInvitationExist()
+            except UserNotFound:
+                pass
 
-        subject_service = SubjectsService(session, user.id)
-        try:
-            subject = await subject_service.create(
-                SubjectCreate(creator_id=user.id, applet_id=applet_id, **invitation_schema.model_dump(by_alias=False))
+            subject_service = SubjectsService(session, user.id)
+            try:
+                subject = await subject_service.create(
+                    SubjectCreate(
+                        creator_id=user.id, applet_id=applet_id, **invitation_schema.model_dump(by_alias=False)
+                    )
+                )
+            except SecretIDUniqueViolationError:
+                raise NonUniqueValue(loc=("body", InvitationRespondentRequest.field_alias("secret_user_id")))
+
+            invitation = await invitation_service.send_respondent_invitation(applet_id, invitation_schema, subject)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                user_target_email=invitation_schema.email,
+                user_target_roles=[Role.RESPONDENT],
+                **http_audit_fields(request, e),
             )
-        except SecretIDUniqueViolationError:
-            raise NonUniqueValue(loc=("body", InvitationRespondentRequest.field_alias("secret_user_id")))
+        )
+        raise
 
-        invitation = await invitation_service.send_respondent_invitation(applet_id, invitation_schema, subject)
-
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            user_target_email=invitation_schema.email,
+            user_target_roles=[Role.RESPONDENT],
+            **http_audit_fields(request),
+        )
+    )
     return Response[InvitationRespondentResponse](result=InvitationRespondentResponse(**invitation.model_dump()))
 
 
 async def invitation_reviewer_send(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     invitation_schema: InvitationReviewerRequest = Body(...),
     session=Depends(get_session),
@@ -133,27 +164,53 @@ async def invitation_reviewer_send(
     for the concrete user giving him role "reviewer" for specific respondents.
     """
 
-    async with atomic(session):
-        await AppletService(session, user.id).exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
-        invitation_srv = InvitationsService(session, user)
-        try:
-            invited_user = await UserService(session).get_by_email(invitation_schema.email)
-            is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(Role.REVIEWER)
-            if is_role_exist:
-                raise ManagerInvitationExist()
-        except UserNotFound:
-            pass
+    try:
+        async with atomic(session):
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+            invitation_srv = InvitationsService(session, user)
+            try:
+                invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+                    Role.REVIEWER
+                )
+                if is_role_exist:
+                    raise ManagerInvitationExist()
+            except UserNotFound:
+                pass
 
-        invitation: InvitationDetailForReviewer = await invitation_srv.send_reviewer_invitation(
-            applet_id, invitation_schema
+            invitation: InvitationDetailForReviewer = await invitation_srv.send_reviewer_invitation(
+                applet_id, invitation_schema
+            )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                user_target_email=invitation_schema.email,
+                user_target_roles=[Role.REVIEWER],
+                **http_audit_fields(request, e),
+            )
         )
+        raise
 
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            user_target_email=invitation_schema.email,
+            user_target_roles=[Role.REVIEWER],
+            **http_audit_fields(request),
+        )
+    )
     return Response[InvitationReviewerResponse](result=InvitationReviewerResponse(**invitation.model_dump()))
 
 
 async def invitation_managers_send(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     invitation_schema: InvitationManagersRequest = Body(...),
     session=Depends(get_session),
@@ -164,121 +221,250 @@ async def invitation_managers_send(
     "manager", "coordinator", "editor".
     """
 
-    async with atomic(session):
-        await AppletService(session, user.id).exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
-        invitation_srv = InvitationsService(session, user)
-        try:
-            invited_user = await UserService(session).get_by_email(invitation_schema.email)
-            is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
-                invitation_schema.role
+    try:
+        async with atomic(session):
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+            invitation_srv = InvitationsService(session, user)
+            try:
+                invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+                    invitation_schema.role
+                )
+                if is_role_exist:
+                    raise ManagerInvitationExist()
+            except UserNotFound:
+                pass
+
+            invitation = await invitation_srv.send_managers_invitation(applet_id, invitation_schema)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                user_target_email=invitation_schema.email,
+                user_target_roles=[invitation_schema.role],
+                **http_audit_fields(request, e),
             )
-            if is_role_exist:
-                raise ManagerInvitationExist()
-        except UserNotFound:
-            pass
+        )
+        raise
 
-        invitation = await invitation_srv.send_managers_invitation(applet_id, invitation_schema)
-
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            user_target_email=invitation_schema.email,
+            user_target_roles=[invitation_schema.role],
+            **http_audit_fields(request),
+        )
+    )
     return Response[InvitationManagersResponse](result=InvitationManagersResponse(**invitation.model_dump()))
 
 
 async def invitation_accept(
     key: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
     """General endpoint to approve the applet invitation."""
+    applet_id = None
     try:
-        async with atomic(session):
-            await InvitationsService(session, user).accept(key)
-    except InvitationSubjectAcceptError as e:
-        # subject applet_id-user_id exists. Check for deleted record
-        invitation = e.invitation
-        assert isinstance(invitation, InvitationDetailRespondent)
-        service = SubjectsService(session, user.id)
-        subject, existing_subject = await asyncio.gather(
-            service.get(uuid.UUID(invitation.meta.subject_id)),
-            service.get_by_user_and_applet(user.id, invitation.applet_id),
-        )
-        assert subject
-        if not existing_subject or existing_subject.is_deleted is not True:
-            raise
+        invitation_service = InvitationsService(session, user)
+        invitation = await invitation_service.get(key)
+        applet_id = invitation.applet_id
 
-        info = await preprocess_arbitrary_url(applet_id=invitation.applet_id, session=session)
-        async with asynccontextmanager(get_answer_session)(info) as answer_session:
+        try:
             async with atomic(session):
-                # remove existing pin of this user
-                await UserAppletAccessService(session, user.id, existing_subject.applet_id).unpin(
-                    pinned_user_id=existing_subject.user_id, pinned_subject_id=None
-                )
-                # remove user_id from deleted subject, accept invitation
-                await service.update(existing_subject.id, user_id=None)
-                await InvitationsService(session, user).accept(key)
+                await invitation_service.accept(key)
+        except InvitationSubjectAcceptError as e:
+            # subject applet_id-user_id exists. Check for deleted record
+            invitation_detail = e.invitation
+            assert isinstance(invitation_detail, InvitationDetailRespondent)
+            service = SubjectsService(session, user.id)
+            subject, existing_subject = await asyncio.gather(
+                service.get(uuid.UUID(invitation_detail.meta.subject_id)),
+                service.get_by_user_and_applet(user.id, invitation_detail.applet_id),
+            )
+            assert subject
+            if not existing_subject or existing_subject.is_deleted is not True:
+                raise
 
-                # move answers from deleted subject to the new one
-                async with atomic(answer_session):
-                    await AnswerService(
-                        session, user_id=user.id, arbitrary_session=answer_session
-                    ).replace_answer_subject(existing_subject.id, subject.id)
+            info = await preprocess_arbitrary_url(applet_id=invitation_detail.applet_id, session=session)
+            async with asynccontextmanager(get_answer_session)(info) as answer_session:
+                async with atomic(session):
+                    # remove existing pin of this user
+                    await UserAppletAccessService(session, user.id, existing_subject.applet_id).unpin(
+                        pinned_user_id=existing_subject.user_id, pinned_subject_id=None
+                    )
+                    # remove user_id from deleted subject, accept invitation
+                    await service.update(existing_subject.id, user_id=None)
+                    await invitation_service.accept(key)
+
+                    # move answers from deleted subject to the new one
+                    async with atomic(answer_session):
+                        await AnswerService(
+                            session, user_id=user.id, arbitrary_session=answer_session
+                        ).replace_answer_subject(existing_subject.id, subject.id)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_ACCEPT,
+                user_id=user.id,
+                curious_applet_id=[applet_id] if applet_id else None,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_ACCEPT,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def private_invitation_accept(
     key: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
-    async with atomic(session):
-        await PrivateInvitationService(session).accept_invitation(user, key)
+    applet_id = None
+    try:
+        private_service = PrivateInvitationService(session)
+        invitation = await private_service.get_invitation(key)
+        applet_id = invitation.applet_id
+
+        async with atomic(session):
+            await private_service.accept_invitation(user, key)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_ACCEPT,
+                user_id=user.id,
+                curious_applet_id=[applet_id] if applet_id else None,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_ACCEPT,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def invitation_decline(
     key: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
     """General endpoint to decline the applet invitation."""
-    async with atomic(session):
-        await InvitationsService(session, user).decline(key)
+    applet_id = None
+    try:
+        invitation_service = InvitationsService(session, user)
+        invitation = await invitation_service.get(key)
+        applet_id = invitation.applet_id
+
+        async with atomic(session):
+            await invitation_service.decline(key)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_DECLINE,
+                user_id=user.id,
+                curious_applet_id=[applet_id] if applet_id else None,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_DECLINE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def invitation_subject_send(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     schema: ShellAccountInvitation = Body(...),
     session=Depends(get_session),
 ) -> Response[InvitationRespondentResponse]:
-    async with atomic(session):
-        await AppletService(session, user.id).exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+    try:
+        async with atomic(session):
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
 
-        subject_service = SubjectsService(session, user.id)
-        subject = await subject_service.get_if_soft_exist(schema.subject_id)
-        if not subject:
-            raise NotFoundError()
-        if subject.user_id:
-            raise ValidationError("Subject already assigned.")
+            subject_service = SubjectsService(session, user.id)
+            subject = await subject_service.get_if_soft_exist(schema.subject_id)
+            if not subject:
+                raise NotFoundError()
+            if subject.user_id:
+                raise ValidationError("Subject already assigned.")
 
-        # check role exists
-        invitation_service = InvitationsService(session, user)
-        try:
-            invited_user = await UserService(session).get_by_email(schema.email)
-            is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(Role.RESPONDENT)
-            if is_role_exist:
-                raise RespondentInvitationExist()
-        except UserNotFound:
-            pass
+            # check role exists
+            invitation_service = InvitationsService(session, user)
+            try:
+                invited_user = await UserService(session).get_by_email(schema.email)
+                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+                    Role.RESPONDENT
+                )
+                if is_role_exist:
+                    raise RespondentInvitationExist()
+            except UserNotFound:
+                pass
 
-        invitation_schema = InvitationRespondentRequest(
-            email=schema.email,
-            first_name=subject.first_name,
-            last_name=subject.last_name,
-            language=schema.language or subject.language,
-            secret_user_id=subject.secret_user_id,
-            nickname=subject.nickname,
+            invitation_schema = InvitationRespondentRequest(
+                email=schema.email,
+                first_name=subject.first_name,
+                last_name=subject.last_name,
+                language=schema.language or subject.language,
+                secret_user_id=subject.secret_user_id,
+                nickname=subject.nickname,
+            )
+            invitation = await invitation_service.send_respondent_invitation(applet_id, invitation_schema, subject)
+            if subject.email != schema.email:
+                await subject_service.update(
+                    subject.id, email=schema.email, language=schema.language or subject.language
+                )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                user_target_email=schema.email,
+                user_target_roles=[Role.RESPONDENT],
+                **http_audit_fields(request, e),
+            )
         )
-        invitation = await invitation_service.send_respondent_invitation(applet_id, invitation_schema, subject)
-        if subject.email != schema.email:
-            await subject_service.update(subject.id, email=schema.email, language=schema.language or subject.language)
+        raise
 
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            user_target_email=schema.email,
+            user_target_roles=[Role.RESPONDENT],
+            **http_audit_fields(request),
+        )
+    )
     return Response[InvitationRespondentResponse](result=InvitationRespondentResponse(**invitation.model_dump()))

--- a/src/apps/invitations/router.py
+++ b/src/apps/invitations/router.py
@@ -27,7 +27,11 @@ from apps.invitations.domain import (
     PrivateInvitationResponse,
     ShellAccountCreateRequest,
 )
-from apps.shared.domain.response import DEFAULT_OPENAPI_RESPONSE, Response, ResponseMulti
+from apps.shared.domain.response import (
+    DEFAULT_OPENAPI_RESPONSE,
+    Response,
+    ResponseMulti,
+)
 from apps.shared.exception import BaseError
 from apps.subjects.api import create_subject
 from apps.subjects.domain import SubjectCreateRequest, SubjectCreateResponse
@@ -151,7 +155,9 @@ async def create_shell_account(
         result = await create_subject(
             user=user,
             session=session,
-            schema=SubjectCreateRequest(applet_id=applet_id, **subject_schema.model_dump(by_alias=False)),
+            schema=SubjectCreateRequest(
+                applet_id=applet_id, **subject_schema.model_dump(by_alias=False)
+            ),
         )
     except BaseError as e:
         await log(
@@ -159,6 +165,7 @@ async def create_shell_account(
                 event_action=EventAction.APPLET_INVITE_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
+                user_target_email=subject_schema.email,
                 user_target_roles=["shell-account"],
                 **http_audit_fields(request, e),
             )
@@ -170,6 +177,7 @@ async def create_shell_account(
             event_action=EventAction.APPLET_INVITE_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_email=subject_schema.email,
             user_target_roles=["shell-account"],
             **http_audit_fields(request),
         )

--- a/src/apps/invitations/router.py
+++ b/src/apps/invitations/router.py
@@ -7,7 +7,6 @@ from starlette.requests import Request
 
 from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
-from apps.shared.exception import BaseError
 from apps.invitations.api import (
     invitation_accept,
     invitation_decline,
@@ -29,6 +28,7 @@ from apps.invitations.domain import (
     ShellAccountCreateRequest,
 )
 from apps.shared.domain.response import DEFAULT_OPENAPI_RESPONSE, Response, ResponseMulti
+from apps.shared.exception import BaseError
 from apps.subjects.api import create_subject
 from apps.subjects.domain import SubjectCreateRequest, SubjectCreateResponse
 from apps.users.domain import User

--- a/src/apps/invitations/router.py
+++ b/src/apps/invitations/router.py
@@ -155,9 +155,7 @@ async def create_shell_account(
         result = await create_subject(
             user=user,
             session=session,
-            schema=SubjectCreateRequest(
-                applet_id=applet_id, **subject_schema.model_dump(by_alias=False)
-            ),
+            schema=SubjectCreateRequest(applet_id=applet_id, **subject_schema.model_dump(by_alias=False)),
         )
     except BaseError as e:
         await log(

--- a/src/apps/invitations/router.py
+++ b/src/apps/invitations/router.py
@@ -3,8 +3,11 @@ import uuid
 from fastapi import Body, Depends
 from fastapi.routing import APIRouter
 from starlette import status
+from starlette.requests import Request
 
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
+from apps.shared.exception import BaseError
 from apps.invitations.api import (
     invitation_accept,
     invitation_decline,
@@ -139,15 +142,39 @@ router.post("/private/{key}/accept")(private_invitation_accept)
 )
 async def create_shell_account(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     subject_schema: ShellAccountCreateRequest = Body(...),
     session=Depends(get_session),
 ):
-    return await create_subject(
-        user=user,
-        session=session,
-        schema=SubjectCreateRequest(applet_id=applet_id, **subject_schema.model_dump(by_alias=False)),
+    try:
+        result = await create_subject(
+            user=user,
+            session=session,
+            schema=SubjectCreateRequest(applet_id=applet_id, **subject_schema.model_dump(by_alias=False)),
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_INVITE_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                user_target_roles=["shell-account"],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_INVITE_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            user_target_roles=["shell-account"],
+            **http_audit_fields(request),
+        )
     )
+    return result
 
 
 # Send invitation to shell account

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -40,6 +40,7 @@ from apps.subjects.services import SubjectsService
 from apps.users import UserSchema
 from apps.users.domain import User, UserCreate, UserCreateRequest
 from apps.workspaces.domain.constants import UserPinRole
+from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.errors import AppletInviteAccessDenied
 from apps.workspaces.service.user_access import UserAccessService
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
@@ -1461,3 +1462,202 @@ class TestInvite(BaseTest):
         key = f"{email}_{applet_one.id}"
         assert key in results
         assert results[key].key == pending_key
+
+    async def test_invite_respondent_audit_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        invitation_respondent_data: InvitationRespondentRequest,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(tom)
+        response = await client.post(
+            self.invite_respondent_url.format(applet_id=str(applet_one.id)),
+            invitation_respondent_data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_email == invitation_respondent_data.email
+        assert event.user_target_roles == [Role.RESPONDENT]
+
+    async def test_invite_reviewer_audit_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        invitation_reviewer_data: InvitationReviewerRequest,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(tom)
+        response = await client.post(
+            self.invite_reviewer_url.format(applet_id=str(applet_one.id)),
+            invitation_reviewer_data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_email == invitation_reviewer_data.email
+        assert event.user_target_roles == [Role.REVIEWER]
+
+    async def test_invite_manager_audit_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        invitation_manager_data: InvitationManagersRequest,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(tom)
+        response = await client.post(
+            self.invite_manager_url.format(applet_id=str(applet_one.id)),
+            invitation_manager_data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_email == invitation_manager_data.email
+        assert event.user_target_roles == [invitation_manager_data.role]
+
+    async def test_invite_respondent_audit_event_failure(
+        self,
+        client: TestClient,
+        lucy: User,
+        applet_one: AppletFull,
+        invitation_respondent_data: InvitationRespondentRequest,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(lucy)
+        response = await client.post(
+            self.invite_respondent_url.format(applet_id=str(applet_one.id)),
+            invitation_respondent_data,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == lucy.id
+
+    async def test_invitation_accept_audit_event(
+        self,
+        session: AsyncSession,
+        client: TestClient,
+        lucy: User,
+        applet_one_lucy_roles: AppletFull,
+        applet_one: AppletFull,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(lucy)
+        response = await client.post(self.accept_url.format(key="6a3ab8e6-f2fa-49ae-b2db-197136677da6"))
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_ACCEPT
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_invitation_accept_audit_event_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(tom)
+        response = await client.post(self.accept_url.format(key=str(uuid.uuid4())))
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_ACCEPT
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id
+
+    async def test_private_invitation_accept_audit_event(
+        self,
+        client: TestClient,
+        lucy: User,
+        applet_one_with_link: AppletFull,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(lucy)
+        response = await client.post(self.accept_private_url.format(key=applet_one_with_link.link))
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_ACCEPT
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == lucy.id
+        assert event.curious_applet_id == [applet_one_with_link.id]
+
+    async def test_invitation_decline_audit_event(
+        self,
+        client: TestClient,
+        lucy: User,
+        applet_one: AppletFull,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(lucy)
+        response = await client.delete(self.decline_url.format(key="6a3ab8e6-f2fa-49ae-b2db-197136677da6"))
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_DECLINE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_invitation_decline_audit_event_failure(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        client.login(tom)
+        response = await client.delete(self.decline_url.format(key=str(uuid.uuid4())))
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_DECLINE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id
+
+    async def test_shell_create_account_audit_event(
+        self, client: TestClient, shell_create_data: dict, bob: User, applet_four: AppletFull, mocker
+    ):
+        audit_log = mocker.patch("apps.invitations.router.log")
+        client.login(bob)
+        response = await client.post(
+            self.shell_acc_create_url.format(applet_id=str(applet_four.id)),
+            shell_create_data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == bob.id
+        assert event.curious_applet_id == [applet_four.id]
+        assert event.user_target_roles == ["shell-account"]

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -155,6 +155,7 @@ def shell_create_data():
         secretUserId="secretUserId",
         nickname="nickname",
         tag="tag",
+        email="shell@example.com",
     )
 
 
@@ -1660,4 +1661,5 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == bob.id
         assert event.curious_applet_id == [applet_four.id]
+        assert event.user_target_email == "shell@example.com"
         assert event.user_target_roles == ["shell-account"]

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -14,6 +14,7 @@ from apps.applets.domain import ManagersRole, Role
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.domain.applet_link import CreateAccessLink
 from apps.applets.service.applet import AppletService
+from apps.audit.enums import EventAction, EventOutcome
 from apps.invitations.crud import InvitationCRUD
 from apps.invitations.db import InvitationSchema
 from apps.invitations.domain import (
@@ -40,7 +41,6 @@ from apps.subjects.services import SubjectsService
 from apps.users import UserSchema
 from apps.users.domain import User, UserCreate, UserCreateRequest
 from apps.workspaces.domain.constants import UserPinRole
-from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.errors import AppletInviteAccessDenied
 from apps.workspaces.service.user_access import UserAccessService
 from apps.workspaces.service.user_applet_access import UserAppletAccessService

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -232,7 +232,7 @@ async def delete_subject(
     except BaseError as e:
         await log(
             AuditEvent(
-                event_action=EventAction.APPLET_MEMBER_REMOVE,
+                event_action=EventAction.APPLET_ACCESS_REVOKE,
                 user_id=user.id,
                 user_target_id=target_user_id,
                 curious_applet_id=[applet_id] if applet_id else None,
@@ -244,7 +244,7 @@ async def delete_subject(
 
     await log(
         AuditEvent(
-            event_action=EventAction.APPLET_MEMBER_REMOVE,
+            event_action=EventAction.APPLET_ACCESS_REVOKE,
             user_id=user.id,
             user_target_id=target_user_id,
             curious_applet_id=[applet_id],

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -4,16 +4,18 @@ from typing import TypedDict
 
 from fastapi import Body, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
 
 from apps.activity_assignments.service import ActivityAssignmentService
 from apps.answers.deps.preprocess_arbitrary import get_answer_session, get_answer_session_by_subject
 from apps.answers.service import AnswerService
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
 from apps.shared.domain import Response, ResponseMulti
-from apps.shared.exception import NotFoundError, ValidationError
+from apps.shared.exception import BaseError, NotFoundError, ValidationError
 from apps.shared.response import EmptyResponse
 from apps.shared.subjects import is_take_now_relation, is_valid_take_now_relation
 from apps.subjects.domain import (
@@ -184,43 +186,70 @@ async def update_subject(
 
 async def delete_subject(
     subject_id: uuid.UUID,
+    request: Request,
     params: SubjectDeleteRequest = Body(...),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     arbitrary_session: AsyncSession | None = Depends(get_answer_session_by_subject),
 ):
-    subject_srv = SubjectsService(session, user.id)
-    subject = await subject_srv.get(subject_id)
-    if not subject:
-        raise NotFoundError()
-    # Check that user has right on applet
-    await UserAccessService(session, user.id).validate_subject_delete_access(subject.applet_id)
-    async with atomic(session):
-        if params.delete_answers:
-            # Remove subject and answers
-            await SubjectsService(session, user.id).delete_hard(subject.id)
-            async with atomic(arbitrary_session):
-                await AnswerService(
-                    user_id=user.id,
-                    session=session,
-                    arbitrary_session=arbitrary_session,
-                ).delete_by_subject(subject_id)
-        else:
-            # Delete subject (soft)
-            await SubjectsService(session, user.id).delete(subject.id)
+    applet_id = None
+    target_user_id = None
+    try:
+        subject_srv = SubjectsService(session, user.id)
+        subject = await subject_srv.get(subject_id)
+        if not subject:
+            raise NotFoundError()
+        applet_id = subject.applet_id
+        target_user_id = subject.user_id
+        # Check that user has right on applet
+        await UserAccessService(session, user.id).validate_subject_delete_access(subject.applet_id)
+        async with atomic(session):
+            if params.delete_answers:
+                # Remove subject and answers
+                await SubjectsService(session, user.id).delete_hard(subject.id)
+                async with atomic(arbitrary_session):
+                    await AnswerService(
+                        user_id=user.id,
+                        session=session,
+                        arbitrary_session=arbitrary_session,
+                    ).delete_by_subject(subject_id)
+            else:
+                # Delete subject (soft)
+                await SubjectsService(session, user.id).delete(subject.id)
 
-        uaa_repository = UserAppletAccessService(session, user.id, subject.applet_id)
-        # remove pinned subject
-        await uaa_repository.unpin(pinned_user_id=subject.user_id, pinned_subject_id=subject.id)
+            uaa_repository = UserAppletAccessService(session, user.id, subject.applet_id)
+            # remove pinned subject
+            await uaa_repository.unpin(pinned_user_id=subject.user_id, pinned_subject_id=subject.id)
 
-        if subject.user_id:
-            ex_resp = await UserService(session).get(subject.user_id)
-            if ex_resp:
-                await InvitationsService(session, ex_resp).delete_for_respondents([subject.applet_id])
-            # Remove respondent role for user
-            await uaa_repository.remove_access_by_user_and_applet_to_role(
-                subject.user_id, subject.applet_id, Role.RESPONDENT
+            if subject.user_id:
+                ex_resp = await UserService(session).get(subject.user_id)
+                if ex_resp:
+                    await InvitationsService(session, ex_resp).delete_for_respondents([subject.applet_id])
+                # Remove respondent role for user
+                await uaa_repository.remove_access_by_user_and_applet_to_role(
+                    subject.user_id, subject.applet_id, Role.RESPONDENT
+                )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_MEMBER_REMOVE,
+                user_id=user.id,
+                user_target_id=target_user_id,
+                curious_applet_id=[applet_id] if applet_id else None,
+                **http_audit_fields(request, e),
             )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_MEMBER_REMOVE,
+            user_id=user.id,
+            user_target_id=target_user_id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def get_subject(

--- a/src/apps/subjects/api.py
+++ b/src/apps/subjects/api.py
@@ -236,6 +236,7 @@ async def delete_subject(
                 user_id=user.id,
                 user_target_id=target_user_id,
                 curious_applet_id=[applet_id] if applet_id else None,
+                curious_subject_id=[subject_id],
                 **http_audit_fields(request, e),
             )
         )
@@ -247,6 +248,7 @@ async def delete_subject(
             user_id=user.id,
             user_target_id=target_user_id,
             curious_applet_id=[applet_id],
+            curious_subject_id=[subject_id],
             **http_audit_fields(request),
         )
     )

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -1457,7 +1457,7 @@ class TestSubjects(BaseTest):
         assert response.status_code == http.HTTPStatus.OK
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
@@ -1470,6 +1470,6 @@ class TestSubjects(BaseTest):
         assert response.status_code == http.HTTPStatus.NOT_FOUND
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_id == tom.id

--- a/src/apps/subjects/tests/tests.py
+++ b/src/apps/subjects/tests/tests.py
@@ -17,6 +17,7 @@ from apps.answers.crud.answers import AnswersCRUD
 from apps.answers.domain import AppletAnswerCreate
 from apps.answers.service import AnswerService
 from apps.applets.domain.applet_full import AppletFull
+from apps.audit.enums import EventAction, EventOutcome
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
 from apps.subjects.crud import SubjectsCrud
@@ -1445,3 +1446,30 @@ class TestSubjects(BaseTest):
         assert shell_account_result["submissionCount"] == 1
         assert shell_account_result["currentlyAssigned"] is False
         assert shell_account_result["teamMemberCanViewData"] is False
+
+    async def test_delete_subject_audit_event(
+        self, client, tom: User, tom_applet_one_subject, applet_one: AppletFull, mocker
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+        delete_url = self.subject_detail_url.format(subject_id=tom_applet_one_subject.id)
+        response = await client.delete(delete_url, data=dict(deleteAnswers=False))
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_delete_subject_audit_event_failure(self, client, tom: User, mocker):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+        delete_url = self.subject_detail_url.format(subject_id=str(uuid.uuid4()))
+        response = await client.delete(delete_url, data=dict(deleteAnswers=False))
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id

--- a/src/apps/transfer_ownership/api.py
+++ b/src/apps/transfer_ownership/api.py
@@ -1,9 +1,12 @@
 import uuid
 
 from fastapi import Body, Depends
+from starlette.requests import Request
 
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
+from apps.shared.exception import BaseError
 from apps.transfer_ownership.domain import InitiateTransfer
 from apps.transfer_ownership.service import TransferService
 from apps.users.domain import User
@@ -14,34 +17,97 @@ from infrastructure.database.deps import get_session
 
 async def transfer_initiate(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     transfer: InitiateTransfer = Body(...),
     session=Depends(get_session),
 ) -> None:
     """Initiate a transfer of ownership of an applet."""
-    async with atomic(session):
-        await AppletService(session, user.id).exist_by_id(applet_id)
-        await CheckAccessService(session, user.id).check_create_transfer_ownership_access(applet_id)
-        await TransferService(session, user).initiate_transfer(applet_id, transfer)
+    try:
+        async with atomic(session):
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_create_transfer_ownership_access(applet_id)
+            await TransferService(session, user).initiate_transfer(applet_id, transfer)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_TRANSFER_INITIATE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_TRANSFER_INITIATE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def transfer_accept(
     applet_id: uuid.UUID,
     key: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ) -> None:
     """Respond to a transfer of ownership of an applet."""
-    async with atomic(session):
-        await TransferService(session, user).accept_transfer(applet_id, key)
+    try:
+        async with atomic(session):
+            await TransferService(session, user).accept_transfer(applet_id, key)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_TRANSFER_ACCEPT,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_TRANSFER_ACCEPT,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def transfer_decline(
     applet_id: uuid.UUID,
     key: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ) -> None:
     """Decline a transfer of ownership of an applet."""
-    async with atomic(session):
-        await TransferService(session, user).decline_transfer(applet_id, key)
+    try:
+        async with atomic(session):
+            await TransferService(session, user).decline_transfer(applet_id, key)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_TRANSFER_DECLINE,
+                user_id=user.id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_TRANSFER_DECLINE,
+            user_id=user.id,
+            curious_applet_id=[applet_id],
+            **http_audit_fields(request),
+        )
+    )

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -9,8 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from apps.applets.domain import Role
 from apps.applets.domain.applet_create_update import AppletReportConfiguration
 from apps.applets.domain.applet_full import AppletFull
-from apps.audit.enums import EventAction, EventOutcome
 from apps.applets.service import AppletService
+from apps.audit.enums import EventAction, EventOutcome
 from apps.authentication.errors import PermissionsError
 from apps.invitations.constants import InvitationStatus
 from apps.invitations.errors import ManagerInvitationExist
@@ -634,9 +634,7 @@ class TestTransfer(BaseTest):
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
 
-    async def test_initiate_transfer_audit_event_failure(
-        self, client: TestClient, tom: User, mocker: MockerFixture
-    ):
+    async def test_initiate_transfer_audit_event_failure(self, client: TestClient, tom: User, mocker: MockerFixture):
         audit_log = mocker.patch("apps.transfer_ownership.api.log")
         client.login(tom)
         data = {"email": "aloevdamirkhon@gmail.com"}

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from apps.applets.domain import Role
 from apps.applets.domain.applet_create_update import AppletReportConfiguration
 from apps.applets.domain.applet_full import AppletFull
+from apps.audit.enums import EventAction, EventOutcome
 from apps.applets.service import AppletService
 from apps.authentication.errors import PermissionsError
 from apps.invitations.constants import InvitationStatus
@@ -612,3 +613,86 @@ class TestTransfer(BaseTest):
         resp = await client.post(self.transfer_url.format(applet_id=applet_one_bob_coordinator_reviewer.id), data=data)
         assert resp.status_code == http.HTTPStatus.FORBIDDEN
         assert resp.json()["result"][0]["message"] == TransferOwnershipAccessDenied.message
+
+    # ── Audit event tests ──
+
+    async def test_initiate_transfer_audit_event(
+        self, client: TestClient, applet_one: AppletFull, tom: User, mailbox: TestMail, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.transfer_ownership.api.log")
+        client.login(tom)
+        data = {"email": "lucy@gmail.com"}
+        response = await client.post(
+            self.transfer_url.format(applet_id=applet_one.id),
+            data=data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_TRANSFER_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_initiate_transfer_audit_event_failure(
+        self, client: TestClient, tom: User, mocker: MockerFixture
+    ):
+        audit_log = mocker.patch("apps.transfer_ownership.api.log")
+        client.login(tom)
+        data = {"email": "aloevdamirkhon@gmail.com"}
+        response = await client.post(
+            self.transfer_url.format(applet_id="00000000-0000-0000-0000-000000000012"),
+            data=data,
+        )
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_TRANSFER_INITIATE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_id == tom.id
+
+    async def test_accept_transfer_audit_event(
+        self,
+        client: TestClient,
+        mocker: MockerFixture,
+        applet_one: AppletFull,
+        lucy: User,
+        tom: User,
+        session: AsyncSession,
+    ):
+        audit_log = mocker.patch("apps.transfer_ownership.api.log")
+        client.login(lucy)
+        mocker.patch("apps.transfer_ownership.crud.TransferCRUD.approve_by_key")
+        response = await client.post(
+            self.response_url.format(
+                applet_id=applet_one.id,
+                key="6a3ab8e6-f2fa-49ae-b2db-197136677da7",
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_TRANSFER_ACCEPT
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_decline_transfer_audit_event(
+        self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, lucy: User
+    ):
+        audit_log = mocker.patch("apps.transfer_ownership.api.log")
+        client.login(lucy)
+        mocker.patch("apps.transfer_ownership.crud.TransferCRUD.decline_by_key")
+        response = await client.delete(
+            self.response_url.format(
+                applet_id=applet_one.id,
+                key="6a3ab8e6-f2fa-49ae-b2db-197136677da7",
+            ),
+        )
+        assert response.status_code == http.HTTPStatus.NO_CONTENT
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_TRANSFER_DECLINE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -236,26 +236,28 @@ async def workspace_remove_manager_access(
                 ids_to_remove = set(schema.applet_ids) - set(management_applets)
                 await InvitationsService(session, ex_admin).delete_for_managers(list(ids_to_remove))
     except BaseError as e:
-        await log(
-            AuditEvent(
-                event_action=EventAction.APPLET_MEMBER_REMOVE,
-                user_id=user.id,
-                user_target_id=schema.user_id,
-                curious_applet_id=schema.applet_ids,
-                **http_audit_fields(request, e),
+        for applet_id in schema.applet_ids:
+            await log(
+                AuditEvent(
+                    event_action=EventAction.APPLET_ACCESS_REVOKE,
+                    user_id=user.id,
+                    user_target_id=schema.user_id,
+                    curious_applet_id=[applet_id],
+                    **http_audit_fields(request, e),
+                )
             )
-        )
         raise
 
-    await log(
-        AuditEvent(
-            event_action=EventAction.APPLET_MEMBER_REMOVE,
-            user_id=user.id,
-            user_target_id=schema.user_id,
-            curious_applet_id=schema.applet_ids,
-            **http_audit_fields(request),
+    for applet_id in schema.applet_ids:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_ACCESS_REVOKE,
+                user_id=user.id,
+                user_target_id=schema.user_id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request),
+            )
         )
-    )
 
 
 async def workspace_respondents_list(
@@ -476,26 +478,28 @@ async def workspace_managers_applet_access_set(
 
             await UserAccessService(session, user.id).set(owner_id, manager_id, accesses)
     except BaseError as e:
-        await log(
-            AuditEvent(
-                event_action=EventAction.APPLET_MEMBER_ROLE_CHANGE,
-                user_id=user.id,
-                user_target_id=manager_id,
-                curious_applet_id=applet_ids,
-                **http_audit_fields(request, e),
+        for applet_id in applet_ids:
+            await log(
+                AuditEvent(
+                    event_action=EventAction.APPLET_ACCESS_GRANT,
+                    user_id=user.id,
+                    user_target_id=manager_id,
+                    curious_applet_id=[applet_id],
+                    **http_audit_fields(request, e),
+                )
             )
-        )
         raise
 
-    await log(
-        AuditEvent(
-            event_action=EventAction.APPLET_MEMBER_ROLE_CHANGE,
-            user_id=user.id,
-            user_target_id=manager_id,
-            curious_applet_id=applet_ids,
-            **http_audit_fields(request),
+    for applet_id in applet_ids:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_ACCESS_GRANT,
+                user_id=user.id,
+                user_target_id=manager_id,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request),
+            )
         )
-    )
 
 
 async def workspace_applet_get_respondent(

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -1,8 +1,7 @@
 import uuid
 from copy import deepcopy
 
-from fastapi import Body, Depends, Query
-from starlette.requests import Request
+from fastapi import Body, Depends, Query, Request
 
 from apps.answers.deps.preprocess_arbitrary import get_answer_session_by_owner_id
 from apps.answers.service import AnswerService

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -2,6 +2,7 @@ import uuid
 from copy import deepcopy
 
 from fastapi import Body, Depends, Query
+from starlette.requests import Request
 
 from apps.answers.deps.preprocess_arbitrary import get_answer_session_by_owner_id
 from apps.answers.service import AnswerService
@@ -11,8 +12,9 @@ from apps.applets.service import AppletService
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.shared.domain import Response, ResponseMulti, ResponseMultiOrdering
-from apps.shared.exception import NotFoundError
+from apps.shared.exception import BaseError, NotFoundError
 from apps.shared.query_params import BaseQueryParams, QueryParams, parse_query_params
 from apps.subjects.services import SubjectsService
 from apps.users.domain import User
@@ -216,21 +218,44 @@ async def workspace_applet_respondent_update(
 
 
 async def workspace_remove_manager_access(
+    request: Request,
     user: User = Depends(get_current_user),
     schema: RemoveManagerAccess = Body(...),
     session=Depends(get_session),
 ):
     """Remove manager access from a specific user."""
-    async with atomic(session):
-        await UserAccessService(session, user.id).remove_manager_access(schema)
-        # Get applets where user still have access
-        ex_admin = await UserService(session).get(schema.user_id)
-        if ex_admin:
-            management_applets = await UserAccessService(session, schema.user_id).get_management_applets(
-                schema.applet_ids
+    try:
+        async with atomic(session):
+            await UserAccessService(session, user.id).remove_manager_access(schema)
+            # Get applets where user still have access
+            ex_admin = await UserService(session).get(schema.user_id)
+            if ex_admin:
+                management_applets = await UserAccessService(session, schema.user_id).get_management_applets(
+                    schema.applet_ids
+                )
+                ids_to_remove = set(schema.applet_ids) - set(management_applets)
+                await InvitationsService(session, ex_admin).delete_for_managers(list(ids_to_remove))
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_MEMBER_REMOVE,
+                user_id=user.id,
+                user_target_id=schema.user_id,
+                curious_applet_id=schema.applet_ids,
+                **http_audit_fields(request, e),
             )
-            ids_to_remove = set(schema.applet_ids) - set(management_applets)
-            await InvitationsService(session, ex_admin).delete_for_managers(list(ids_to_remove))
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_MEMBER_REMOVE,
+            user_id=user.id,
+            user_target_id=schema.user_id,
+            curious_applet_id=schema.applet_ids,
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def workspace_respondents_list(
@@ -436,17 +461,41 @@ async def workspace_users_applet_access_list(
 async def workspace_managers_applet_access_set(
     owner_id: uuid.UUID,
     manager_id: uuid.UUID,
+    request: Request,
     accesses: ManagerAccesses = Body(...),
     user: User = Depends(get_current_user),
     session=Depends(get_session),
 ):
-    async with atomic(session):
-        await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
-        await AppletService(session, user.id).exist_by_ids([access.applet_id for access in accesses.accesses])
-        await CheckAccessService(session, user.id).check_workspace_manager_accesses_access(owner_id)
-        await UserService(session).exists_by_id(manager_id)
+    applet_ids = [access.applet_id for access in accesses.accesses]
+    try:
+        async with atomic(session):
+            await WorkspaceService(session, user.id).exists_by_owner_id(owner_id)
+            await AppletService(session, user.id).exist_by_ids(applet_ids)
+            await CheckAccessService(session, user.id).check_workspace_manager_accesses_access(owner_id)
+            await UserService(session).exists_by_id(manager_id)
 
-        await UserAccessService(session, user.id).set(owner_id, manager_id, accesses)
+            await UserAccessService(session, user.id).set(owner_id, manager_id, accesses)
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                event_action=EventAction.APPLET_MEMBER_ROLE_CHANGE,
+                user_id=user.id,
+                user_target_id=manager_id,
+                curious_applet_id=applet_ids,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            event_action=EventAction.APPLET_MEMBER_ROLE_CHANGE,
+            user_id=user.id,
+            user_target_id=manager_id,
+            curious_applet_id=applet_ids,
+            **http_audit_fields(request),
+        )
+    )
 
 
 async def workspace_applet_get_respondent(

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -478,25 +478,27 @@ async def workspace_managers_applet_access_set(
 
             await UserAccessService(session, user.id).set(owner_id, manager_id, accesses)
     except BaseError as e:
-        for applet_id in applet_ids:
+        for access in accesses.accesses:
             await log(
                 AuditEvent(
                     event_action=EventAction.APPLET_ACCESS_GRANT,
                     user_id=user.id,
                     user_target_id=manager_id,
-                    curious_applet_id=[applet_id],
+                    user_target_roles=list(access.roles),
+                    curious_applet_id=[access.applet_id],
                     **http_audit_fields(request, e),
                 )
             )
         raise
 
-    for applet_id in applet_ids:
+    for access in accesses.accesses:
         await log(
             AuditEvent(
                 event_action=EventAction.APPLET_ACCESS_GRANT,
                 user_id=user.id,
                 user_target_id=manager_id,
-                curious_applet_id=[applet_id],
+                user_target_roles=list(access.roles),
+                curious_applet_id=[access.applet_id],
                 **http_audit_fields(request),
             )
         )

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -9,10 +9,10 @@ from apps.answers.service import AnswerService
 from apps.applets.domain.applet_full import PublicAppletFull
 from apps.applets.filters import AppletQueryParams
 from apps.applets.service import AppletService
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.invitations.errors import NonUniqueValue
 from apps.invitations.services import InvitationsService
-from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.shared.domain import Response, ResponseMulti, ResponseMultiOrdering
 from apps.shared.exception import BaseError, NotFoundError
 from apps.shared.query_params import BaseQueryParams, QueryParams, parse_query_params

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -23,6 +23,7 @@ from apps.subjects.constants import SubjectStatus
 from apps.subjects.domain import Subject, SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User, UserSchema, UsersCRUD
+from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.domain.workspace import WorkspaceApplet
 from apps.workspaces.errors import AppletAccessDenied, InvalidAppletIDFilter
 from apps.workspaces.service.user_applet_access import UserAppletAccessService
@@ -1483,3 +1484,50 @@ class TestWorkspaces(BaseTest):
         assert date_now.year == date_answer.year
         assert date_now.hour == date_answer.hour
         assert date_now.minute == date_answer.minute
+
+    # ── Audit event tests ──
+
+    async def test_remove_manager_access_audit_event(
+        self, client, tom, lucy, applet_one, applet_one_lucy_manager, mocker
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+        data = {
+            "user_id": lucy.id,
+            "applet_ids": [str(applet_one.id)],
+        }
+        response = await client.delete(self.remove_manager_access, data=data)
+        assert response.status_code == 200
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.user_target_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_managers_applet_access_set_audit_event(
+        self, client, tom, lucy, applet_one, applet_one_lucy_manager, mocker
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+        data = {
+            "accesses": [
+                {
+                    "applet_id": str(applet_one.id),
+                    "roles": [Role.COORDINATOR],
+                }
+            ]
+        }
+        response = await client.post(
+            self.workspace_manager_accesses_url.format(owner_id=tom.id, manager_id=lucy.id),
+            data=data,
+        )
+        assert response.status_code == 200
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_MEMBER_ROLE_CHANGE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_id == tom.id
+        assert event.user_target_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -1500,7 +1500,7 @@ class TestWorkspaces(BaseTest):
         assert response.status_code == 200
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_MEMBER_REMOVE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.user_target_id == lucy.id
@@ -1526,7 +1526,7 @@ class TestWorkspaces(BaseTest):
         assert response.status_code == 200
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.APPLET_MEMBER_ROLE_CHANGE
+        assert event.event_action == EventAction.APPLET_ACCESS_GRANT
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.user_target_id == lucy.id

--- a/src/apps/workspaces/tests/test_workspaces.py
+++ b/src/apps/workspaces/tests/test_workspaces.py
@@ -13,6 +13,7 @@ from apps.applets.domain.applet_create_update import AppletCreate
 from apps.applets.domain.applet_full import AppletFull
 from apps.applets.domain.applet_link import CreateAccessLink
 from apps.applets.service.applet import AppletService
+from apps.audit.enums import EventAction, EventOutcome
 from apps.invitations.domain import InvitationManagersRequest, InvitationRespondentRequest
 from apps.invitations.services import InvitationsService
 from apps.shared.enums import Language
@@ -23,7 +24,6 @@ from apps.subjects.constants import SubjectStatus
 from apps.subjects.domain import Subject, SubjectCreate
 from apps.subjects.services import SubjectsService
 from apps.users import User, UserSchema, UsersCRUD
-from apps.audit.enums import EventAction, EventOutcome
 from apps.workspaces.domain.workspace import WorkspaceApplet
 from apps.workspaces.errors import AppletAccessDenied, InvalidAppletIDFilter
 from apps.workspaces.service.user_applet_access import UserAppletAccessService


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-#10745](https://mindlogger.atlassian.net/browse/M2-10745)

Changes include:

Add audit event logging to applet-related endpoints:

- Applet create, delete, encryption update
- Transfer ownership initiate, accept, decline
- Invitation send (respondent, reviewer, manager, subject, shell account)
- Invitation accept (regular and private), decline
- Remove team member, change team member permissions
- Data retention and report configuration changes