### PR TITLE
feat: instrument audit logs workspace IAM events (M2-10699)

### DIFF
--- a/src/apps/applets/tests/fixtures/applets.py
+++ b/src/apps/applets/tests/fixtures/applets.py
@@ -280,6 +280,12 @@ async def applet_one_lucy_manager(session: AsyncSession, applet_one: AppletFull,
 
 
 @pytest.fixture
+async def applet_two_lucy_manager(session: AsyncSession, applet_two: AppletFull, tom: User, lucy: User) -> AppletFull:
+    await UserAppletAccessService(session, tom.id, applet_two.id).add_role(lucy.id, Role.MANAGER)
+    return applet_two
+
+
+@pytest.fixture
 async def applet_one_lucy_respondent(
     session: AsyncSession, applet_one: AppletFull, tom: User, lucy: User
 ) -> AppletFull:

--- a/src/apps/subjects/tests/test_audit.py
+++ b/src/apps/subjects/tests/test_audit.py
@@ -165,7 +165,7 @@ class TestSubjectsAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == tom.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_target_id == lucy.id
         assert event.curious_applet_id == [lucy_applet_one_subject.applet_id]
@@ -191,7 +191,7 @@ class TestSubjectsAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == lucy.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
         assert event.curious_subject_id == [tom_applet_one_subject.id]

--- a/src/apps/subjects/tests/test_audit.py
+++ b/src/apps/subjects/tests/test_audit.py
@@ -1,14 +1,28 @@
 import http
 import uuid
 
+import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.applets.domain.applet_full import AppletFull
 from apps.audit import EventAction, EventOutcome
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.subjects.db.schemas import SubjectSchema
 from apps.subjects.domain import Subject
 from apps.users import User
+
+
+@pytest.fixture
+async def lucy_applet_one_subject(session: AsyncSession, lucy: User, applet_one_lucy_respondent: AppletFull) -> Subject:
+    query = select(SubjectSchema).where(
+        SubjectSchema.user_id == lucy.id,
+        SubjectSchema.applet_id == applet_one_lucy_respondent.id,
+    )
+    res = await session.execute(query, execution_options={"synchronize_session": False})
+    return Subject.model_validate(res.scalars().one())
 
 
 class TestSubjectsAudit(BaseTest):
@@ -130,6 +144,57 @@ class TestSubjectsAudit(BaseTest):
         assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
         assert event.curious_subject_id is not None
         assert tom_applet_one_subject.id in event.curious_subject_id
+
+    async def test_delete_subject_audit_success(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        lucy_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(tom)
+
+        response = await client.delete(
+            self.subject_detail_url.format(subject_id=lucy_applet_one_subject.id),
+            data={"delete_answers": False},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK, response.json()
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_target_id == lucy.id
+        assert event.curious_applet_id == [lucy_applet_one_subject.applet_id]
+        assert event.curious_subject_id == [lucy_applet_one_subject.id]
+
+    async def test_delete_subject_audit_failure_403(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.subjects.api.log")
+        client.login(lucy)
+
+        response = await client.delete(
+            self.subject_detail_url.format(subject_id=tom_applet_one_subject.id),
+            data={"delete_answers": False},
+        )
+
+        assert response.status_code == http.HTTPStatus.FORBIDDEN, response.json()
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [tom_applet_one_subject.applet_id]
+        assert event.curious_subject_id == [tom_applet_one_subject.id]
 
     async def test_get_target_subjects_by_respondent_audit_failure_invalid_respondent(
         self,

--- a/src/apps/workspaces/api.py
+++ b/src/apps/workspaces/api.py
@@ -573,6 +573,7 @@ async def workspace_managers_applet_access_set(
                     user_target_id=manager_id,
                     user_target_roles=list(access.roles),
                     curious_applet_id=[access.applet_id],
+                    curious_subject_id=access.subjects or None,
                     **http_audit_fields(request, e),
                 )
             )
@@ -586,6 +587,7 @@ async def workspace_managers_applet_access_set(
                 user_target_id=manager_id,
                 user_target_roles=list(access.roles),
                 curious_applet_id=[access.applet_id],
+                curious_subject_id=access.subjects or None,
                 **http_audit_fields(request),
             )
         )

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -22,6 +22,7 @@ class TestWorkspacesAudit(BaseTest):
     workspace_respondents_url = "/workspaces/{owner_id}/respondents"
     workspace_applet_respondents_list = "/workspaces/{owner_id}/applets/{applet_id}/respondents"
     workspace_get_applet_respondent = "/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}"
+    workspace_manager_accesses_url = "/workspaces/{owner_id}/managers/{manager_id}/accesses"
 
     async def test_workspace_respondents_list_audit_success_emits_event_per_applet(
         self,
@@ -167,3 +168,133 @@ class TestWorkspacesAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_SUBJECT_VIEW
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet_one.id]
+
+    async def test_access_grant_success_multi_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        applet_two: AppletFull,
+        tom_applet_one_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.post(
+            self.workspace_manager_accesses_url.format(owner_id=tom.id, manager_id=lucy.id),
+            dict(
+                accesses=[
+                    {"applet_id": str(applet_two.id), "roles": ["manager", "coordinator"]},
+                    {
+                        "applet_id": str(applet_one.id),
+                        "roles": ["reviewer"],
+                        "subjects": [str(tom_applet_one_subject.id)],
+                    },
+                ]
+            ),
+        )
+
+        assert response.status_code == http.HTTPStatus.OK, response.json()
+        assert audit_log.await_count == 2
+        events = [call.args[0] for call in audit_log.call_args_list]
+        for event in events:
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+            assert event.event_outcome == EventOutcome.SUCCESS
+            assert event.user_target_id == lucy.id
+            assert event.curious_applet_id is not None
+            assert len(event.curious_applet_id) == 1
+
+        events_by_applet = {event.curious_applet_id[0]: event for event in events}
+        assert set(events_by_applet[applet_two.id].user_target_roles or []) == {"manager", "coordinator"}
+        assert events_by_applet[applet_two.id].curious_subject_id is None
+        assert events_by_applet[applet_one.id].user_target_roles == ["reviewer"]
+        assert events_by_applet[applet_one.id].curious_subject_id == [tom_applet_one_subject.id]
+
+    async def test_access_grant_success_single_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.post(
+            self.workspace_manager_accesses_url.format(owner_id=tom.id, manager_id=lucy.id),
+            dict(accesses=[{"applet_id": str(applet_one.id), "roles": ["coordinator"]}]),
+        )
+
+        assert response.status_code == http.HTTPStatus.OK, response.json()
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_roles == ["coordinator"]
+        assert event.curious_subject_id is None
+
+    async def test_access_grant_failure_404(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        applet_two: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        missing_owner_id = uuid.uuid4()
+        response = await client.post(
+            self.workspace_manager_accesses_url.format(owner_id=missing_owner_id, manager_id=lucy.id),
+            dict(
+                accesses=[
+                    {"applet_id": str(applet_one.id), "roles": ["manager"]},
+                    {"applet_id": str(applet_two.id), "roles": ["coordinator"]},
+                ]
+            ),
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        assert audit_log.await_count == 2
+        events = [call.args[0] for call in audit_log.call_args_list]
+        for event in events:
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+            assert event.event_outcome == EventOutcome.FAILURE
+            assert event.user_target_id == lucy.id
+
+        applet_ids = {event.curious_applet_id[0] for event in events}
+        assert applet_ids == {applet_one.id, applet_two.id}
+
+    async def test_access_grant_failure_403(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(lucy)
+
+        response = await client.post(
+            self.workspace_manager_accesses_url.format(owner_id=tom.id, manager_id=lucy.id),
+            dict(accesses=[{"applet_id": str(applet_one.id), "roles": ["manager"]}]),
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_target_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_roles == ["manager"]

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -202,7 +202,7 @@ class TestWorkspacesAudit(BaseTest):
         events = [call.args[0] for call in audit_log.call_args_list]
         for event in events:
             assert event.user_id == tom.id
-            assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+            assert event.event_action == EventAction.APPLET_ACCESS_GRANT
             assert event.event_outcome == EventOutcome.SUCCESS
             assert event.user_target_id == lucy.id
             assert event.curious_applet_id is not None
@@ -233,7 +233,7 @@ class TestWorkspacesAudit(BaseTest):
         assert response.status_code == http.HTTPStatus.OK, response.json()
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+        assert event.event_action == EventAction.APPLET_ACCESS_GRANT
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_one.id]
         assert event.user_target_roles == ["coordinator"]
@@ -267,7 +267,7 @@ class TestWorkspacesAudit(BaseTest):
         events = [call.args[0] for call in audit_log.call_args_list]
         for event in events:
             assert event.user_id == tom.id
-            assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+            assert event.event_action == EventAction.APPLET_ACCESS_GRANT
             assert event.event_outcome == EventOutcome.FAILURE
             assert event.user_target_id == lucy.id
 
@@ -294,7 +294,7 @@ class TestWorkspacesAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == lucy.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_GRANT
+        assert event.event_action == EventAction.APPLET_ACCESS_GRANT
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_target_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
@@ -321,7 +321,7 @@ class TestWorkspacesAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == tom.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_target_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
@@ -350,7 +350,7 @@ class TestWorkspacesAudit(BaseTest):
         events = [call.args[0] for call in audit_log.call_args_list]
         for event in events:
             assert event.user_id == tom.id
-            assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+            assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
             assert event.event_outcome == EventOutcome.SUCCESS
             assert event.user_target_id == lucy.id
 
@@ -377,7 +377,7 @@ class TestWorkspacesAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == lucy.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_target_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
@@ -401,7 +401,7 @@ class TestWorkspacesAudit(BaseTest):
         audit_log.assert_awaited_once()
         event = audit_log.call_args[0][0]
         assert event.user_id == tom.id
-        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_action == EventAction.APPLET_ACCESS_REVOKE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_target_id == tom.id
         assert event.curious_applet_id == [applet_one.id]

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -334,6 +334,7 @@ class TestWorkspacesAudit(BaseTest):
         applet_one: AppletFull,
         applet_two: AppletFull,
         applet_one_lucy_manager: AppletFull,
+        applet_two_lucy_manager: AppletFull,
         mocker: MockerFixture,
     ):
         audit_log = mocker.patch("apps.workspaces.api.log")

--- a/src/apps/workspaces/tests/test_audit.py
+++ b/src/apps/workspaces/tests/test_audit.py
@@ -23,6 +23,7 @@ class TestWorkspacesAudit(BaseTest):
     workspace_applet_respondents_list = "/workspaces/{owner_id}/applets/{applet_id}/respondents"
     workspace_get_applet_respondent = "/workspaces/{owner_id}/applets/{applet_id}/respondents/{respondent_id}"
     workspace_manager_accesses_url = "/workspaces/{owner_id}/managers/{manager_id}/accesses"
+    remove_manager_access_url = "/workspaces/managers/removeAccess"
 
     async def test_workspace_respondents_list_audit_success_emits_event_per_applet(
         self,
@@ -298,3 +299,108 @@ class TestWorkspacesAudit(BaseTest):
         assert event.user_target_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
         assert event.user_target_roles == ["manager"]
+
+    async def test_access_revoke_success_single_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        applet_one_lucy_manager: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.delete(
+            self.remove_manager_access_url,
+            data={"user_id": str(lucy.id), "applet_ids": [str(applet_one.id)]},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK, response.json()
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_target_id == lucy.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_access_revoke_success_multi_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        applet_two: AppletFull,
+        applet_one_lucy_manager: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.delete(
+            self.remove_manager_access_url,
+            data={"user_id": str(lucy.id), "applet_ids": [str(applet_one.id), str(applet_two.id)]},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK, response.json()
+        assert audit_log.await_count == 2
+        events = [call.args[0] for call in audit_log.call_args_list]
+        for event in events:
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+            assert event.event_outcome == EventOutcome.SUCCESS
+            assert event.user_target_id == lucy.id
+
+        applet_ids = {event.curious_applet_id[0] for event in events}
+        assert applet_ids == {applet_one.id, applet_two.id}
+
+    async def test_access_revoke_failure_403(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(lucy)
+
+        response = await client.delete(
+            self.remove_manager_access_url,
+            data={"user_id": str(tom.id), "applet_ids": [str(applet_one.id)]},
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_target_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]
+
+    async def test_access_revoke_failure_self(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.workspaces.api.log")
+        client.login(tom)
+
+        response = await client.delete(
+            self.remove_manager_access_url,
+            data={"user_id": str(tom.id), "applet_ids": [str(applet_one.id)]},
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.WORKSPACE_ACCESS_REVOKE
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.user_target_id == tom.id
+        assert event.curious_applet_id == [applet_one.id]


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10699](https://mindlogger.atlassian.net/browse/M2-10699)

Changes include:

- **`workspace:access:grant`** - emitted when a manager's applet access is set via `workspace_managers_applet_access_set`. One event per applet in the request. Each event includes:
  - `user_id` - admin performing the grant
  - `user_target_id` - manager receiving access
  - `user_target_roles` - role(s) being granted for that applet
  - `curious_applet_id` - the applet access is being granted on
  - `curious_subject_id` - reviewer subject scope, when `ManagerAccess.subjects` is populated

- **`workspace:access:revoke`** (manager) - emitted when manager access is removed via `workspace_remove_manager_access`. One event per applet in the request. Each event includes:
  - `user_id` - admin performing the revoke
  - `user_target_id` - manager losing access
  - `curious_applet_id` - the applet access is being revoked on
  
- **`workspace:access:revoke`** (subject) - emitted when a subject is deleted via `delete_subject`. One event per deletion. Each event includes:
  - `user_id` - admin performing the deletion
  - `user_target_id` - user whose respondent access is being revoked (when the subject has an associated user)
  - `curious_applet_id` - the applet the subject belongs to
  - `curious_subject_id` - the subject being deleted


Both events are emitted on success and failure paths.

### ✏️ Notes

Depends on `feat/data-access-audit-logs`.