### PR TITLE
feat: emit logs for file download events (M2-10746)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -59,7 +59,7 @@ from apps.applets.db.schemas import AppletSchema
 from apps.applets.domain.applet_history import VersionPublic
 from apps.applets.errors import InvalidVersionError, NotValidAppletHistory
 from apps.applets.service import AppletHistoryService, AppletService
-from apps.audit import AuditEvent, EventAction, http_audit_fields, log
+from apps.audit import AuditEvent, EventAction, EventOutcome, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.integrations.oneup_health.service.domain import EHRData
 from apps.integrations.oneup_health.service.ehr_storage import create_ehr_storage
@@ -1366,31 +1366,47 @@ async def applet_ehr_answers_export(
     ehr_storage = await create_ehr_storage(session=session, applet_id=applet_id, app_settings=app_settings)
     zip_buffer = io.BytesIO()
     try:
-        with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
-            ehr_answer: AnswerEHRFull
-            for ehr_answer in ehr_answers:
-                data = EHRData(
-                    target_subject_id=ehr_answer.target_subject_id,
-                    activity_id=ehr_answer.activity_id,
-                    submit_id=ehr_answer.submit_id,
-                    date=ehr_answer.date,
-                    user_id=user.id,
-                )
-                ehr_zip_buffer = io.BytesIO()
-
-                try:
-                    ehr_zip_filename = ehr_storage.download_ehr_zip(
-                        storage_path=ehr_answer.ehr_storage_uri,  # type: ignore
-                        data=data,
-                        file_buffer=ehr_zip_buffer,
+        try:
+            with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+                ehr_answer: AnswerEHRFull
+                for ehr_answer in ehr_answers:
+                    data = EHRData(
+                        target_subject_id=ehr_answer.target_subject_id,
+                        activity_id=ehr_answer.activity_id,
+                        submit_id=ehr_answer.submit_id,
+                        date=ehr_answer.date,
+                        user_id=user.id,
                     )
+                    ehr_zip_buffer = io.BytesIO()
 
-                    zip_file.writestr(ehr_zip_filename, ehr_zip_buffer.getvalue())
-                finally:
-                    ehr_zip_buffer.close()
+                    try:
+                        ehr_zip_filename = ehr_storage.download_ehr_zip(
+                            storage_path=ehr_answer.ehr_storage_uri,  # type: ignore
+                            data=data,
+                            file_buffer=ehr_zip_buffer,
+                        )
 
-        zip_buffer.seek(0)
-        headers = {"Content-Disposition": "attachment; filename=EHR.zip"}
-        return FastAPIResponse(zip_buffer.getvalue(), headers=headers, media_type="application/zip")
+                        zip_file.writestr(ehr_zip_filename, ehr_zip_buffer.getvalue())
+                    finally:
+                        ehr_zip_buffer.close()
+
+            zip_buffer.seek(0)
+            headers = {"Content-Disposition": "attachment; filename=EHR.zip"}
+            return FastAPIResponse(zip_buffer.getvalue(), headers=headers, media_type="application/zip")
+        except Exception as e:
+            await log(
+                AuditEvent(
+                    user_id=user.id,
+                    event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
+                    curious_applet_id=[applet_id],
+                    curious_subject_id=list({a.target_subject_id for a in ehr_answers}) or None,
+                    curious_activity_id=list({a.activity_id for a in ehr_answers}) or None,
+                    curious_submit_id=list({a.submit_id for a in ehr_answers}) or None,
+                    event_outcome=EventOutcome.FAILURE,
+                    error_type=type(e).__name__,
+                    **http_audit_fields(request),
+                )
+            )
+            raise
     finally:
         zip_buffer.close()

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -1340,6 +1340,9 @@ async def applet_ehr_answers_export(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
                 curious_applet_id=[applet_id],
+                curious_subject_id=query_params.filters.get("target_subject_ids"),
+                curious_activity_id=query_params.filters.get("activity_ids"),
+                curious_flow_id=query_params.filters.get("flow_ids"),
                 **http_audit_fields(request, e),
             )
         )

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -350,19 +350,45 @@ async def summary_activity_latest_report_retrieve(
     applet_id: uuid.UUID,
     activity_id: uuid.UUID,
     subject_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> FastApiResponse:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    subject = await SubjectsService(session, user.id).get_if_soft_exist(subject_id)
-    if not subject:
-        raise NotFoundError(f"Subject {subject_id} not found.")
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        subject = await SubjectsService(session, user.id).get_if_soft_exist(subject_id)
+        if not subject:
+            raise NotFoundError(f"Subject {subject_id} not found.")
 
-    report = await AnswerService(session, user.id, answer_session).get_summary_latest_report(
-        applet_id, activity_id, subject_id
+        report = await AnswerService(session, user.id, answer_session).get_summary_latest_report(
+            applet_id, activity_id, subject_id
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
+                curious_applet_id=[applet_id],
+                curious_activity_id=[activity_id],
+                curious_subject_id=[subject_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
+            curious_applet_id=[applet_id],
+            curious_activity_id=[activity_id],
+            curious_subject_id=[subject_id],
+            **http_audit_fields(request),
+        )
     )
+
     if report:
         return FastApiResponse(
             base64.b64decode(report.pdf.encode()),
@@ -377,19 +403,45 @@ async def summary_flow_latest_report_retrieve(
     applet_id: uuid.UUID,
     flow_id: uuid.UUID,
     subject_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> FastApiResponse:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
-    subject = await SubjectsService(session, user.id).get_if_soft_exist(subject_id)
-    if not subject:
-        raise NotFoundError(f"Subject {subject_id} not found.")
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
+        subject = await SubjectsService(session, user.id).get_if_soft_exist(subject_id)
+        if not subject:
+            raise NotFoundError(f"Subject {subject_id} not found.")
 
-    report = await AnswerService(session, user.id, answer_session).get_flow_summary_latest_report(
-        applet_id, flow_id, subject_id
+        report = await AnswerService(session, user.id, answer_session).get_flow_summary_latest_report(
+            applet_id, flow_id, subject_id
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
+                curious_applet_id=[applet_id],
+                curious_flow_id=[flow_id],
+                curious_subject_id=[subject_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
+            curious_applet_id=[applet_id],
+            curious_flow_id=[flow_id],
+            curious_subject_id=[subject_id],
+            **http_audit_fields(request),
+        )
     )
+
     if report:
         return FastApiResponse(
             base64.b64decode(report.pdf.encode()),

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -1268,17 +1268,41 @@ async def applet_submissions_list(
 
 async def applet_ehr_answers_export(
     applet_id: uuid.UUID,
+    request: Request,
     user: User = Depends(get_current_user),
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
     query_params: QueryParams = Depends(parse_query_params(AnswerEHRExportFilters)),
     app_settings: Settings = Depends(get_settings),
 ) -> FastAPIResponse:
-    await AppletService(session, user.id).exist_by_id(applet_id)
-    await CheckAccessService(session, user.id).check_answers_export_access(applet_id)
+    try:
+        await AppletService(session, user.id).exist_by_id(applet_id)
+        await CheckAccessService(session, user.id).check_answers_export_access(applet_id)
 
-    ehr_answers: list[AnswerEHRFull] = await AnswerService(session, user.id, answer_session).export_ehr_answers(
-        applet_id, query_params
+        ehr_answers: list[AnswerEHRFull] = await AnswerService(session, user.id, answer_session).export_ehr_answers(
+            applet_id, query_params
+        )
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
+                curious_applet_id=[applet_id],
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
+            curious_applet_id=[applet_id],
+            curious_subject_id=list({a.target_subject_id for a in ehr_answers}) or None,
+            curious_activity_id=list({a.activity_id for a in ehr_answers}) or None,
+            curious_submit_id=list({a.submit_id for a in ehr_answers}) or None,
+            **http_audit_fields(request),
+        )
     )
 
     if len(ehr_answers) == 0:

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -15,7 +15,16 @@ from apps.applets.domain.applet_full import AppletFull
 from apps.audit import EventAction, EventOutcome
 from apps.shared.test import BaseTest
 from apps.shared.test.client import TestClient
+from apps.subjects.domain import Subject
+from apps.subjects.services import SubjectsService
 from apps.users.domain import User
+
+
+@pytest.fixture
+async def tom_applet_with_flow_subject(session: AsyncSession, tom: User, applet_with_flow: AppletFull) -> Subject:
+    subject = await SubjectsService(session, tom.id).get_by_user_and_applet(tom.id, applet_with_flow.id)
+    assert subject is not None
+    return subject
 
 
 @pytest.fixture
@@ -913,3 +922,155 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet.id]
+
+    # --- summary_activity_latest_report_retrieve / summary_flow_latest_report_retrieve ---
+
+    activity_report_url = "/answers/applet/{applet_id}/activities/{activity_id}/subjects/{subject_id}/latest_report"
+    flow_report_url = "/answers/applet/{applet_id}/flows/{flow_id}/subjects/{subject_id}/latest_report"
+
+    async def test_activity_report_download_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        tom_applet_subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.post(
+            self.activity_report_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+                subject_id=tom_applet_subject.id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_activity_id == [applet.activities[0].id]
+        assert event.curious_subject_id == [tom_applet_subject.id]
+        assert event.curious_flow_id is None
+
+    async def test_activity_report_download_failure_subject_not_found(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_subject_id = uuid.uuid4()
+        response = await client.post(
+            self.activity_report_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+                subject_id=missing_subject_id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_activity_id == [applet.activities[0].id]
+        assert event.curious_subject_id == [missing_subject_id]
+
+    async def test_activity_report_download_failure_403(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet: AppletFull,
+        tom_applet_subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(lucy)
+
+        response = await client.post(
+            self.activity_report_url.format(
+                applet_id=applet.id,
+                activity_id=applet.activities[0].id,
+                subject_id=tom_applet_subject.id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_activity_id == [applet.activities[0].id]
+
+    async def test_flow_report_download_success(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_with_flow: AppletFull,
+        tom_applet_with_flow_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.post(
+            self.flow_report_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+                subject_id=tom_applet_with_flow_subject.id,
+            )
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_flow_id == [applet_with_flow.activity_flows[0].id]
+        assert event.curious_subject_id == [tom_applet_with_flow_subject.id]
+        assert event.curious_activity_id is None
+
+    async def test_flow_report_download_failure_403(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet_with_flow: AppletFull,
+        tom_applet_with_flow_subject: Subject,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(lucy)
+
+        response = await client.post(
+            self.flow_report_url.format(
+                applet_id=applet_with_flow.id,
+                flow_id=applet_with_flow.activity_flows[0].id,
+                subject_id=tom_applet_with_flow_subject.id,
+            )
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet_with_flow.id]
+        assert event.curious_flow_id == [applet_with_flow.activity_flows[0].id]

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -923,6 +923,39 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet.id]
 
+    async def test_ehr_download_failure_promotes_query_filters(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(lucy)
+
+        target_subject_id = uuid.uuid4()
+        activity_id = uuid.uuid4()
+        flow_id = uuid.uuid4()
+        response = await client.get(
+            self.ehr_export_url.format(applet_id=applet.id),
+            query={
+                "targetSubjectIds": str(target_subject_id),
+                "activityIds": str(activity_id),
+                "flowIds": str(flow_id),
+            },
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_subject_id == [target_subject_id]
+        assert event.curious_activity_id == [activity_id]
+        assert event.curious_flow_id == [flow_id]
+
     # --- summary_activity_latest_report_retrieve / summary_flow_latest_report_retrieve ---
 
     activity_report_url = "/answers/applet/{applet_id}/activities/{activity_id}/subjects/{subject_id}/latest_report"

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -956,6 +956,52 @@ class TestAnswersAudit(BaseTest):
         assert event.curious_activity_id == [activity_id]
         assert event.curious_flow_id == [flow_id]
 
+    async def test_ehr_download_zip_failure_emits_error_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        subject_id = uuid.uuid4()
+        activity_id = uuid.uuid4()
+        submit_id = uuid.uuid4()
+        ehr_rows = [
+            AnswerEHRFull(
+                submit_id=submit_id,
+                ehr_ingestion_status=EHRIngestionStatus.COMPLETED,
+                activity_id=activity_id,
+                ehr_storage_uri=None,
+                target_subject_id=subject_id,
+                date=datetime.datetime.now(datetime.UTC),
+            ),
+        ]
+        mocker.patch(
+            "apps.answers.api.AnswerService.export_ehr_answers",
+            return_value=ehr_rows,
+        )
+        fake_storage = mocker.MagicMock()
+        fake_storage.download_ehr_zip.side_effect = RuntimeError("S3 unavailable")
+        mocker.patch("apps.answers.api.create_ehr_storage", new=AsyncMock(return_value=fake_storage))
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(self.ehr_export_url.format(applet_id=applet.id))
+
+        assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert audit_log.await_count == 2
+        success_event = audit_log.call_args_list[0][0][0]
+        assert success_event.event_outcome == EventOutcome.SUCCESS
+        failure_event = audit_log.call_args_list[1][0][0]
+        assert failure_event.user_id == tom.id
+        assert failure_event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert failure_event.event_outcome == EventOutcome.FAILURE
+        assert failure_event.error_type == "RuntimeError"
+        assert failure_event.curious_applet_id == [applet.id]
+        assert failure_event.curious_subject_id == [subject_id]
+        assert failure_event.curious_activity_id == [activity_id]
+        assert failure_event.curious_submit_id == [submit_id]
+
     # --- summary_activity_latest_report_retrieve / summary_flow_latest_report_retrieve ---
 
     activity_report_url = "/answers/applet/{applet_id}/activities/{activity_id}/subjects/{subject_id}/latest_report"

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -1,6 +1,7 @@
 import datetime
 import http
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -8,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.answers.db.schemas import AnswerSchema
 from apps.answers.domain import ClientMeta
-from apps.answers.domain.answers import AppletAnswerCreate, ItemAnswerCreate
+from apps.answers.domain.answers import AnswerEHRFull, AppletAnswerCreate, EHRIngestionStatus, ItemAnswerCreate
 from apps.answers.service import AnswerService
 from apps.applets.domain.applet_full import AppletFull
 from apps.audit import EventAction, EventOutcome
@@ -783,3 +784,132 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_EXPORT
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [missing_applet_id]
+
+    # --- applet_ehr_answers_export ---
+
+    ehr_export_url = "/answers/applet/{applet_id}/ehr-data"
+
+    async def test_ehr_download_success_logs_subject_activity_submit(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        subject_id_a = uuid.uuid4()
+        subject_id_b = uuid.uuid4()
+        activity_id_a = uuid.uuid4()
+        submit_id_a = uuid.uuid4()
+        submit_id_b = uuid.uuid4()
+        ehr_rows = [
+            AnswerEHRFull(
+                submit_id=submit_id_a,
+                ehr_ingestion_status=EHRIngestionStatus.COMPLETED,
+                activity_id=activity_id_a,
+                ehr_storage_uri=None,
+                target_subject_id=subject_id_a,
+                date=datetime.datetime.now(datetime.UTC),
+            ),
+            AnswerEHRFull(
+                submit_id=submit_id_b,
+                ehr_ingestion_status=EHRIngestionStatus.COMPLETED,
+                activity_id=activity_id_a,
+                ehr_storage_uri=None,
+                target_subject_id=subject_id_b,
+                date=datetime.datetime.now(datetime.UTC),
+            ),
+        ]
+        mocker.patch(
+            "apps.answers.api.AnswerService.export_ehr_answers",
+            return_value=ehr_rows,
+        )
+        # Replace ehr-storage with an AsyncMock so the zip path runs cleanly
+        # without touching real S3.
+        fake_storage = mocker.MagicMock()
+        fake_storage.download_ehr_zip.return_value = "fake.zip"
+        mocker.patch("apps.answers.api.create_ehr_storage", new=AsyncMock(return_value=fake_storage))
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(self.ehr_export_url.format(applet_id=applet.id))
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_subject_id is not None
+        assert set(event.curious_subject_id) == {subject_id_a, subject_id_b}
+        assert event.curious_activity_id == [activity_id_a]
+        assert event.curious_submit_id is not None
+        assert set(event.curious_submit_id) == {submit_id_a, submit_id_b}
+
+    async def test_ehr_download_success_no_data_emits_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(
+            "apps.answers.api.AnswerService.export_ehr_answers",
+            return_value=[],
+        )
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        response = await client.get(self.ehr_export_url.format(applet_id=applet.id))
+
+        assert response.status_code == http.HTTPStatus.NO_CONTENT
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet.id]
+        assert event.curious_subject_id is None
+        assert event.curious_activity_id is None
+        assert event.curious_submit_id is None
+
+    async def test_ehr_download_failure_404_applet(
+        self,
+        client: TestClient,
+        tom: User,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(tom)
+
+        missing_applet_id = uuid.uuid4()
+        response = await client.get(self.ehr_export_url.format(applet_id=missing_applet_id))
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [missing_applet_id]
+
+    async def test_ehr_download_failure_403_access_denied(
+        self,
+        client: TestClient,
+        tom: User,
+        lucy: User,
+        applet: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.answers.api.log")
+        client.login(lucy)
+
+        response = await client.get(self.ehr_export_url.format(applet_id=applet.id))
+
+        assert response.status_code != http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == lucy.id
+        assert event.event_action == EventAction.APPLET_ANSWER_EHR_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet.id]

--- a/src/apps/file/api/file.py
+++ b/src/apps/file/api/file.py
@@ -11,11 +11,12 @@ import aiofiles
 import pytz
 from botocore.exceptions import ClientError
 from ddtrace import tracer
-from fastapi import Body, Depends, File, Query, UploadFile
+from fastapi import Body, Depends, File, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq import TaskiqResult, TaskiqResultTimeoutError
 
+from apps.audit import AuditEvent, EventAction, http_audit_fields, log
 from apps.authentication.deps import get_current_user
 from apps.file.domain import (
     AnswerUploadedFile,
@@ -35,7 +36,7 @@ from apps.file.errors import FileNotFoundError, SomethingWentWrongError
 from apps.file.services import LogFileService
 from apps.file.tasks import convert_audio_file, convert_image
 from apps.shared.domain.response import Response, ResponseMulti
-from apps.shared.exception import NotFoundError
+from apps.shared.exception import BaseError, NotFoundError
 from apps.users.domain import User
 from apps.users.services.user import UserService
 from apps.workspaces.crud.user_applet_access import UserAppletAccessCRUD
@@ -250,21 +251,44 @@ async def answer_upload(
 
 async def answer_download(
     applet_id: uuid.UUID,
-    request: FileDownloadRequest = Body(...),
+    request: Request,
+    schema: FileDownloadRequest = Body(...),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     app_settings=Depends(get_settings),
 ) -> StreamingResponse:
-    cdn_client = await select_answer_storage(applet_id=applet_id, session=session, app_settings=app_settings)
-    if request.key.startswith(LogFileService.LOG_KEY):
-        LogFileService.raise_for_access(user.email)
-
     try:
-        file, media_type = cdn_client.download(request.key)
-    except ClientError:
-        raise SomethingWentWrongError
-    except ObjectNotFoundError:
-        raise FileNotFoundError
+        cdn_client = await select_answer_storage(applet_id=applet_id, session=session, app_settings=app_settings)
+        if schema.key.startswith(LogFileService.LOG_KEY):
+            LogFileService.raise_for_access(user.email)
+
+        try:
+            file, media_type = cdn_client.download(schema.key)
+        except ClientError:
+            raise SomethingWentWrongError
+        except ObjectNotFoundError:
+            raise FileNotFoundError
+    except BaseError as e:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_FILE_DOWNLOAD,
+                curious_applet_id=[applet_id],
+                file_path=schema.key,
+                **http_audit_fields(request, e),
+            )
+        )
+        raise
+
+    await log(
+        AuditEvent(
+            user_id=user.id,
+            event_action=EventAction.APPLET_ANSWER_FILE_DOWNLOAD,
+            curious_applet_id=[applet_id],
+            file_path=schema.key,
+            **http_audit_fields(request),
+        )
+    )
     return StreamingResponse(file, media_type=media_type)
 
 
@@ -314,13 +338,38 @@ async def check_file_uploaded(
 
 async def presign(
     applet_id: uuid.UUID,
-    request: FilePresignRequest = Body(...),
+    request: Request,
+    schema: FilePresignRequest = Body(...),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
     app_settings=Depends(get_settings),
 ) -> ResponseMulti[str | None]:
-    service = await get_presign_service(applet_id, user.id, session, app_settings)
-    links = await service.presign(request.private_urls)
+    try:
+        service = await get_presign_service(applet_id, user.id, session, app_settings)
+        links = await service.presign(schema.private_urls)
+    except BaseError as e:
+        for url in schema.private_urls:
+            await log(
+                AuditEvent(
+                    user_id=user.id,
+                    event_action=EventAction.APPLET_ANSWER_FILE_DOWNLOAD,
+                    curious_applet_id=[applet_id],
+                    file_path=url,
+                    **http_audit_fields(request, e),
+                )
+            )
+        raise
+
+    for url in schema.private_urls:
+        await log(
+            AuditEvent(
+                user_id=user.id,
+                event_action=EventAction.APPLET_ANSWER_FILE_DOWNLOAD,
+                curious_applet_id=[applet_id],
+                file_path=url,
+                **http_audit_fields(request),
+            )
+        )
     return ResponseMulti[str | None](result=links, count=len(links))  # noqa
 
 

--- a/src/apps/file/tests/test_audit.py
+++ b/src/apps/file/tests/test_audit.py
@@ -1,0 +1,162 @@
+import http
+
+import pytest
+from botocore.exceptions import ClientError
+from pytest_mock import MockerFixture
+
+from apps.applets.domain.applet_full import AppletFull
+from apps.audit import EventAction, EventOutcome
+from apps.shared.exception import AccessDeniedError
+from apps.shared.test import BaseTest
+from apps.shared.test.client import TestClient
+from apps.users.domain import User
+
+
+@pytest.mark.usefixtures("cdn_settings", "override_app_settings", "s3_resource")
+class TestFileDownloadAudit(BaseTest):
+    answer_download_url = "/file/{applet_id}/download"
+    presign_url = "/file/{applet_id}/presign"
+
+    async def test_file_download_success_logs_file_path(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(
+            "infrastructure.storage.storage_client.StorageClient.download",
+            return_value=(iter(("a", "b")), "txt"),
+        )
+        audit_log = mocker.patch("apps.file.api.file.log")
+        client.login(tom)
+
+        key = "1693560380000/c60859c4-6f5f-4390-a572-da85fcd59709"
+        response = await client.post(
+            self.answer_download_url.format(applet_id=applet_one.id),
+            data={"key": key},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_FILE_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.file_path == key
+
+    async def test_file_download_failure_404_logs_event(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(
+            "botocore.client.BaseClient._make_api_call",
+            side_effect=ClientError({"Error": {"Code": "404"}}, "Not Found"),
+        )
+        audit_log = mocker.patch("apps.file.api.file.log")
+        client.login(tom)
+
+        key = "1693560380000/c60859c4-6f5f-4390-a572-da85fcd59709"
+        response = await client.post(
+            self.answer_download_url.format(applet_id=applet_one.id),
+            data={"key": key},
+        )
+
+        assert response.status_code == http.HTTPStatus.NOT_FOUND
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.user_id == tom.id
+        assert event.event_action == EventAction.APPLET_ANSWER_FILE_DOWNLOAD
+        assert event.event_outcome == EventOutcome.FAILURE
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.file_path == key
+
+    async def test_presign_success_fan_out_per_url(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.file.api.file.log")
+        client.login(tom)
+
+        key = "1693560380000/c60859c4-6f5f-4390-a572-da85fcd59709"
+        urls = [
+            f"s3://bucket/mindlogger/answer/{tom.id}/{applet_one.id}/{key}-a",
+            f"s3://bucket/mindlogger/answer/{tom.id}/{applet_one.id}/{key}-b",
+            f"s3://bucket/mindlogger/answer/{tom.id}/{applet_one.id}/{key}-c",
+        ]
+        response = await client.post(
+            self.presign_url.format(applet_id=applet_one.id),
+            data={"privateUrls": urls},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        assert audit_log.await_count == 3
+        for call, url in zip(audit_log.await_args_list, urls):
+            event = call.args[0]
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.APPLET_ANSWER_FILE_DOWNLOAD
+            assert event.event_outcome == EventOutcome.SUCCESS
+            assert event.curious_applet_id == [applet_one.id]
+            assert event.file_path == url
+
+    async def test_presign_success_single_url(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        audit_log = mocker.patch("apps.file.api.file.log")
+        client.login(tom)
+
+        key = "1693560380000/c60859c4-6f5f-4390-a572-da85fcd59709"
+        url = f"s3://bucket/mindlogger/answer/{tom.id}/{applet_one.id}/{key}"
+        response = await client.post(
+            self.presign_url.format(applet_id=applet_one.id),
+            data={"privateUrls": [url]},
+        )
+
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_ANSWER_FILE_DOWNLOAD
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.curious_applet_id == [applet_one.id]
+        assert event.file_path == url
+
+    async def test_presign_failure_emits_per_url(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(
+            "apps.file.api.file.get_presign_service",
+            side_effect=AccessDeniedError(),
+        )
+        audit_log = mocker.patch("apps.file.api.file.log")
+        client.login(tom)
+
+        urls = ["s3://bucket/a", "s3://bucket/b"]
+        response = await client.post(
+            self.presign_url.format(applet_id=applet_one.id),
+            data={"privateUrls": urls},
+        )
+
+        assert response.status_code != http.HTTPStatus.OK
+        assert audit_log.await_count == 2
+        for call, url in zip(audit_log.await_args_list, urls):
+            event = call.args[0]
+            assert event.user_id == tom.id
+            assert event.event_action == EventAction.APPLET_ANSWER_FILE_DOWNLOAD
+            assert event.event_outcome == EventOutcome.FAILURE
+            assert event.curious_applet_id == [applet_one.id]
+            assert event.file_path == url


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10746](https://mindlogger.atlassian.net/browse/M2-10746)

Instruments five file-download endpoints with `AuditEvent` emission. No enum, mapping, or index changes - everything we need is already declared.

| event.action | Endpoint |
|---|---|
| `applet:answer:ehr:download` | `GET /answers/applet/{applet_id}/ehr-data` |
| `applet:answer:file:download` | `POST /file/{applet_id}/download` |
| `applet:answer:file:download` | `POST /file/{applet_id}/presign` |
| `applet:answer:report:download` | `POST /answers/applet/{applet_id}/activities/{activity_id}/subjects/{subject_id}/latest_report` |
| `applet:answer:report:download` | `POST /answers/applet/{applet_id}/flows/{flow_id}/subjects/{subject_id}/latest_report` |

Notes:

- **EHR success** carries the distinct `subject_id` / `activity_id` / `submit_id` sets derived from the exported rows; failure paths only know the applet.
- **Presign fan-out**: one event per `private_url` in the request body, matching the workspace IAM precedent.
- **Body param rename** in `apps/file/api/file.py`: `request: FileDownloadRequest` → `schema: FileDownloadRequest` (same for presign) so `Request` can be injected for `http_audit_fields`. Parameter-name change only; no client impact.

