### PR TITLE
Feat: i18n add af, xh, zu languages support ( M2-10767 )

### DIFF
--- a/src/apps/activity_assignments/tests/test_assignments.py
+++ b/src/apps/activity_assignments/tests/test_assignments.py
@@ -130,7 +130,7 @@ class TestActivityAssignments(BaseTest):
     user_activities_assignments = "/users/me/assignments/{applet_id}"
     activities_assign_unassign_applet = "/assignments/applet/{applet_id}"
 
-    @pytest.mark.parametrize("invite_language", ["en", "fr", "el"])
+    @pytest.mark.parametrize("invite_language", ["en", "fr", "el", "af", "xh", "zu"])
     async def test_create_one_assignment(
         self,
         client: TestClient,

--- a/src/apps/invitations/domain.py
+++ b/src/apps/invitations/domain.py
@@ -21,6 +21,9 @@ class InvitationLanguage(StrEnum):
     EL = "el"  # Greek
     ES = "es"  # Spanish
     PT = "pt"  # Portuguese
+    AF = "af"  # Afrikaans
+    XH = "xh"  # isiXhosa
+    ZU = "zu"  # isiZulu
 
 
 class InvitationRequest(InternalModel):

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -213,7 +213,7 @@ class TestInvite(BaseTest):
     shell_acc_create_url = f"{invitation_list}/{{applet_id}}/shell-account"
     shell_acc_invite_url = f"{invitation_list}/{{applet_id}}/subject"
 
-    @pytest.mark.parametrize("invite_language", ["en", "fr", "el"])
+    @pytest.mark.parametrize("invite_language", ["en", "fr", "el", "af", "xh", "zu"])
     @pytest.mark.parametrize(
         "inviter_type,invitee_type,invite_status",
         [
@@ -301,7 +301,7 @@ class TestInvite(BaseTest):
                 assert response.json()["result"]["tag"] is not None
                 assert response.json()["result"]["tag"] == payload.tag
 
-    @pytest.mark.parametrize("invite_language", ["en", "fr"])
+    @pytest.mark.parametrize("invite_language", ["en", "fr", "af", "xh", "zu"])
     @pytest.mark.parametrize("invitee_type", ["manager", "coordinator", "editor", "reviewer", "respondent"])
     async def test_invite_new_user(
         self,

--- a/src/apps/mailing/static/templates/blocks/team_info_af.html
+++ b/src/apps/mailing/static/templates/blocks/team_info_af.html
@@ -1,0 +1,3 @@
+<tr>
+  <td style="padding-top: 24px; padding-bottom: 1%">– die Curious-span</td>
+</tr>

--- a/src/apps/mailing/static/templates/blocks/team_info_xh.html
+++ b/src/apps/mailing/static/templates/blocks/team_info_xh.html
@@ -1,0 +1,3 @@
+<tr>
+  <td style="padding-top: 24px; padding-bottom: 1%">– Iqela le-Curious</td>
+</tr>

--- a/src/apps/mailing/static/templates/blocks/team_info_zu.html
+++ b/src/apps/mailing/static/templates/blocks/team_info_zu.html
@@ -1,0 +1,3 @@
+<tr>
+  <td style="padding-top: 24px; padding-bottom: 1%">– Ithimba Le-Curious</td>
+</tr>

--- a/src/apps/mailing/static/templates/footers/footer_info_af.html
+++ b/src/apps/mailing/static/templates/footers/footer_info_af.html
@@ -1,0 +1,40 @@
+<table border="0" cellpadding="0" cellspacing="0" style="width: 100%; text-align: center">
+  <tr>
+    <td>
+      <table border="0" cellpadding="0" cellspacing="0" style="
+          width: 100%;
+          background: #eff4fa;
+          padding: 26px;
+          border-radius: 8px;
+          text-align: center;
+        ">
+        <tr>
+          <td colspan="2" style="padding-bottom: 14px; font-size: 14px"> Kry die Curious- mobiele toep: </td>
+        </tr>
+        <tr>
+          <td width="50%" align="right" style="padding-right: 4px">
+            <a href="https://apps.apple.com/br/app/mindlogger/id1299242097">
+              <img src="https://media.mindlogger.org/apple-store.png" style="height: 44px" alt="Kry iOS-toep">
+            </a>
+          </td>
+          <td width="50%" align="left" style="padding-left: 4px">
+            <a href="https://play.google.com/store/apps/details?id=lab.childmindinstitute.data&pli=1">
+              <img src="https://media.mindlogger.org/google-play.png" style="height: 44px" alt="Kry Android-toep">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="padding-top: 23px; font-size: 14px"> Benodig hulp? <a href="https://mindlogger.atlassian.net/servicedesk/customer/portals" style="color: black"> Besoek ons hulpsentrum </a>. </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="padding-top: 32px">
+      <img src="https://media.mindlogger.org/cmi-logo.png" style="width: 106px" alt="Child Mind Institute">
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="color: #51606f; padding-top: 12px; font-size: 12px"> Die Child Mind Institute is die skepper van Curious, maar dit is nie verantwoordelik vir inhoud wat deur buitepartye geskep word nie. </td>
+  </tr>
+</table>

--- a/src/apps/mailing/static/templates/footers/footer_info_xh.html
+++ b/src/apps/mailing/static/templates/footers/footer_info_xh.html
@@ -1,0 +1,40 @@
+<table border="0" cellpadding="0" cellspacing="0" style="width: 100%; text-align: center">
+  <tr>
+    <td>
+      <table border="0" cellpadding="0" cellspacing="0" style="
+          width: 100%;
+          background: #eff4fa;
+          padding: 26px;
+          border-radius: 8px;
+          text-align: center;
+        ">
+        <tr>
+          <td colspan="2" style="padding-bottom: 14px; font-size: 14px"> Fumana i-Curious app mobile: </td>
+        </tr>
+        <tr>
+          <td width="50%" align="right" style="padding-right: 4px">
+            <a href="https://apps.apple.com/br/app/mindlogger/id1299242097">
+              <img src="https://media.mindlogger.org/apple-store.png" style="height: 44px" alt="Fumana usetyenziso lwe-iOS">
+            </a>
+          </td>
+          <td width="50%" align="left" style="padding-left: 4px">
+            <a href="https://play.google.com/store/apps/details?id=lab.childmindinstitute.data&pli=1">
+              <img src="https://media.mindlogger.org/google-play.png" style="height: 44px" alt="Fumana usetyenziso lwe-Android">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="padding-top: 23px; font-size: 14px"> Udinga uncedo? <a href="https://mindlogger.atlassian.net/servicedesk/customer/portals" style="color: black"> Ndwendwela iziko lethu loNcedo </a>. </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="padding-top: 32px">
+      <img src="https://media.mindlogger.org/cmi-logo.png" style="width: 106px" alt="Iziko leNgqondo yoMntwana">
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="color: #51606f; padding-top: 12px; font-size: 12px"> I-Child Mind Institute ngumdali weCurious kodwa ayinaxanduva lomxholo owenziwe ngamaqela angaphandle. </td>
+  </tr>
+</table>

--- a/src/apps/mailing/static/templates/footers/footer_info_zu.html
+++ b/src/apps/mailing/static/templates/footers/footer_info_zu.html
@@ -1,0 +1,40 @@
+<table border="0" cellpadding="0" cellspacing="0" style="width: 100%; text-align: center">
+  <tr>
+    <td>
+      <table border="0" cellpadding="0" cellspacing="0" style="
+          width: 100%;
+          background: #eff4fa;
+          padding: 26px;
+          border-radius: 8px;
+          text-align: center;
+        ">
+        <tr>
+          <td colspan="2" style="padding-bottom: 14px; font-size: 14px"> Thola i-app yeselula ye-Curious: </td>
+        </tr>
+        <tr>
+          <td width="50%" align="right" style="padding-right: 4px">
+            <a href="https://apps.apple.com/br/app/mindlogger/id1299242097">
+              <img src="https://media.mindlogger.org/apple-store.png" style="height: 44px" alt="Thola i-app ye-iOS">
+            </a>
+          </td>
+          <td width="50%" align="left" style="padding-left: 4px">
+            <a href="https://play.google.com/store/apps/details?id=lab.childmindinstitute.data&pli=1">
+              <img src="https://media.mindlogger.org/google-play.png" style="height: 44px" alt="Thola i-app ye-Android">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="padding-top: 23px; font-size: 14px"> Udinga usizo? <a href="https://mindlogger.atlassian.net/servicedesk/customer/portals" style="color: black"> Vakashela Isikhungo sethu Sosizo </a>. </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="padding-top: 32px">
+      <img src="https://media.mindlogger.org/cmi-logo.png" style="width: 106px" alt="I-Child Mind Institute">
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" style="color: #51606f; padding-top: 12px; font-size: 12px"> I-Child Mind Institute ingumsunguli we-Curious kodwa ayinasibopho sokuqukethwe okusungulwe amaqembu angaphandle. </td>
+  </tr>
+</table>

--- a/src/apps/mailing/static/templates/invitation_new_user_af.html
+++ b/src/apps/mailing/static/templates/invitation_new_user_af.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Hallo {{first_name}} </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Jy word uitgenooi om {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}’n{% else %}’n{% endif %} {{role}} van <b>“{{applet_name}}”</b> te word in Curious, ’n dataversamelingsplatform vir geestesgesondheid en leeruitdagings. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Skep jou rekening en kom aan die gang </a>
+    </td>
+  </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_new_user_xh.html
+++ b/src/apps/mailing/static/templates/invitation_new_user_xh.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Mholo {{first_name}}, </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Umenyiwe ukuba ube {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} of <b>"{{applet_name}}"</b> kwi-Curious, iqonga lokuqokelela idatha kwimpilo yengqondo kunye nemingeni yokufunda. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Yenza i-akhawunti yakho kwaye uqalise </a>
+    </td>
+  </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_new_user_zu.html
+++ b/src/apps/mailing/static/templates/invitation_new_user_zu.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Sawubona {{first_name}}, </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Umenywe ukuthi ube {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} of <b>"{{applet_name}}"</b> ku-Curious, inkundla yokuqoqwa kwedatha yezinselele zempilo yengqondo nokufunda. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Sungula i-akhawunti yakho bese uqala </a>
+    </td>
+  </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_registered_user_af.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_af.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Hallo {{first_name}} </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Jy word uitgenooi om {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}’n{% else %}’n{% endif %} {{role}} van <b>“{{applet_name}}”</b> te word in Curious. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Kom aan die gang </a>
+    </td>
+  </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_registered_user_xh.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_xh.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Mholo {{first_name}}, </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Umenyiwe ukuba ube {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} ye <b>"{{applet_name}}"</b> kwi-Curious. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Qalisa </a>
+    </td>
+  </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/invitation_registered_user_zu.html
+++ b/src/apps/mailing/static/templates/invitation_registered_user_zu.html
@@ -1,0 +1,13 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+
+<body> {% include 'header.html' %} <table style="padding: 0"> <tr>
+    <td style="padding-bottom: 1%"> Sawubona {{first_name}}, </td>
+  </tr> <tr>
+    <td style="padding-bottom: 1%"> Umenywe ukuthi ube {% if role[0]|lower in ['a', 'e', 'i', 'o', 'u'] %}an{% else %}a{% endif %} {{role}} kokuthi <b>"{{applet_name}}"</b> ku-Curious. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}/{{key}}?lang={{language}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Qalisa </a>
+    </td>
+  </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_account_locked_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_account_locked_af.html
@@ -1,0 +1,23 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Jou rekening is gesluit as gevolg van te veel mislukte tweefaktor-verifikasiepogings. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Besonderhede:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Mislukte pogings: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Rede: {{lockout_reason}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Gesluit om: {{locked_at}} </td>
+      </tr> {% if lockout_ttl_seconds %} <tr>
+        <td style="padding-bottom: 16px"> Jou rekening sal outomaties ontsluit word oor ongeveer {{(lockout_ttl_seconds / 60)|int}} minute. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> As jy nie probeer het om aan te meld nie, dan probeer iemand dalk om toegang tot jou rekening te kry. Ons beveel dit aan dat jy dadelik jou wagwoord verander nadat jou rekening ontsluit is. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Indien jy onmiddellike bystand benodig, kontak asseblief ons steundiensspan by <a href="mailto:{{support_email}}">{{support_email}}</a>. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_account_locked_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_account_locked_xh.html
@@ -1,0 +1,23 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> I-akhawunti yakho itshixiwe ngenxa yeenzame ezininzi ezingaphumelelanga zokuqinisekisa. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Iinkcukacha:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Iinzame aziphumelelanga: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Isizathu: {{lockout_reason}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Itshixiwe: {{locked_at}} </td>
+      </tr> {% if lockout_ttl_seconds %} <tr>
+        <td style="padding-bottom: 16px"> I-akhawunti yakho iya kuvulwa ngokuzenzekelayo malunga {{(lockout_ttl_seconds / 60)|int}} imizuzu. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> Ukuba khange uzame ukungena, kukho umntu ozama ukufikelela kwi-akhawunti yakho. Sicebisa ukuba utshintshe igama eliyimfihlo ngoko nangoko emva kokuba i-akhawunti yakho ivuliwe. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba ufuna uncedo olukhawulezileyo, nceda uqhagamshelane neqela lethu lenkxaso ku <a href="mailto:{{support_email}}">{{support_email}}</a>. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_account_locked_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_account_locked_zu.html
@@ -1,0 +1,23 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> I-akhawunti yakho ikhiyiwe ngenxa yemizamo eminingi ehlulekile yokuqinisekisa izici ezimbili. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Imininingwane:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Imizamo ehlulekile: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Isizathu: {{lockout_reason}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Kukhiywe kokuthi: {{locked_at}} </td>
+      </tr> {% if lockout_ttl_seconds %} <tr>
+        <td style="padding-bottom: 16px"> I-akhawunti yakho izovulwa ngokuzenzakalela cishe emizuzwini engu-{{(lockout_ttl_seconds / 60)|int}}. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange uzame ukungena, kungenzeka ukuthi othile uzama ukufinyelela i-akhawunti yakho. Sincoma ukuthi uguqule iphasiwedi yakho ngokushesha ngemuva kokuthi i-akhawunti yakho isivuliwe. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma udinga usizo olusheshayo, sicela uxhumane nethimba lethu losekelo kokuthi <a href="mailto:{{support_email}}">{{support_email}}</a>. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_af.html
@@ -1,0 +1,25 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Iemand het probeer om tweefaktor-verifikasie op jou rekening met ’n verkeerde verifikasiekode te deaktiveer. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Pogingbesonderhede:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Tyd: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Mislukte pogings: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Jou tweefaktor-verifikasie bly geaktiveer en jou rekening is beveiligd. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Indien dit nie jy was nie, het iemand dalk toegang tot jou wagwoord. Onderneem dadelik aksie: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Verander dadelik jou wagwoord </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Gaan jou onlangse rekeningaktiwiteit na </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Kontak die steundiens as jy bystand benodig </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_xh.html
@@ -1,0 +1,25 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Umntu othile uzame ukukhubaza ungqinisiso lwezinto ezimbini kwi-akhawunti yakho ngekhowudi yokuqinisekisa engachanekanga. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Iinkcukacha Zomzamo:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ixesha: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Iinzame aziphumelelanga: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> I-two-factor authentication yakho ihlala isebenza kwaye i-akhawunti yakho ikhuselekile. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ukuba ibingenguwe lo, umntu unokufikelela kwiphasiwedi yakho. Thatha inyathelo ngokukhawuleza: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Tshintsha iphasiwedi yakho ngoku </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Phonononga umsebenzi we-akhawunti yakho yakutshanje </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Qhagamshelana nenkxaso ukuba ufuna uncedo </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disable_failed_attempts_zu.html
@@ -1,0 +1,25 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Othile uzame ukukhubaza ukuqinisekiswa kwezici ezimbili ku-akhawunti yakho ngekhodi yokuqinisekisa engalungile. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Imininingwane Yomzamo:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Isikhathi: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Imizamo ehlulekile: {{failed_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuqinisekisa kwakho kwezici ezimbili kuhlala kunikwe amandla futhi i-akhawunti yakho ivikelekile. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Uma bekungewena lona, ​​omunye angase akwazi ukufinyelela iphasiwedi yakho. Thatha isinyathelo ngokushesha: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Shintsha iphasiwedi yakho manje </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Buyekeza umsebenzi wakho wakamuva we-akhawunti </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Xhumana nosekelo uma udinga usizo </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disabled_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disabled_af.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Tweefaktor-verifikasie is op jou rekening gedeaktiveer. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Hierdie verandering is op {{disabled_at}} aangebring. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00;"> Jou rekening is nou minder beveiligd sonder tweefaktor-verifikasie. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Indien jy nie tweefaktor-verifikasie gedeaktiveer het nie, is jou rekening dalk in gevaar. Doen die volgende: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Verander dadelik jou wagwoord </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Heraktiveer tweefaktor-verifikasie </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Gaan jou onlangse rekeningaktiwiteit na </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disabled_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disabled_xh.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> I-Two-Factor Authentication ivaliwe kwi-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Olu tshintsho lwenziwe kwi {{disabled_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00;"> I-akhawunti yakho ngoku ayikhuselekanga kancinci ngaphandle koqinisekiso lwezinto ezimbini. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba awuzange ucime i-two-factor authentication, i-akhawunti yakho inokuba sengozini. Uyacelwa: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Tshintsha iphasiwedi yakho ngoko nangoko </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Yenza kwakhona i two-factor authenticate isebenze </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Phonononga umsebenzi we-akhawunti yakho yakutshanje </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_disabled_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_disabled_zu.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ukufakazela ubuqiniso kwezici ezimbili kukhutshaziwe ku-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Lolu shintsho lwenziwe ngo-{{disabled_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00;"> I-akhawunti yakho manje ivikeleke kancane ngaphandle kokuqinisekiswa kwezici ezimbili. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange ucime ukuqinisekiswa kwezici ezimbili, i-akhawunti yakho ingase ibe sengozini. Ngiyacela: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Shintsha iphasiwedi yakho ngokushesha </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Nika amandla kabusha ukuqinisekiswa kwezici ezimbili </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Buyekeza umsebenzi wakho wakamuva we-akhawunti </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_enabled_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_enabled_af.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #388e3c; font-weight: bold;"> Tweefaktor-verifikasie is suksesvol op jou rekening geaktiveer! </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Hierdie verandering is op {{enabled_at}} aangebring. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Jou rekening is nou meer beveiligd. Van nou af sal jy ’n verifikasiekode vanaf jou waarmerkingstoep (authenticator) moet invoer wanneer jy aanmeld. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Belangrik: Jy het {{recovery_codes_count}} herstelkodes. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Herstelkodes gee jou toegang tot jou rekening as jy jou waarmerkingstoestel (authenticator) verloor. Jy kan jou herstelkodes enige tyd besigtig deur jou instellings in die Curious-admin te besoek. Doen die volgende: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Bewaar dit op ’n veilige plek </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Moenie dit met enigiemand deel nie </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> As jy nie tweefaktor-verifikasie geaktiveer het nie, kontak dadelik die steundiens. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_enabled_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_enabled_xh.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #388e3c; font-weight: bold;"> I-Two-factor authentication yenziwe ngempumelelo kwi-akhawunti yakho! </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Olu tshintsho lwenziwe {{enabled_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> I-akhawunti yakho ngoku ikhuseleke ngakumbi. Ukusukela ngoku ukuya phambili, kuya kufuneka ufake ikhowudi yokuqinisekisa kwi-app yakho yesiqinisekiso xa ungena. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Important: Unayo {{recovery_codes_count}} iikhowudi yokuchacha. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Iikhowudi zokubuyisa zikuvumela ukuba ufikelele kwi-akhawunti yakho ukuba ulahlekelwe sisixhobo sakho sobunyani. Ungajonga iikhowudi zakho zokubuyisela nanini na ngokundwendwela useto lwakho kwiCurious admin. Qiniseka ukuba: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Zigcine kwindawo ekhuselekileyo nekhuselekileyo </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Ungabelani ngazo nabani na </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba awuzange wenze i-two-factor authentication isebenze, nceda uqhagamshelane nenkxaso ngoko nangoko. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_enabled_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_enabled_zu.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #388e3c; font-weight: bold;"> Ukuqinisekiswa kwezici ezimbili kuvulwe amandla ngempumelelo ku-akhawunti yakho! </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Lolu shintsho lwenziwe ngo-{{enabled_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> I-akhawunti yakho manje isivikeleke kakhulu. Kusukela manje, uzodinga ukufaka ikhodi yokuqinisekisa kusukela ku-app yokufakazela ubuqiniso uma ungena ngemvume. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Okubalulekile: Unamakhodi okutakula angu-{{recovery_codes_count}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Amakhodi okutakula akuvumela ukuthi ufinyelele i-akhawunti yakho uma ulahlekelwa idivayisi yakho yokuqinisekisa. Ungabuka amakhodi akho okutakula noma kunini ngokuvakashela amasethingi akho kumphathi we-Curious. Qiniseka ukuthi: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Uwagcina endaweni ephephile nevikelekile </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Awabelani ngawo nanoma ubani </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange unike amandla ukuqinisekiswa kwezici ezimbili, sicela uxhumane nosekelo ngokushesha. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_af.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Ons het meerdere mislukte verifikasiepogings op jou rekening bespeur. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Mislukte pogings:</strong> {{failed_attempts}} van {{max_attempts}} maksimum pogings </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Pogings oor:</strong> {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Waarskuwing: Jou rekening sal tydelik gesluit wees as jy {{max_attempts}} mislukte pogings bereik het. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Indien dit jy is, doen asseblief die volgende: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Sorg dat jy die korrekte verifikasiekode van jou waarmerkingstoep (authenticator) gebruik </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Gebruik ’n herstelkode as jy nie toegang tot jou waarmerkingstoep (authenticator) het nie </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> As jy nie probeer het om aan te meld nie, dan probeer iemand dalk om toegang tot jou rekening te kry. Oorweeg dit om jou wagwoord te verander. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_xh.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Sichonge iinzame ezininzi ezisileleyo zokuqinisekisa kwi-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Iinzame ezingaphumelelanga:</strong> {{failed_attempts}} of {{max_attempts}} ubuninzi bemizamo </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Iinzame eziseleyo:</strong> {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> I-akhawunti yakho iya kuvalwa okwethutyana ukuba uyafikelela {{max_attempts}} iinzame aziphumelelanga. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba nguwe lo, nceda: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Qinisekisa ukuba usebenzisa ikhowudi yokuqinisekisa eyiyo ye-athenticator app yakho </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Sebenzisa ikhowudi yokubuyisela ukuba awukwazi ukufikelela ye-athenticator app yakho </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba khange uzame ukungena, kukho umntu ozama ukufikelela kwi-akhawunti yakho. Cinga ngokutshintsha iphasiwedi yakho. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_failed_attempts_warning_zu.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Sithole imizamo eminingi ehlulekile yokuqinisekisa ku-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Imizamo Ehlulekile:</strong> {{failed_attempts}} kwemikhawulo yemizamo engu-{{max_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <strong>Imizamo Esele:</strong> {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Isexwayiso: I-akhawunti yakho izokhiywa isikhashana uma ufinyelela imizamo ehlulekile engu-{{max_attempts}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma kunguwe lo, sicela: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Qiniseka ukuthi usebenzisa ikhodi yokuqinisekisa elungile evela ku-app yokufakazela ubuqiniso </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Sebenzisa ikhodi yokutakula uma ungakwazi ukufinyelela ku-app yokufakazela ubuqiniso </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange uzame ukungena, kungenzeka ukuthi othile uzama ukufinyelela i-akhawunti yakho. Cabangela ukushintsha iphasiwedi yakho. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_af.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Jy het {% if remaining_count == 0 %}geen{% else %}slegs {{remaining_count}}{% endif %} herstelkode{% if remaining_count != 1 %}s{% endif %} oor. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Herstelkodes word gebruik om toegang tot jou rekening te kry wanneer jy nie toegang tot jou waarmerkingstoep (authenticator) het nie. Sodra jy al jou kodes gebruik het, sal jy dit nie meer kan gebruik om aan te meld nie. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ons beveel sterk aan dat jy nou nuwe herstelkodes genereer om te verseker dat jy altyd toegang tot jou rekening het. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Hoe om nuwe herstelkodes te genereer: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Meld aan by jou rekening </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Gaan na jou sekuriteitinstellings </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Kies “Genereer nuwe herstelkodes” </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_xh.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Une {% if remaining_count == 0 %}no{% else %} kuphela {{remaining_count}}{% endif %} recovery code{% if remaining_count != 1 %}s{% endif %} eseleyo. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Iikhowudi zokubuyisa zisetyenziselwa ukufikelela kwi-akhawunti yakho xa ungafikeleli kwi-app yakho yesiqinisekiso. Nje ukuba usebenzise zonke iikhowudi zakho, awuyi kukwazi ukuzisebenzisa ukungena. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Sicebisa ngamandla ukwenza iikhowudi ezintsha zokubuyisela ngoku ukuze uqinisekise ukuba ungasoloko ufikelela kwi-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukwenza iikhowudi ezintsha zokubuyisela: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Ngena kwi-akhawunti yakho </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Yiya kwiisetingi zakho zokhuseleko </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Khetha "Yenza iikhowudi zoBuyiselo eziNtsha" </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_last_recovery_code_zu.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Usalelwe {% if remaining_count == 0 %}no{% else %}only {{remaining_count}}{% endif %} recovery code{% if remaining_count != 1 %}s{% endif %}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Amakhodi okutakula asetshenziselwa ukufinyelela i-akhawunti yakho uma ungakwazi ukufinyelela ku-app lokufakazela ubuqiniso. Uma ususebenzise wonke amakhodi akho, ngeke ukwazi ukuwasebenzisa ukuze ungene ngemvume. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Sincoma ngokuqinile ukuthi ukhiqize amakhodi amasha okutakula manje ukuze uqinisekise ukuthi ungahlala ufinyelela i-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuze ukhiqize amakhodi amasha okutakula: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Ngena ngemvume ku-akhawunti yakho </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Iya kumasethingi akho okuphepha </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Khetha “Khiqiza Amakhodi Okubuyisela amasha” </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_af.html
@@ -1,0 +1,15 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> ’n Herstelkode is gebruik om toegang tot jou rekening te kry. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> ’n Herstelkode is gebruik op {{used_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Jy het <strong>{{remaining_codes}} herstelkode{% if remaining_codes != 1 %}s{% endif %} oor</strong>. </td>
+      </tr> {% if remaining_codes <= 3 %} <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Jy het tans min herstelkodes oor. Oorweeg dit om binnekort nuwes te genereer. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> Indien dit nie jy was nie, is jou rekening dalk in gevaar. Verander jou wagwoord en gaan dadelik jou sekuriteitinstellings na. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_xh.html
@@ -1,0 +1,15 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ikhowudi yokubuyisela isetyenziswe ukufikelela kwi-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ikhowudi yokubuyisela isetyenziswe {{used_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Une <strong>{{remaining_codes}} recovery code{% if remaining_codes != 1 %}s{% endif %} remaining</strong>. </td>
+      </tr> {% if remaining_codes <= 3 %} <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Uphelelwa kwiikhowudi zokubuyisela. Cinga ngokwenza ezintsha kungekudala. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> Ukuba ibingenguwe lo, i-akhawunti yakho inokuba sengozini. Tshintsha iphasiwedi yakho kwaye ujonge useto lwakho lokhuseleko kwangoko. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_code_used_zu.html
@@ -1,0 +1,15 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ikhodi yokutakula isetshenzisiwe ukuze kufinyelelwe i-akhawunti yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ikhodi yokutakula isetshenziswe ngo-{{used_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Usalelwe <strong>{{remaining_codes}} recovery code{% if remaining_codes != 1 %}s{% endif %}</strong>. </td>
+      </tr> {% if remaining_codes <= 3 %} <tr>
+        <td style="padding-bottom: 16px; color: #f57c00; font-weight: bold;"> Uphelelwa ngamakhodi okutakula. Cabangela ukukhiqiza amasha maduze. </td>
+      </tr> {% endif %} <tr>
+        <td style="padding-bottom: 16px"> Uma bekungewena lona, ​​i-akhawunti yakho ingase ibe sengozini. Shintsha iphasiwedi yakho futhi ubuyekeze amasethingi akho okuphepha ngokushesha. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_af.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Jou herstelkodes is afgelaai op {{downloaded_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Herstelkodes is sensitiewe sekuriteitsaanmeldinligting wat jou in staat stel om toegang tot jou rekening te kry wanneer jy nie jou waarmerkingstoep (authenticator) het nie. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Sekuriteitherinnering: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Bewaar dit op ’n beveiligde plek </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Moet dit nooit met iemand deel nie </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Elke kode kan slegs een keer gebruik word </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Genereer nuwe kodes as daar min oor is </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> As jy nie jou herstelkodes aflaai nie, kontak dadelik die steundiens. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_xh.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Iikhowudi zakho zokubuyisela zikhutshelwe {{downloaded_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Iikhowudi zoBuyiselo ziziqinisekiso zokhuseleko ezibuthathaka ezikuvumela ukuba ufikelele kwi-akhawunti yakho xa ungenayo i-app yakho yesiqinisekiso. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Isikhumbuzi sokhuseleko: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Zigcine kwindawo ekhuselekileyo </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ungaze wabelane ngazo nabani na </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ikhowudi nganye ingasetyenziswa kube kanye kuphela </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Yenza iikhowudi ezintsha xa uphantsi </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba awuzange ukhuphele iikhowudi zakho zokubuyisela, nceda uqhagamshelane nenkxaso ngokukhawuleza. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_downloaded_zu.html
@@ -1,0 +1,21 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Amakhodi akho okutakula adawunilodwe ngo-{{downloaded_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Amakhodi okutakula ayiziqinisekiso zokuvikela ezibucayi ezikuvumela ukuthi ufinyelele i-akhawunti yakho uma ungenayo i-app yakho yokufakazela ubuqiniso. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Isikhumbuzi sokuvikeleka: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Wagcine endaweni evikelekile </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ungalokothi wabelane ngawo nanoma ubani </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ikhodi ngayinye ingasetshenziswa kanye kuphela </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Khiqiza amakhodi amasha uma uphelelwa amandla </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange udawunilode amakhodi akho okutakula, sicela uxhumane nosekelo ngokushesha. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_af.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Jou herstelkodes is bekyk op {{viewed_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Hierdie is ’n roetine-sekuriteitskennisgewing om jou op hoogte te hou oor die toegang tot jou herstelkodes. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Herstelkodes is sensitiewe sekuriteitsinligting. Doen die volgende: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Hou dit privaat en beveiligd </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Moet dit nooit met iemand deel nie </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Bewaar dit op ’n veilige plek </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> As jy nie jou herstelkodes bekyk het nie, kontak dadelik die steundiens. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_xh.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Iikhowudi zakho zokubuyisela zijongwe {{viewed_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Esi sisaziso sokhuseleko esihlala sisazi malunga nokufikelela kwiikhowudi zakho zokubuyisela. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Iikhowudi zokubuyisa ziimpawu zokhuseleko ezinovakalelo. Qiniseka ukuba: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Zigcine ziyimfihlo kwaye zikhuselekile </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ungaze wabelane ngazo nabani na </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Zigcine kwindawo ekhuselekileyo </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba awukhange ujonge iikhowudi zakho zokubuyisela, nceda uqhagamshelane nenkxaso ngokukhawuleza. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_recovery_codes_viewed_zu.html
@@ -1,0 +1,19 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Amakhodi akho okuthola abukwe ku-{{viewed_at}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Lesi isaziso sokuphepha esijwayelekile sokukugcina unolwazi mayelana nokufinyelela amakhodi akho okutakula. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Amakhodi okutakula ayiziqinisekiso zokuphepha ezibucayi. Qiniseka ukuthi: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Uwagcina eyimfihlo futhi evikelekile </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ungalokothi wabelane ngawo nanoma ubani </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Uwagcina endaweni ephephile </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange ubuke amakhodi akho okutakula, sicela uxhumane nosekelo ngokushesha. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_af.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_af.html
@@ -1,0 +1,31 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Hallo {{first_name}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Iemand het probeer om jou herstelkodes met ’n verkeerde verifikasiekode te bekyk. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Pogingbesonderhede:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Tyd: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Mislukte pogings: {{failed_attempts}} van {{max_attempts}} maksimum pogings </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Pogings oor: {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Jou herstelkodes bly beveiligd en daar is nie daartoe toegang verkry nie. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Waarskuwing: Jou rekening sal tydelik gesluit wees as jy {{max_attempts}} mislukte pogings bereik het. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Indien dit nie jy was nie, het iemand dalk toegang tot jou wagwoord. Onderneem dadelik aksie: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Verander dadelik jou wagwoord </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Gaan jou onlangse rekeningaktiwiteit na </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Maak seker dat jou waarmerkingstoep (authenticator) gesinkroniseer is en korrek werk </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> As jy probeer het om jou herstelkodes te sien, maak asseblief seker dat jy die korrekte verifikasiekode van jou waarmerkingstoep (authenticator) gebruik. </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_xh.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_xh.html
@@ -1,0 +1,31 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Mholo {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Umntu uzame ukujonga iikhowudi zakho zokubuyisela ngekhowudi yokuqinisekisa engachanekanga. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Iinkcukacha Zomzamo:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Ixesha: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> Iinzame ezingaphumelelanga: {{failed_attempts}} of {{max_attempts}} ubuninzi bemizamo </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> Iinzame eziseleyo: {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Iikhowudi zakho zokubuyisela zihlala zikhuselekile kwaye azikafikelelwa. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> I-akhawunti yakho iya kuvalwa okwethutyana ukuba uyafikelela {{max_attempts}} iinzame aziphumelelanga. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Ukuba ibingenguwe lo, umntu unokufikelela kwiphasiwedi yakho. Thatha inyathelo ngokukhawuleza: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Tshintsha iphasiwedi yakho ngoku </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Phonononga umsebenzi we-akhawunti yakho yakutshanje </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Qinisekisa ukuba i-app yakho yonyaniselwano ingqanyaniswa kwaye isebenza ngokuchanekileyo </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba ubuzama ukujonga iikhowudi zakho zokubuyisela, nceda uqinisekise ukuba usebenzisa ikhowudi yokuqinisekisa echanekileyo esuka kwi-app yakho yesiqinisekiso. </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_zu.html
+++ b/src/apps/mailing/static/templates/mfa/mfa_view_recovery_codes_failed_attempts_zu.html
@@ -1,0 +1,31 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sawubona {{first_name}}, </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Othile uzame ukubuka amakhodi akho okutakula ngekhodi yokuqinisekisa engalungile. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px">
+          <strong>Imininingwane Yomzamo:</strong>
+        </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> • Isikhathi: {{attempted_at}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Imizamo ehlulekile: {{failed_attempts}} kwemikhawulo yemizamo engu-{{max_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> • Imizamo esele: {{remaining_attempts}} </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Amakhodi akho okutakula ahlala evikelekile futhi awakaze afinyelelwe. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; color: #d32f2f; font-weight: bold;"> Isexwayiso: I-akhawunti yakho izokhiywa isikhashana uma ufinyelela imizamo ehlulekile engu-{{max_attempts}}. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px; font-weight: bold;"> Uma bekungewena lona, ​​omunye angase akwazi ukufinyelela iphasiwedi yakho. Thatha isinyathelo ngokushesha: </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 1. Shintsha iphasiwedi yakho manje </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 8px"> 2. Buyekeza umsebenzi wakho wakamuva we-akhawunti </td>
+      </tr> <tr>
+        <td style="padding-left: 20px; padding-bottom: 16px"> 3. Qiniseka ukuthi i-app yakho yokufakazela ubuqiniso ivumelanisiwe futhi isebenza kahle </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ubuzama ukubuka amakhodi akho okutakula, sicela uqinisekise ukuthi usebenzisa ikhodi yokuqinisekisa elungile evela ku-app yokufakazela ubuqiniso. </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/new_activity_assignments_af.html
+++ b/src/apps/mailing/static/templates/new_activity_assignments_af.html
@@ -1,0 +1,16 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+<body> {% include 'header.html' %} <table style="padding: 0">
+  <tr>
+    <td style="padding-bottom: 1%"> Hallo {{first_name}} </td>
+  </tr>
+  <tr>
+    <td style="padding-bottom: 1%"> Jy is aan 1 of meer aktiwiteite toegewys in <b>“{{applet_name}}”</b>. </td>
+  </tr>
+</table> <ul> {% for name in activity_or_flows_names %} <li>{{name}}</li> {% endfor %} </ul> <table style="padding: 0"> <tr>
+    <td> Meld asseblief aan om die besonderhede van die toewysing in Curious te beoordeel. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Kom aan die gang </a>
+    </td>
+  </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/new_activity_assignments_xh.html
+++ b/src/apps/mailing/static/templates/new_activity_assignments_xh.html
@@ -1,0 +1,16 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+<body> {% include 'header.html' %} <table style="padding: 0">
+  <tr>
+    <td style="padding-bottom: 1%"> Mholo {{first_name}}, </td>
+  </tr>
+  <tr>
+    <td style="padding-bottom: 1%"> Unikwe umsebenzi om-1 okanye ngaphezulu <b>"{{applet_name}}"</b>. </td>
+  </tr>
+</table> <ul> {% for name in activity_or_flows_names %} <li>{{name}}</li> {% endfor %} </ul> <table style="padding: 0"> <tr>
+    <td> Nceda ungene ukuze ujonge iinkcukacha zesabelo kwi-Curious. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Qalisa </a>
+    </td>
+  </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/new_activity_assignments_zu.html
+++ b/src/apps/mailing/static/templates/new_activity_assignments_zu.html
@@ -1,0 +1,16 @@
+<html style="max-width: 700px" lang="en" dir="ltr">
+<body> {% include 'header.html' %} <table style="padding: 0">
+  <tr>
+    <td style="padding-bottom: 1%"> Sawubona {{first_name}}, </td>
+  </tr>
+  <tr>
+    <td style="padding-bottom: 1%"> Unikezwe umsebenzi o-1 noma ngaphezulu kokuthi <b>"{{applet_name}}"</b>. </td>
+  </tr>
+</table> <ul> {% for name in activity_or_flows_names %} <li>{{name}}</li> {% endfor %} </ul> <table style="padding: 0"> <tr>
+    <td> Sicela ungene ngemvume ukuze ubuyekeze imininingwane yomsebenzi ozokwenziwa ku-Curious. </td>
+  </tr> <tr>
+    <td style="padding-top: 2%; padding-bottom: 1%;">
+      <a href="{{link}}" style="padding: 0.4rem 1rem; font-size: 0.8rem; line-height: 1.5; border-radius: 100px; display: inline-block; font-weight: 400; text-align: center; vertical-align: middle; text-decoration: none; color: #ffffff; background-color: #00639A; border-color: #00639A;"> Qalisa </a>
+    </td>
+  </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/reset_password_af.html
+++ b/src/apps/mailing/static/templates/reset_password_af.html
@@ -1,0 +1,13 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Ons het ’n versoek ontvang om jou wagwoord terug te stel. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <a href="{{url}}">Klik hierdie skakel</a> om nou jou wagwoord terug te stel. Die skakel sal oor 15 minute verval. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Indien jy nie hierdie versoek gedoen het nie, kan jy hierdie e-pos ignoreer. </td>
+      </tr> <tr>
+        <td>
+          <i> Nadat jou wagwoord opgedateer is, sal jy nie meer vorige data in die toep kan sien nie. Moenie bekommerd wees nie, ons het dit nog. </i>
+        </td>
+      </tr> {% include 'blocks/team_info_af.html' %} </table> {% include 'footers/footer_info_af.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/reset_password_xh.html
+++ b/src/apps/mailing/static/templates/reset_password_xh.html
@@ -1,0 +1,13 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sifumene isicelo sokuseta ngokutsha iphasiwedi yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <a href="{{url}}">Cofa eli khonkco</a> ukuseta kwakhona iphasiwedi yakho ngoku. Ikhonkco liya kuphelelwa kwimizuzu eyi-15. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Ukuba awusenzanga esi sicelo, ungayihoya le imeyile. </td>
+      </tr> <tr>
+        <td>
+          <i> Emva kokuhlaziya igama eligqithisiweyo, awuyi kubona idatha yakho yangaphambili kwi-app. Kodwa ungakhathazeki, sisenayo. </i>
+        </td>
+      </tr> {% include 'blocks/team_info_xh.html' %} </table> {% include 'footers/footer_info_xh.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/reset_password_zu.html
+++ b/src/apps/mailing/static/templates/reset_password_zu.html
@@ -1,0 +1,13 @@
+<html style="max-width: 450px; line-height: 2.1rem; font-size: 10px" lang="en" dir="ltr">
+  <body> {% include 'header.html' %} <table style="padding: 0; font-size: 1.4rem"> <tr>
+        <td style="padding-bottom: 16px"> Sithole isicelo sokusetha kabusha iphasiwedi yakho. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> <a href="{{url}}">Chofoza le linki</a> ukuze usethe kabusha iphasiwedi yakho manje. Ilinki izophelelwa yisikhathi emzuzwini eyi-15. </td>
+      </tr> <tr>
+        <td style="padding-bottom: 16px"> Uma ungazange wenze lesi sicelo, ungayiziba le imeyili. </td>
+      </tr> <tr>
+        <td>
+          <i> Ngemva kokubuyekeza iphasiwedi yakho, ngeke ubone idatha yakho yangaphambilini ku-app. Kodwa ungakhathazeki, sisenayo. </i>
+        </td>
+      </tr> {% include 'blocks/team_info_zu.html' %} </table> {% include 'footers/footer_info_zu.html' %} </body>
+</html>

--- a/src/apps/mailing/static/templates/subjects/assignment_notification_af.txt
+++ b/src/apps/mailing/static/templates/subjects/assignment_notification_af.txt
@@ -1,0 +1,1 @@
+Toewysing-kennisgewing

--- a/src/apps/mailing/static/templates/subjects/assignment_notification_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/assignment_notification_xh.txt
@@ -1,0 +1,1 @@
+Isaziso sesabelo

--- a/src/apps/mailing/static/templates/subjects/assignment_notification_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/assignment_notification_zu.txt
@@ -1,0 +1,1 @@
+Isaziso Sesabelo

--- a/src/apps/mailing/static/templates/subjects/invitation_af.txt
+++ b/src/apps/mailing/static/templates/subjects/invitation_af.txt
@@ -1,0 +1,1 @@
+{{ applet_name }}-uitnodiging

--- a/src/apps/mailing/static/templates/subjects/invitation_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/invitation_xh.txt
@@ -1,0 +1,1 @@
+{{ applet_name }} isimemo

--- a/src/apps/mailing/static/templates/subjects/invitation_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/invitation_zu.txt
@@ -1,0 +1,1 @@
+Isimemo se-{{ applet_name }}

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_af.txt
@@ -1,0 +1,1 @@
+Rekening tydelik gesluit – sekuriteitwaarskuwing

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_xh.txt
@@ -1,0 +1,1 @@
+I-akhawunti itshixiwe okwethutyana-Isilumkiso soKhuseleko

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_account_locked_zu.txt
@@ -1,0 +1,1 @@
+I-akhawunti Ikhiyiwe Isikhashana - Isexwayiso Sokuvikela

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_af.txt
@@ -1,0 +1,1 @@
+Mislukte poging om tweefaktor-verifikasie te deaktiveer

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_xh.txt
@@ -1,0 +1,1 @@
+Akuphumelelanga kwiLinge lokwenza kungasebenzi i Two-Factor Authentication

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disable_failed_attempts_zu.txt
@@ -1,0 +1,1 @@
+Umzamo Wehlulekile Wokukhubaza Ukuqinisekiswa Kwezici Ezimbili

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_af.txt
@@ -1,0 +1,1 @@
+Tweefaktor-verifikasie gedeaktiveer

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_xh.txt
@@ -1,0 +1,1 @@
+Ivaliwe i-Two-Factor Authentication 

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_disabled_zu.txt
@@ -1,0 +1,1 @@
+Ukuqinisekiswa Kwezici Ezimbili Kukhutshaziwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_af.txt
@@ -1,0 +1,1 @@
+Tweefaktor-verifikasie geaktiveer

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_xh.txt
@@ -1,0 +1,1 @@
+I-Two-Factor Authentication Iyasebenza

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_enabled_zu.txt
@@ -1,0 +1,1 @@
+Ukuqinisekiswa Kwezici Ezimbili Kunikwe amandla

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_af.txt
@@ -1,0 +1,1 @@
+Meerdere mislukte aanmeldingpogings bespeur

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_xh.txt
@@ -1,0 +1,1 @@
+Iinzame ezininzi ezingaphumelelanga zokungena zifunyenwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_failed_attempts_warning_zu.txt
@@ -1,0 +1,1 @@
+Kutholwe Imizamo Eminingi Yokungena Ngemvume Ehlulekile

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_af.txt
@@ -1,0 +1,1 @@
+Laaste herstelkode-waarskuwing

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_xh.txt
@@ -1,0 +1,1 @@
+Isilumkiso seKhowudi yoBuyiselo yokugqibela

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_last_recovery_code_zu.txt
@@ -1,0 +1,1 @@
+Isexwayiso sekhodi yokutakula yokugcina

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_af.txt
@@ -1,0 +1,1 @@
+Herstelkode is gebruik

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_xh.txt
@@ -1,0 +1,1 @@
+Ikhowudi yoBuyiselo Esetyenzisiweyo

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_code_used_zu.txt
@@ -1,0 +1,1 @@
+Ikhodi yokutakula esetshenzisiwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_af.txt
@@ -1,0 +1,1 @@
+Terugstelkodes is afgelaai

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_xh.txt
@@ -1,0 +1,1 @@
+Iikhowudi zoBuyiselo zikhutshelwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_downloaded_zu.txt
@@ -1,0 +1,1 @@
+Amakhodi Okutakula Adawunilodiwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_af.txt
@@ -1,0 +1,1 @@
+Terugstelkodes is bekyk

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_xh.txt
@@ -1,0 +1,1 @@
+Iikhowudi zoBuyiselo Zijongwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_recovery_codes_viewed_zu.txt
@@ -1,0 +1,1 @@
+Amakhodi Okubuyisela Abukiwe

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_af.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_af.txt
@@ -1,0 +1,1 @@
+Mislukte poging om terugstelkodes te bekyk

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_xh.txt
@@ -1,0 +1,1 @@
+Akuphumelelanga Kwiinzame zokuJonga iiKhowudi zoBuyiselo

--- a/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/mfa/mfa_view_recovery_codes_failed_attempts_zu.txt
@@ -1,0 +1,1 @@
+Umzamo Wehlulekile Wokubuka Amakhodi Okubuyisela

--- a/src/apps/mailing/static/templates/subjects/reset_password_af.txt
+++ b/src/apps/mailing/static/templates/subjects/reset_password_af.txt
@@ -1,0 +1,1 @@
+Wagwoordterugstelling

--- a/src/apps/mailing/static/templates/subjects/reset_password_xh.txt
+++ b/src/apps/mailing/static/templates/subjects/reset_password_xh.txt
@@ -1,0 +1,1 @@
+Ukusetha kwakhona iphasiwedi

--- a/src/apps/mailing/static/templates/subjects/reset_password_zu.txt
+++ b/src/apps/mailing/static/templates/subjects/reset_password_zu.txt
@@ -1,0 +1,1 @@
+Ukusetha kabusha iphasiwedi

--- a/src/apps/users/tests/test_password.py
+++ b/src/apps/users/tests/test_password.py
@@ -214,6 +214,37 @@ class TestPassword:
         assert len(mailbox.mails[0].recipients) == 1
         assert mailbox.mails[0].recipients[0].email == password_recovery_request.email
 
+    @pytest.mark.parametrize(
+        "language,expected_subject",
+        [
+            ("af", "Wagwoordterugstelling"),
+            ("xh", "Ukusetha kwakhona iphasiwedi"),
+            ("zu", "Ukusetha kabusha iphasiwedi"),
+        ],
+    )
+    async def test_password_recovery_localized(
+        self,
+        client: TestClient,
+        user_create: UserCreate,
+        mailbox: TestMail,
+        language: str,
+        expected_subject: str,
+    ):
+        password_recovery_request: PasswordRecoveryRequest = PasswordRecoveryRequest(
+            email=user_create.model_dump()["email"]
+        )
+
+        response = await client.post(
+            url=self.password_recovery_url,
+            data=password_recovery_request.model_dump(),
+            headers={"Content-Language": language},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(mailbox.mails) == 1
+        assert mailbox.mails[0].subject == expected_subject
+        assert f'data-language="{language}"' in mailbox.mails[0].body
+
     async def test_password_recovery_approve(self, client: TestClient, user_create: UserCreate):
         cache = RedisCache()
 


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10767](https://mindlogger.atlassian.net/browse/M2-10767)

Adds backend email support for three new languages - **Afrikaans (af)**, **isiXhosa (xh)**, and **isiZulu (zu)**.

After this PR merges, the existing `MailingService` will pick the localised templates whenever an incoming request carries `Content-Language: af|xh|zu` (e.g. password recovery from web) or the API receives `language=af|xh|zu` on an `InvitationRequest`. MFA notifications also localise automatically once a user has `language=af|xh|zu` set, since `tasks.py` already passes `get_user_language(user)` through to the mailing service. The existing recursive English fallback in `MailingService.get_localized_*_template` continues to apply for any locale we still don't support.

Changes include:

- Added the three new languages to `InvitationLanguage` in src/apps/invitations/domain.py, making `af`/`xh`/`zu` valid values for `InvitationRequest.language`.
- Added 6 new shared template fragments - `blocks/team_info_{af,xh,zu}.html` and `footers/footer_info_{af,xh,zu}.html` - that the main email bodies `{% include %}` for the localised sign-off and footer.
- Added 12 main email body templates: `reset_password_{af,xh,zu}.html`, `invitation_new_user_{af,xh,zu}.html`, `invitation_registered_user_{af,xh,zu}.html`, `new_activity_assignments_{af,xh,zu}.html`.
- Added 9 subject-line templates under `subjects/`: `reset_password_{af,xh,zu}.txt`, `invitation_{af,xh,zu}.txt`, `assignment_notification_{af,xh,zu}.txt`.
- Added 30 MFA email body templates under `mfa/`: `mfa_account_locked_{af,xh,zu}.html`, `mfa_disable_failed_attempts_{af,xh,zu}.html`, `mfa_disabled_{af,xh,zu}.html`, `mfa_enabled_{af,xh,zu}.html`, `mfa_failed_attempts_warning_{af,xh,zu}.html`, `mfa_last_recovery_code_{af,xh,zu}.html`, `mfa_recovery_code_used_{af,xh,zu}.html`, `mfa_recovery_codes_downloaded_{af,xh,zu}.html`, `mfa_recovery_codes_viewed_{af,xh,zu}.html`, `mfa_view_recovery_codes_failed_attempts_{af,xh,zu}.html`.
- Added 30 MFA subject-line templates under `subjects/mfa/` covering the same 10 notification types.
- Restored Jinja syntax in the 4 isiXhosa main-body templates and the 10 isiXhosa MFA templates. The translation vendor's deliverable had translated Jinja keywords and several variable names into isiXhosa (`if → ukuba`, `else → enye`, `for → yegama`, `include → ziquka`, `role → indima`, `lower → ngezantsi`, `in → phakathi`, `{{name}} → {{igama}}`, plus MFA-specific `{{locked_at}} → {{itshixelwe_e}}`, `{{lockout_reason}} → {{lockout_isizathu}}`, `{{failed_attempts}} → {{Failed_attempts}}`, `{{remaining_attempts}} → {{Remaining_attempts}}`), which would have raised `TemplateSyntaxError` at email-send time. Body text remains as the vendor translated it; only the code paths are restored to match the existing pt/fr/el/es template structure.
- Extended the existing language parametrize lists in `test_invite.py` and `test_assignments.py` from `["en", "fr", "el"]` (and `["en", "fr"]`) to also include `af`, `xh`, `zu`.

### ✏️ Notes

- **Translation vendor:** the source files were delivered by Responsive Translations. The af and zu deliverables were clean; the xh deliverable had its Jinja keywords / variable names translated (see commits 3 and 8 for the full lists). The body text portions in xh templates may still contain a few untranslated English fragments left by the vendor (e.g. the word "of" appearing in `invitation_new_user_xh.html`); those are visible text issues, not code issues, and can be patched in a follow-up vendor turnaround if needed.
