### PR TITLE
feat: add Auth events in audit export (M2-10957)

### DIFF
--- a/src/apps/audit/constants.py
+++ b/src/apps/audit/constants.py
@@ -1,5 +1,20 @@
 from .enums import EventAction, EventCategory, EventType
 
+# Account-level events (logged without ``curious.applet_id``) surfaced in an applet's audit export,
+# but only for users with a manager-class role on that applet.
+ACCOUNT_LEVEL_EXPORT_ACTIONS: frozenset[EventAction] = frozenset(
+    {
+        EventAction.USER_SESSION_LOGIN,
+        EventAction.USER_SESSION_LOGOUT,
+        EventAction.USER_SESSION_INVALID,
+        EventAction.USER_MFA_ENABLE,
+        EventAction.USER_MFA_DISABLE,
+        EventAction.USER_MFA_RECOVERY_VIEW,
+        EventAction.USER_MFA_RECOVERY_DOWNLOAD,
+        EventAction.USER_MFA_RECOVERY_USE,
+    }
+)
+
 EVENT_ACTION_TO_EVENT_CATEGORY: dict[EventAction, tuple[EventCategory, ...]] = {
     # User auth
     EventAction.USER_SESSION_LOGIN: (EventCategory.SESSION, EventCategory.AUTHENTICATION),

--- a/src/apps/audit/crud.py
+++ b/src/apps/audit/crud.py
@@ -67,6 +67,7 @@ class AuditLogCRUD(BaseCRUD[AuditLogSchema]):
         privileged_user_ids = select(UserAppletAccessSchema.user_id).where(
             UserAppletAccessSchema.applet_id == applet_id,
             UserAppletAccessSchema.role.in_(Role.managers()),
+            UserAppletAccessSchema.soft_exists(),
         )
 
         scope = or_(

--- a/src/apps/audit/crud.py
+++ b/src/apps/audit/crud.py
@@ -1,10 +1,13 @@
 import datetime
 import uuid
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
 
+from apps.audit.constants import ACCOUNT_LEVEL_EXPORT_ACTIONS
 from apps.audit.db.schemas import AuditLogSchema
+from apps.workspaces.db.schemas import UserAppletAccessSchema
+from apps.workspaces.domain.constants import Role
 from infrastructure.database.crud import BaseCRUD
 
 DEFAULT_PAGE_SIZE = 1000
@@ -51,7 +54,23 @@ class AuditLogCRUD(BaseCRUD[AuditLogSchema]):
         page: int = 1,
         limit: int = DEFAULT_PAGE_SIZE,
     ) -> tuple[list[AuditLogSchema], int]:
-        conditions = [AuditLogSchema.applet_ids.contains([applet_id])]
+        # Users with a manager-class role on this applet. Their account-level events
+        # (login/logout/MFA/...) are surfaced in the export even though those events
+        # carry no applet id; respondents are intentionally excluded.
+        privileged_user_ids = select(UserAppletAccessSchema.user_id).where(
+            UserAppletAccessSchema.applet_id == applet_id,
+            UserAppletAccessSchema.role.in_(Role.managers()),
+        )
+
+        scope = or_(
+            AuditLogSchema.applet_ids.contains([applet_id]),
+            and_(
+                AuditLogSchema.event_action.in_(ACCOUNT_LEVEL_EXPORT_ACTIONS),
+                AuditLogSchema.user_id.in_(privileged_user_ids),
+            ),
+        )
+
+        conditions = [scope]
         if from_datetime is not None:
             conditions.append(AuditLogSchema.event_timestamp >= _to_naive_utc(from_datetime))
         if to_datetime is not None:

--- a/src/apps/audit/crud.py
+++ b/src/apps/audit/crud.py
@@ -54,6 +54,13 @@ class AuditLogCRUD(BaseCRUD[AuditLogSchema]):
         page: int = 1,
         limit: int = DEFAULT_PAGE_SIZE,
     ) -> tuple[list[AuditLogSchema], int]:
+        """Events for an applet's audit export.
+
+        Returns the applet's own events plus account-level events
+        (``ACCOUNT_LEVEL_EXPORT_ACTIONS``) for its manager-class users. Membership
+        is resolved at query time against current roles, so an account event stops
+        appearing once the user loses their role on the applet.
+        """
         # Users with a manager-class role on this applet. Their account-level events
         # (login/logout/MFA/...) are surfaced in the export even though those events
         # carry no applet id; respondents are intentionally excluded.

