### PR TITLE
Fix: Accept UTC datetime in audit log date filters instead of date-only (M2

### DIFF
--- a/src/apps/audit/api.py
+++ b/src/apps/audit/api.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timezone
 
 from fastapi import Depends, Request
 
@@ -31,6 +32,12 @@ async def applet_audit_export(
 
         from_datetime = query_params.filters.get("from_datetime")
         to_datetime = query_params.filters.get("to_datetime")
+
+        if from_datetime and from_datetime.tzinfo is None:
+            from_datetime = from_datetime.replace(tzinfo=timezone.utc)
+        if to_datetime and to_datetime.tzinfo is None:
+            to_datetime = to_datetime.replace(tzinfo=timezone.utc)
+
         if from_datetime and to_datetime and from_datetime > to_datetime:
             raise InvalidAuditDateRangeError(path=["fromDatetime"])
 

--- a/src/apps/audit/api.py
+++ b/src/apps/audit/api.py
@@ -29,15 +29,15 @@ async def applet_audit_export(
         await AppletService(session, user.id).exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_audit_export_access(applet_id)
 
-        from_date = query_params.filters.get("from_date")
-        to_date = query_params.filters.get("to_date")
-        if from_date and to_date and from_date > to_date:
-            raise InvalidAuditDateRangeError(path=["fromDate"])
+        from_datetime = query_params.filters.get("from_datetime")
+        to_datetime = query_params.filters.get("to_datetime")
+        if from_datetime and to_datetime and from_datetime > to_datetime:
+            raise InvalidAuditDateRangeError(path=["fromDatetime"])
 
         events, total = await AuditQueryService().search_applet_events(
             applet_id,
-            from_date=from_date,
-            to_date=to_date,
+            from_datetime=from_datetime,
+            to_datetime=to_datetime,
             page=query_params.page,
             limit=query_params.limit,
         )

--- a/src/apps/audit/errors.py
+++ b/src/apps/audit/errors.py
@@ -4,5 +4,5 @@ from apps.shared.exception import FieldError
 
 
 class InvalidAuditDateRangeError(FieldError):
-    message = _("fromDate must be less than or equal to toDate")
+    message = _("fromDatetime must be less than or equal to toDatetime")
     zero_path = "query"

--- a/src/apps/audit/filters.py
+++ b/src/apps/audit/filters.py
@@ -4,6 +4,6 @@ from apps.shared.query_params import BaseQueryParams
 
 
 class AuditExportFilters(BaseQueryParams):
-    from_date: datetime.datetime | None = None
-    to_date: datetime.datetime | None = None
+    from_datetime: datetime.datetime | None = None
+    to_datetime: datetime.datetime | None = None
     limit: int = 10000

--- a/src/apps/audit/filters.py
+++ b/src/apps/audit/filters.py
@@ -4,6 +4,6 @@ from apps.shared.query_params import BaseQueryParams
 
 
 class AuditExportFilters(BaseQueryParams):
-    from_date: datetime.date | None = None
-    to_date: datetime.date | None = None
+    from_date: datetime.datetime | None = None
+    to_date: datetime.datetime | None = None
     limit: int = 10000

--- a/src/apps/audit/query_service.py
+++ b/src/apps/audit/query_service.py
@@ -8,10 +8,6 @@ from infrastructure.utility.opensearch_client import DEFAULT_PAGE_SIZE, OpenSear
 SORT: list[dict] = [{"@timestamp": "asc"}, {"event.id": "asc"}]
 
 
-def _utc_midnight(d: datetime.date) -> str:
-    return datetime.datetime.combine(d, datetime.time.min, tzinfo=datetime.timezone.utc).isoformat()
-
-
 class AuditQueryService:
     def __init__(self, client: OpenSearchClient | None = None) -> None:
         self._client = client or OpenSearchClient()
@@ -21,8 +17,8 @@ class AuditQueryService:
         self,
         applet_id: uuid.UUID,
         *,
-        from_date: datetime.date | None = None,
-        to_date: datetime.date | None = None,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
         page: int = 1,
         limit: int = DEFAULT_PAGE_SIZE,
     ) -> tuple[list[AuditEvent], int]:
@@ -42,17 +38,16 @@ class AuditQueryService:
     @staticmethod
     def _build_query(
         applet_id: uuid.UUID,
-        from_date: datetime.date | None,
-        to_date: datetime.date | None,
+        from_date: datetime.datetime | None,
+        to_date: datetime.datetime | None,
     ) -> dict:
         filters: list[dict] = [{"term": {"curious.applet_id": str(applet_id)}}]
 
         timestamp_range: dict = {}
         if from_date is not None:
-            timestamp_range["gte"] = _utc_midnight(from_date)
+            timestamp_range["gte"] = from_date.isoformat()
         if to_date is not None:
-            # to_date is inclusive at day granularity; +1 day at UTC midnight is the exclusive upper bound.
-            timestamp_range["lt"] = _utc_midnight(to_date + datetime.timedelta(days=1))
+            timestamp_range["lte"] = to_date.isoformat()
         if timestamp_range:
             filters.append({"range": {"@timestamp": timestamp_range}})
 

--- a/src/apps/audit/query_service.py
+++ b/src/apps/audit/query_service.py
@@ -45,8 +45,12 @@ class AuditQueryService:
 
         timestamp_range: dict = {}
         if from_datetime is not None:
+            if from_datetime.tzinfo is None:
+                from_datetime = from_datetime.replace(tzinfo=datetime.timezone.utc)
             timestamp_range["gte"] = from_datetime.isoformat()
         if to_datetime is not None:
+            if to_datetime.tzinfo is None:
+                to_datetime = to_datetime.replace(tzinfo=datetime.timezone.utc)
             timestamp_range["lt"] = to_datetime.isoformat()
         if timestamp_range:
             filters.append({"range": {"@timestamp": timestamp_range}})

--- a/src/apps/audit/query_service.py
+++ b/src/apps/audit/query_service.py
@@ -17,12 +17,12 @@ class AuditQueryService:
         self,
         applet_id: uuid.UUID,
         *,
-        from_date: datetime.datetime | None = None,
-        to_date: datetime.datetime | None = None,
+        from_datetime: datetime.datetime | None = None,
+        to_datetime: datetime.datetime | None = None,
         page: int = 1,
         limit: int = DEFAULT_PAGE_SIZE,
     ) -> tuple[list[AuditEvent], int]:
-        query = self._build_query(applet_id, from_date, to_date)
+        query = self._build_query(applet_id, from_datetime, to_datetime)
         response = await self._client.search(
             self._index,
             query=query,
@@ -38,16 +38,16 @@ class AuditQueryService:
     @staticmethod
     def _build_query(
         applet_id: uuid.UUID,
-        from_date: datetime.datetime | None,
-        to_date: datetime.datetime | None,
+        from_datetime: datetime.datetime | None,
+        to_datetime: datetime.datetime | None,
     ) -> dict:
         filters: list[dict] = [{"term": {"curious.applet_id": str(applet_id)}}]
 
         timestamp_range: dict = {}
-        if from_date is not None:
-            timestamp_range["gte"] = from_date.isoformat()
-        if to_date is not None:
-            timestamp_range["lte"] = to_date.isoformat()
+        if from_datetime is not None:
+            timestamp_range["gte"] = from_datetime.isoformat()
+        if to_datetime is not None:
+            timestamp_range["lt"] = to_datetime.isoformat()
         if timestamp_range:
             filters.append({"range": {"@timestamp": timestamp_range}})
 

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -55,7 +55,7 @@ async def test_invalid_date_range_returns_422(client: TestClient, tom: User, app
     client.login(tom)
     response = await client.get(
         URL.format(applet_id=applet_one.id),
-        dict(fromDatetime="2026-05-10", toDatetime="2026-05-01"),
+        dict(fromDatetime="2026-05-10T14:30:00", toDatetime="2026-05-01T08:00:00"),
     )
     assert response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -91,15 +91,15 @@ async def test_date_range_reaches_opensearch_query(client: TestClient, tom: User
     client.login(tom)
     response = await client.get(
         URL.format(applet_id=applet_one.id),
-        dict(fromDatetime="2026-05-01", toDatetime="2026-05-07"),
+        dict(fromDatetime="2026-05-01T14:30:00", toDatetime="2026-05-07T18:00:00"),
     )
     assert response.status_code == http.HTTPStatus.OK
 
     filters = OpenSearchClientTest.last_search_body["query"]["bool"]["filter"]
     range_clause = next(f for f in filters if "range" in f)
     assert range_clause["range"]["@timestamp"] == {
-        "gte": "2026-05-01T00:00:00",
-        "lt": "2026-05-07T00:00:00",
+        "gte": "2026-05-01T14:30:00+00:00",
+        "lt": "2026-05-07T18:00:00+00:00",
     }
 
 

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -55,7 +55,7 @@ async def test_invalid_date_range_returns_422(client: TestClient, tom: User, app
     client.login(tom)
     response = await client.get(
         URL.format(applet_id=applet_one.id),
-        dict(fromDate="2026-05-10", toDate="2026-05-01"),
+        dict(fromDatetime="2026-05-10", toDatetime="2026-05-01"),
     )
     assert response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -91,7 +91,7 @@ async def test_date_range_reaches_opensearch_query(client: TestClient, tom: User
     client.login(tom)
     response = await client.get(
         URL.format(applet_id=applet_one.id),
-        dict(fromDate="2026-05-01", toDate="2026-05-07"),
+        dict(fromDatetime="2026-05-01", toDatetime="2026-05-07"),
     )
     assert response.status_code == http.HTTPStatus.OK
 
@@ -99,7 +99,7 @@ async def test_date_range_reaches_opensearch_query(client: TestClient, tom: User
     range_clause = next(f for f in filters if "range" in f)
     assert range_clause["range"]["@timestamp"] == {
         "gte": "2026-05-01T00:00:00",
-        "lte": "2026-05-07T00:00:00",
+        "lt": "2026-05-07T00:00:00",
     }
 
 

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -98,8 +98,8 @@ async def test_date_range_reaches_opensearch_query(client: TestClient, tom: User
     filters = OpenSearchClientTest.last_search_body["query"]["bool"]["filter"]
     range_clause = next(f for f in filters if "range" in f)
     assert range_clause["range"]["@timestamp"] == {
-        "gte": "2026-05-01T00:00:00+00:00",
-        "lt": "2026-05-08T00:00:00+00:00",
+        "gte": "2026-05-01T00:00:00",
+        "lte": "2026-05-07T00:00:00",
     }
 
 

--- a/src/apps/audit/tests/test_query_service.py
+++ b/src/apps/audit/tests/test_query_service.py
@@ -35,10 +35,13 @@ def _seed_doc(**overrides: object) -> dict:
 async def test_query_filters_by_applet_and_dates(fresh_service: AuditQueryService):
     applet_id = uuid.uuid4()
 
+    from_dt = datetime.datetime(2026, 5, 1, 14, 30, 0, tzinfo=datetime.timezone.utc)
+    to_dt = datetime.datetime(2026, 5, 7, 18, 0, 0, tzinfo=datetime.timezone.utc)
+
     await fresh_service.search_applet_events(
         applet_id,
-        from_date=datetime.date(2026, 5, 1),
-        to_date=datetime.date(2026, 5, 7),
+        from_date=from_dt,
+        to_date=to_dt,
     )
 
     body = OpenSearchClientTest.last_search_body
@@ -47,8 +50,8 @@ async def test_query_filters_by_applet_and_dates(fresh_service: AuditQueryServic
     assert filters[1] == {
         "range": {
             "@timestamp": {
-                "gte": "2026-05-01T00:00:00+00:00",
-                "lt": "2026-05-08T00:00:00+00:00",
+                "gte": "2026-05-01T14:30:00+00:00",
+                "lte": "2026-05-07T18:00:00+00:00",
             }
         }
     }

--- a/src/apps/audit/tests/test_query_service.py
+++ b/src/apps/audit/tests/test_query_service.py
@@ -40,8 +40,8 @@ async def test_query_filters_by_applet_and_dates(fresh_service: AuditQueryServic
 
     await fresh_service.search_applet_events(
         applet_id,
-        from_date=from_dt,
-        to_date=to_dt,
+        from_datetime=from_dt,
+        to_datetime=to_dt,
     )
 
     body = OpenSearchClientTest.last_search_body
@@ -51,7 +51,7 @@ async def test_query_filters_by_applet_and_dates(fresh_service: AuditQueryServic
         "range": {
             "@timestamp": {
                 "gte": "2026-05-01T14:30:00+00:00",
-                "lte": "2026-05-07T18:00:00+00:00",
+                "lt": "2026-05-07T18:00:00+00:00",
             }
         }
     }

--- a/src/infrastructure/utility/opensearch_client.py
+++ b/src/infrastructure/utility/opensearch_client.py
@@ -76,7 +76,6 @@ class OpenSearchClient:
             use_ssl=settings.opensearch.use_ssl,
             verify_certs=settings.opensearch.verify_certs,
             ssl_show_warn=False,
-            timeout=30,
         )
 
     async def ensure_index(self, index: str, mapping: dict) -> None:

--- a/src/infrastructure/utility/opensearch_client.py
+++ b/src/infrastructure/utility/opensearch_client.py
@@ -76,6 +76,7 @@ class OpenSearchClient:
             use_ssl=settings.opensearch.use_ssl,
             verify_certs=settings.opensearch.verify_certs,
             ssl_show_warn=False,
+            timeout=30,
         )
 
     async def ensure_index(self, index: str, mapping: dict) -> None:


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

- Change fromDate and toDate query parameters on the audit export endpoint from datetime.date to datetime.datetime, allowing the frontend to specify exact timestamps (e.g., fromDate=2026-05-01T14:30:00Z) instead of only dates
- Remove the _utc_midnight() helper and +1 day workaround — datetime values are now passed directly to the OpenSearch range query, consistent with how the answer and EHR export endpoints handle date filtering

🔗 [Jira Bug Ticket M2-#10832](https://mindlogger.atlassian.net/browse/M2-10832)
🔗 [Jira Ticket M2-#10540](https://mindlogger.atlassian.net/browse/M2-10540)