--- a/src/apps/audit/db/schemas.py
+++ b/src/apps/audit/db/schemas.py
@@ -10,6 +10,10 @@ class AuditLogSchema(Base):
     Append-only. A few columns are denormalized from the ECS document for
     filtering/sorting; the full event is kept in ``payload`` as the same
     dotted-alias JSON that is produced by ``AuditEvent.model_dump(mode="json")``.
+
+    Note: for failed logins the denormalized ``user_id`` is resolved from the
+    attempted email at persist time and may therefore be set even though
+    ``payload["user.id"]`` stays ``null`` (see ``tasks._resolve_actor_from_email``).
     """
 
     __tablename__ = "audit_logs"

--- a/src/apps/audit/tasks.py
+++ b/src/apps/audit/tasks.py
@@ -1,11 +1,32 @@
 import datetime
 import uuid
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.audit.constants import ACCOUNT_LEVEL_EXPORT_ACTIONS
 from apps.audit.crud import AuditLogCRUD
 from apps.audit.db.schemas import AuditLogSchema
+from apps.users.cruds.user import UsersCRUD
 from broker import broker
 from infrastructure.database import atomic, session_manager
 from infrastructure.logger import logger
+
+
+async def _resolve_actor_from_email(session: AsyncSession, payload: dict) -> uuid.UUID | None:
+    """Resolve the denormalized ``user_id`` for an account-level event with no
+    authenticated actor (e.g. a failed login carrying only ``user.email``), so the
+    applet export can scope it. Only the column is populated; ``payload`` keeps
+    ``user.id = null``. Unknown emails stay unresolved and are never exposed.
+    """
+    if payload.get("user.id") is not None:
+        return None
+    if payload.get("event.action") not in ACCOUNT_LEVEL_EXPORT_ACTIONS:
+        return None
+    email = payload.get("user.email")
+    if not email:
+        return None
+    user = await UsersCRUD(session).get_user_or_none_by_email(email)
+    return user.id if user else None
 
 
 def _build_schema(payload: dict) -> AuditLogSchema:
@@ -44,7 +65,10 @@ async def send_audit_event(payload: dict, retries: int = 3) -> None:
         session_maker = session_manager.get_session()
         async with session_maker() as session:
             async with atomic(session):
-                await AuditLogCRUD(session).save(_build_schema(payload))
+                schema = _build_schema(payload)
+                if schema.user_id is None:
+                    schema.user_id = await _resolve_actor_from_email(session, payload)
+                await AuditLogCRUD(session).save(schema)
     except Exception as e:
         if retries > 0:
             logger.warning("audit_event_retry", retries_left=retries, error=str(e))

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -49,6 +49,26 @@ async def _seed_event(
     return event
 
 
+async def _seed_account_event(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    timestamp: datetime.datetime,
+    action: EventAction = EventAction.USER_SESSION_LOGIN,
+    event_id: uuid.UUID | None = None,
+) -> AuditEvent:
+    """Seed an account-level event (no applet id), as already persisted with a
+    resolved ``user_id``."""
+    event = AuditEvent(
+        event_action=action,
+        user_id=user_id,
+        timestamp=timestamp,
+        event_id=event_id or uuid.uuid4(),
+    )
+    await AuditLogCRUD(session).save(_build_schema(event.model_dump(mode="json")))
+    return event
+
+
 async def test_unauthenticated_request_returns_401(client: TestClient, applet_one: AppletFull):
     response = await client.get(URL.format(applet_id=applet_one.id))
     assert response.status_code == http.HTTPStatus.UNAUTHORIZED
@@ -130,6 +150,74 @@ async def test_date_range_filters_results(client: TestClient, session: AsyncSess
     body = response.json()
     assert body["count"] == 1
     assert body["result"][0]["event.id"] == str(inside.event_id)
+
+
+async def test_owner_sees_own_account_event(
+    client: TestClient, session: AsyncSession, tom: User, applet_one: AppletFull
+):
+    login = await _seed_account_event(session, user_id=tom.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet_one.id))
+    assert response.status_code == http.HTTPStatus.OK
+    body = response.json()
+    assert body["count"] == 1
+    assert body["result"][0]["event.id"] == str(login.event_id)
+    assert body["result"][0]["event.action"] == EventAction.USER_SESSION_LOGIN.value
+
+
+async def test_owner_sees_manager_account_events(
+    client: TestClient, session: AsyncSession, tom: User, lucy: User, applet_one_lucy_manager: AppletFull
+):
+    applet = applet_one_lucy_manager
+    login = await _seed_account_event(session, user_id=lucy.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))
+    mfa = await _seed_account_event(
+        session,
+        user_id=lucy.id,
+        timestamp=datetime.datetime(2026, 5, 1, 11, 0, 0),
+        action=EventAction.USER_MFA_DISABLE,
+    )
+    # A failed login attributed (post-enrichment) to the manager.
+    invalid = await _seed_account_event(
+        session,
+        user_id=lucy.id,
+        timestamp=datetime.datetime(2026, 5, 1, 12, 0, 0),
+        action=EventAction.USER_SESSION_INVALID,
+    )
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet.id))
+    assert response.status_code == http.HTTPStatus.OK
+    returned = {r["event.id"] for r in response.json()["result"]}
+    assert returned == {str(login.event_id), str(mfa.event_id), str(invalid.event_id)}
+
+
+async def test_owner_does_not_see_respondent_account_events(
+    client: TestClient, session: AsyncSession, tom: User, lucy: User, applet_one_lucy_respondent: AppletFull
+):
+    applet = applet_one_lucy_respondent
+    await _seed_account_event(session, user_id=lucy.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet.id))
+    assert response.status_code == http.HTTPStatus.OK
+    assert response.json()["count"] == 0
+
+
+async def test_owner_does_not_see_refresh_events(
+    client: TestClient, session: AsyncSession, tom: User, applet_one: AppletFull
+):
+    await _seed_account_event(
+        session,
+        user_id=tom.id,
+        timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0),
+        action=EventAction.USER_SESSION_REFRESH,
+    )
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet_one.id))
+    assert response.status_code == http.HTTPStatus.OK
+    assert response.json()["count"] == 0
 
 
 async def test_export_self_logs_applet_audit_export(

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.applets.domain.applet_full import AppletFull
@@ -13,6 +14,7 @@ from apps.audit.enums import EventAction
 from apps.audit.tasks import _build_schema
 from apps.shared.test.client import TestClient
 from apps.users.domain import User
+from apps.workspaces.db.schemas import UserAppletAccessSchema
 
 URL = "/audit/applets/{applet_id}/events"
 
@@ -190,6 +192,25 @@ async def test_owner_sees_manager_account_events(
     assert response.status_code == http.HTTPStatus.OK
     returned = {r["event.id"] for r in response.json()["result"]}
     assert returned == {str(login.event_id), str(mfa.event_id), str(invalid.event_id)}
+
+
+async def test_owner_does_not_see_revoked_manager_account_events(
+    client: TestClient, session: AsyncSession, tom: User, lucy: User, applet_one_lucy_manager: AppletFull
+):
+    applet = applet_one_lucy_manager
+    await _seed_account_event(session, user_id=lucy.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))
+
+    # Revoke lucy's access (role removal is a soft delete).
+    await session.execute(
+        update(UserAppletAccessSchema)
+        .where(UserAppletAccessSchema.user_id == lucy.id, UserAppletAccessSchema.applet_id == applet.id)
+        .values(is_deleted=True)
+    )
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet.id))
+    assert response.status_code == http.HTTPStatus.OK
+    assert response.json()["count"] == 0
 
 
 async def test_owner_does_not_see_respondent_account_events(

--- a/src/apps/audit/tests/test_constants.py
+++ b/src/apps/audit/tests/test_constants.py
@@ -6,7 +6,11 @@ don't inherit from `BaseTest` and don't need pytest fixtures.
 
 import pytest
 
-from apps.audit.constants import EVENT_ACTION_TO_EVENT_CATEGORY, EVENT_ACTION_TO_EVENT_TYPE
+from apps.audit.constants import (
+    ACCOUNT_LEVEL_EXPORT_ACTIONS,
+    EVENT_ACTION_TO_EVENT_CATEGORY,
+    EVENT_ACTION_TO_EVENT_TYPE,
+)
 from apps.audit.enums import EventAction
 
 
@@ -27,3 +31,25 @@ def test_constant_covers_all_event_actions(constant_name: str, constant: dict) -
     extra = set(constant) - set(EventAction)
     assert not missing, f"{constant_name} is missing entries for: {sorted(m.value for m in missing)}"
     assert not extra, f"{constant_name} has extra entries not in EventAction: {extra}"
+
+
+def test_account_level_export_actions() -> None:
+    """The account-level export set carries session (minus refresh) and MFA actions.
+
+    Guards the export scoping policy: high-volume ``refresh`` events and applet-scoped
+    actions must never be classified as account-level.
+    """
+    expected = {
+        EventAction.USER_SESSION_LOGIN,
+        EventAction.USER_SESSION_LOGOUT,
+        EventAction.USER_SESSION_INVALID,
+        EventAction.USER_MFA_ENABLE,
+        EventAction.USER_MFA_DISABLE,
+        EventAction.USER_MFA_RECOVERY_VIEW,
+        EventAction.USER_MFA_RECOVERY_DOWNLOAD,
+        EventAction.USER_MFA_RECOVERY_USE,
+    }
+    assert ACCOUNT_LEVEL_EXPORT_ACTIONS == expected
+    assert EventAction.USER_SESSION_REFRESH not in ACCOUNT_LEVEL_EXPORT_ACTIONS
+    # All account-level actions are applet-less (their resource is "user", never "applet").
+    assert all(action.resource == "user" for action in ACCOUNT_LEVEL_EXPORT_ACTIONS)

--- a/src/apps/audit/tests/test_query_service.py
+++ b/src/apps/audit/tests/test_query_service.py
@@ -3,11 +3,13 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apps.applets.domain.applet_full import AppletFull
 from apps.audit.crud import AuditLogCRUD
 from apps.audit.domain import AuditEvent
 from apps.audit.enums import EventAction
 from apps.audit.query_service import AuditQueryService
 from apps.audit.tasks import _build_schema
+from apps.users.domain import User
 
 
 def _make_event(
@@ -21,6 +23,22 @@ def _make_event(
         event_action=EventAction.APPLET_ANSWER_VIEW,
         user_id=user_id or uuid.uuid4(),
         curious_applet_id=[applet_id],
+        timestamp=timestamp,
+        event_id=event_id or uuid.uuid4(),
+    )
+
+
+def _make_account_event(
+    *,
+    user_id: uuid.UUID,
+    timestamp: datetime.datetime,
+    action: EventAction = EventAction.USER_SESSION_LOGIN,
+    event_id: uuid.UUID | None = None,
+) -> AuditEvent:
+    """An account-level event (login/MFA/...) that carries no applet id."""
+    return AuditEvent(
+        event_action=action,
+        user_id=user_id,
         timestamp=timestamp,
         event_id=event_id or uuid.uuid4(),
     )
@@ -99,6 +117,45 @@ async def test_returns_empty_when_no_events(session: AsyncSession):
     events, total = await AuditQueryService(session).search_applet_events(uuid.uuid4())
     assert events == []
     assert total == 0
+
+
+async def test_includes_account_event_for_privileged_user(session: AsyncSession, tom: User, applet_one: AppletFull):
+    """A login by a manager-class user of the applet is surfaced, even though it
+    carries no applet id; the same event by a non-member is not."""
+    ts = datetime.datetime(2026, 5, 1, 10, 0, 0)
+    owner_login = _make_account_event(user_id=tom.id, timestamp=ts)
+    stranger_login = _make_account_event(user_id=uuid.uuid4(), timestamp=ts)
+    await _seed(session, owner_login)
+    await _seed(session, stranger_login)
+
+    events, total = await AuditQueryService(session).search_applet_events(applet_one.id)
+
+    assert total == 1
+    assert [e.event_id for e in events] == [owner_login.event_id]
+
+
+async def test_excludes_refresh_account_event(session: AsyncSession, tom: User, applet_one: AppletFull):
+    """USER_SESSION_REFRESH is deliberately kept out of the export."""
+    ts = datetime.datetime(2026, 5, 1, 10, 0, 0)
+    await _seed(session, _make_account_event(user_id=tom.id, timestamp=ts, action=EventAction.USER_SESSION_REFRESH))
+
+    events, total = await AuditQueryService(session).search_applet_events(applet_one.id)
+
+    assert total == 0
+    assert events == []
+
+
+async def test_mixes_applet_and_account_events(session: AsyncSession, tom: User, applet_one: AppletFull):
+    """Applet-scoped and account-level events are returned together, in timestamp order."""
+    account_event = _make_account_event(user_id=tom.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))
+    applet_event = _make_event(applet_one.id, user_id=tom.id, timestamp=datetime.datetime(2026, 5, 2, 10, 0, 0))
+    await _seed(session, applet_event)
+    await _seed(session, account_event)
+
+    events, total = await AuditQueryService(session).search_applet_events(applet_one.id)
+
+    assert total == 2
+    assert [e.event_id for e in events] == [account_event.event_id, applet_event.event_id]
 
 
 async def test_save_is_idempotent_on_event_id(session: AsyncSession):

--- a/src/apps/audit/tests/test_query_service.py
+++ b/src/apps/audit/tests/test_query_service.py
@@ -158,6 +158,25 @@ async def test_mixes_applet_and_account_events(session: AsyncSession, tom: User,
     assert [e.event_id for e in events] == [account_event.event_id, applet_event.event_id]
 
 
+async def test_account_event_isolated_across_applets(
+    session: AsyncSession,
+    tom: User,
+    lucy: User,
+    applet_one_lucy_manager: AppletFull,
+    applet_two: AppletFull,
+):
+    """An account event surfaces only in exports of applets the user is privileged
+    on. lucy manages applet_one but has no role on applet_two, so her login must
+    not leak into applet_two's export."""
+    await _seed(session, _make_account_event(user_id=lucy.id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0)))
+
+    _, total_one = await AuditQueryService(session).search_applet_events(applet_one_lucy_manager.id)
+    _, total_two = await AuditQueryService(session).search_applet_events(applet_two.id)
+
+    assert total_one == 1
+    assert total_two == 0
+
+
 async def test_save_is_idempotent_on_event_id(session: AsyncSession):
     applet_id = uuid.uuid4()
     event = _make_event(applet_id, timestamp=datetime.datetime(2026, 5, 1, 10, 0, 0))

--- a/src/apps/audit/tests/test_tasks.py
+++ b/src/apps/audit/tests/test_tasks.py
@@ -1,0 +1,44 @@
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.audit.domain import AuditEvent
+from apps.audit.enums import EventAction
+from apps.audit.tasks import _resolve_actor_from_email
+from apps.users.domain import User
+
+
+def _payload(**overrides) -> dict:
+    event = AuditEvent(
+        event_action=EventAction.USER_SESSION_INVALID,
+        user_id=None,
+        user_email="tom@mindlogger.com",
+    )
+    payload = event.model_dump(mode="json")
+    payload.update(overrides)
+    return payload
+
+
+async def test_resolves_failed_login_email_to_user(session: AsyncSession, tom: User):
+    """A failed login carrying only an email is resolved to the account's user id."""
+    resolved = await _resolve_actor_from_email(session, _payload())
+    assert resolved == tom.id
+
+
+async def test_unknown_email_is_not_resolved(session: AsyncSession, tom: User):
+    """An unknown / typo'd email cannot be attributed and stays unresolved."""
+    resolved = await _resolve_actor_from_email(session, _payload(**{"user.email": "nobody@nowhere.test"}))
+    assert resolved is None
+
+
+async def test_skips_when_actor_already_present(session: AsyncSession, tom: User):
+    """Events with an authenticated actor are left untouched."""
+    resolved = await _resolve_actor_from_email(session, _payload(**{"user.id": str(uuid.uuid4())}))
+    assert resolved is None
+
+
+async def test_skips_non_account_level_action(session: AsyncSession, tom: User):
+    """Only account-level actions get email resolution."""
+    payload = _payload(**{"event.action": EventAction.APPLET_ANSWER_VIEW.value})
+    resolved = await _resolve_actor_from_email(session, payload)
+    assert resolved is None


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] For new features, QA automation engineers have been tagged
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10957](https://mindlogger.atlassian.net/browse/M2-10957)

Includes user auth/MFA events in the applet audit logs export. These events are account-level (no applet id), so they're surfaced only for users with a manager-class role on the applet - respondents are excluded.

Changes include:

- Define `ACCOUNT_LEVEL_EXPORT_ACTIONS` (login/logout/invalid + MFA; excludes `refresh`).
- Extend the applet export query to also return account-level events for the applet's manager-class users (single query; pagination/count unchanged).
- Attribute failed logins to a user by resolving the attempted email at persist time (payload keeps `user.id` null).

### 🪤 Peer Testing

- As an owner/manager, open **Applet Settings → Audit Logs Export** and export.

    **Expected outcome:** The export includes your and other managers' login/logout/MFA/failed-login events alongside the applet events.

- Log in as a **respondent** of the applet, then export again.

    **Expected outcome:** The respondent's auth events do **not** appear; `refresh` events do **not** appear.

### ✏️ Notes

- Membership is evaluated at query time against current roles.
- No frontend change needed - the existing CSV export handles these events.
