### PR TITLE
fix: Clean up applet IAM events (M2-10745)

### DIFF
--- a/src/apps/audit/tests/test_tasks.py
+++ b/src/apps/audit/tests/test_tasks.py
@@ -12,7 +12,7 @@ def _payload(**overrides) -> dict:
     event = AuditEvent(
         event_action=EventAction.USER_SESSION_INVALID,
         user_id=None,
-        user_email="tom@mindlogger.com",
+        user_email="tom@gettingcurious.com",
     )
     payload = event.model_dump(mode="json")
     payload.update(overrides)

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -103,21 +103,24 @@ async def invitation_respondent_send(
     invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
-            await AppletService(session, user.id).exist_by_id(applet_id)
-            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
-            invitation_service = InvitationsService(session, user)
             try:
+                # Resolve invited user first so failure audit events carry user ID
                 invited_user = await UserService(session).get_by_email(invitation_schema.email)
                 invited_user_id = invited_user.id
-                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
-                    Role.RESPONDENT
-                )
-                if is_role_exist:
-                    raise RespondentInvitationExist()
             except UserNotFound:
                 # Inviting an email that is not yet associated with a user is valid.
                 # Continue flow to create subject and send invitation.
                 pass
+
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+            invitation_service = InvitationsService(session, user)
+            if invited_user_id:
+                is_role_exist = await UserAppletAccessService(session, invited_user_id, applet_id).has_role(
+                    Role.RESPONDENT
+                )
+                if is_role_exist:
+                    raise RespondentInvitationExist()
 
             subject_service = SubjectsService(session, user.id)
             try:
@@ -173,21 +176,24 @@ async def invitation_reviewer_send(
     invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
+            try:
+                # Resolve invited user first so failure audit events carry user ID
+                invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                invited_user_id = invited_user.id
+            except UserNotFound:
+                # Inviting by email is allowed even if the user does not exist yet.
+                # Continue so the invitation can be created for later acceptance/registration.
+                pass
+
             await AppletService(session, user.id).exist_by_id(applet_id)
             await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
             invitation_srv = InvitationsService(session, user)
-            try:
-                invited_user = await UserService(session).get_by_email(invitation_schema.email)
-                invited_user_id = invited_user.id
-                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+            if invited_user_id:
+                is_role_exist = await UserAppletAccessService(session, invited_user_id, applet_id).has_role(
                     Role.REVIEWER
                 )
                 if is_role_exist:
                     raise ManagerInvitationExist()
-            except UserNotFound:
-                # Inviting by email is allowed even if the user does not exist yet.
-                # Continue so the invitation can be created for later acceptance/registration.
-                invited_user = None
 
             invitation: InvitationDetailForReviewer = await invitation_srv.send_reviewer_invitation(
                 applet_id, invitation_schema
@@ -236,21 +242,24 @@ async def invitation_managers_send(
     invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
-            await AppletService(session, user.id).exist_by_id(applet_id)
-            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
-            invitation_srv = InvitationsService(session, user)
             try:
+                # Resolve invited user first so failure audit events carry user ID
                 invited_user = await UserService(session).get_by_email(invitation_schema.email)
                 invited_user_id = invited_user.id
-                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
-                    invitation_schema.role
-                )
-                if is_role_exist:
-                    raise ManagerInvitationExist()
             except UserNotFound:
                 # Inviting emails that are not yet associated with a user is allowed.
                 # In this case there is no existing user-role assignment to validate.
                 pass
+
+            await AppletService(session, user.id).exist_by_id(applet_id)
+            await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
+            invitation_srv = InvitationsService(session, user)
+            if invited_user_id:
+                is_role_exist = await UserAppletAccessService(session, invited_user_id, applet_id).has_role(
+                    invitation_schema.role
+                )
+                if is_role_exist:
+                    raise ManagerInvitationExist()
 
             invitation = await invitation_srv.send_managers_invitation(applet_id, invitation_schema)
     except BaseError as e:
@@ -431,6 +440,14 @@ async def invitation_subject_send(
     invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
+            try:
+                # Resolve invited user first so failure audit events carry user ID
+                invited_user = await UserService(session).get_by_email(schema.email)
+                invited_user_id = invited_user.id
+            except UserNotFound:
+                # Expected: invitee may not have an account yet; proceed with invitation flow.
+                pass
+
             await AppletService(session, user.id).exist_by_id(applet_id)
             await CheckAccessService(session, user.id).check_applet_invite_access(applet_id)
 
@@ -443,17 +460,12 @@ async def invitation_subject_send(
 
             # check role exists
             invitation_service = InvitationsService(session, user)
-            try:
-                invited_user = await UserService(session).get_by_email(schema.email)
-                invited_user_id = invited_user.id
-                is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
+            if invited_user_id:
+                is_role_exist = await UserAppletAccessService(session, invited_user_id, applet_id).has_role(
                     Role.RESPONDENT
                 )
                 if is_role_exist:
                     raise RespondentInvitationExist()
-            except UserNotFound:
-                # Expected: invitee may not have an account yet; proceed with invitation flow.
-                pass
 
             invitation_schema = InvitationRespondentRequest(
                 email=schema.email,

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -100,6 +100,7 @@ async def invitation_respondent_send(
     for the concrete user giving him a role "respondent".
     """
 
+    invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
             await AppletService(session, user.id).exist_by_id(applet_id)
@@ -107,6 +108,7 @@ async def invitation_respondent_send(
             invitation_service = InvitationsService(session, user)
             try:
                 invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                invited_user_id = invited_user.id
                 is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
                     Role.RESPONDENT
                 )
@@ -134,7 +136,8 @@ async def invitation_respondent_send(
                 event_action=EventAction.APPLET_INVITE_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
-                user_target_email=invitation_schema.email,
+                user_target_id=invited_user_id,
+                user_target_email=None if invited_user_id else invitation_schema.email,
                 user_target_roles=[Role.RESPONDENT],
                 **http_audit_fields(request, e),
             )
@@ -146,7 +149,8 @@ async def invitation_respondent_send(
             event_action=EventAction.APPLET_INVITE_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
-            user_target_email=invitation_schema.email,
+            user_target_id=invited_user_id,
+            user_target_email=None if invited_user_id else invitation_schema.email,
             user_target_roles=[Role.RESPONDENT],
             **http_audit_fields(request),
         )
@@ -166,6 +170,7 @@ async def invitation_reviewer_send(
     for the concrete user giving him role "reviewer" for specific respondents.
     """
 
+    invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
             await AppletService(session, user.id).exist_by_id(applet_id)
@@ -173,6 +178,7 @@ async def invitation_reviewer_send(
             invitation_srv = InvitationsService(session, user)
             try:
                 invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                invited_user_id = invited_user.id
                 is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
                     Role.REVIEWER
                 )
@@ -192,7 +198,8 @@ async def invitation_reviewer_send(
                 event_action=EventAction.APPLET_INVITE_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
-                user_target_email=invitation_schema.email,
+                user_target_id=invited_user_id,
+                user_target_email=None if invited_user_id else invitation_schema.email,
                 user_target_roles=[Role.REVIEWER],
                 **http_audit_fields(request, e),
             )
@@ -204,7 +211,8 @@ async def invitation_reviewer_send(
             event_action=EventAction.APPLET_INVITE_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
-            user_target_email=invitation_schema.email,
+            user_target_id=invited_user_id,
+            user_target_email=None if invited_user_id else invitation_schema.email,
             user_target_roles=[Role.REVIEWER],
             **http_audit_fields(request),
         )
@@ -225,6 +233,7 @@ async def invitation_managers_send(
     "manager", "coordinator", "editor".
     """
 
+    invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
             await AppletService(session, user.id).exist_by_id(applet_id)
@@ -232,6 +241,7 @@ async def invitation_managers_send(
             invitation_srv = InvitationsService(session, user)
             try:
                 invited_user = await UserService(session).get_by_email(invitation_schema.email)
+                invited_user_id = invited_user.id
                 is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
                     invitation_schema.role
                 )
@@ -249,7 +259,8 @@ async def invitation_managers_send(
                 event_action=EventAction.APPLET_INVITE_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
-                user_target_email=invitation_schema.email,
+                user_target_id=invited_user_id,
+                user_target_email=None if invited_user_id else invitation_schema.email,
                 user_target_roles=[invitation_schema.role],
                 **http_audit_fields(request, e),
             )
@@ -261,7 +272,8 @@ async def invitation_managers_send(
             event_action=EventAction.APPLET_INVITE_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
-            user_target_email=invitation_schema.email,
+            user_target_id=invited_user_id,
+            user_target_email=None if invited_user_id else invitation_schema.email,
             user_target_roles=[invitation_schema.role],
             **http_audit_fields(request),
         )
@@ -416,6 +428,7 @@ async def invitation_subject_send(
     schema: ShellAccountInvitation = Body(...),
     session=Depends(get_session),
 ) -> Response[InvitationRespondentResponse]:
+    invited_user_id: uuid.UUID | None = None
     try:
         async with atomic(session):
             await AppletService(session, user.id).exist_by_id(applet_id)
@@ -432,6 +445,7 @@ async def invitation_subject_send(
             invitation_service = InvitationsService(session, user)
             try:
                 invited_user = await UserService(session).get_by_email(schema.email)
+                invited_user_id = invited_user.id
                 is_role_exist = await UserAppletAccessService(session, invited_user.id, applet_id).has_role(
                     Role.RESPONDENT
                 )
@@ -460,7 +474,8 @@ async def invitation_subject_send(
                 event_action=EventAction.APPLET_INVITE_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
-                user_target_email=schema.email,
+                user_target_id=invited_user_id,
+                user_target_email=None if invited_user_id else schema.email,
                 user_target_roles=[Role.RESPONDENT],
                 **http_audit_fields(request, e),
             )
@@ -472,7 +487,8 @@ async def invitation_subject_send(
             event_action=EventAction.APPLET_INVITE_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
-            user_target_email=schema.email,
+            user_target_id=invited_user_id,
+            user_target_email=None if invited_user_id else schema.email,
             user_target_roles=[Role.RESPONDENT],
             **http_audit_fields(request),
         )

--- a/src/apps/invitations/api.py
+++ b/src/apps/invitations/api.py
@@ -298,11 +298,13 @@ async def invitation_accept(
 ):
     """General endpoint to approve the applet invitation."""
     applet_id = None
+    invitation_role = None
     try:
         invitation_service = InvitationsService(session, user)
         invitation = await invitation_service.get(key)
         if invitation:
             applet_id = invitation.applet_id
+            invitation_role = invitation.role
 
         try:
             async with atomic(session):
@@ -342,6 +344,8 @@ async def invitation_accept(
                 event_action=EventAction.APPLET_INVITE_ACCEPT,
                 user_id=user.id,
                 curious_applet_id=[applet_id] if applet_id else None,
+                user_target_id=user.id,
+                user_target_roles=[invitation_role] if invitation_role else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -352,6 +356,8 @@ async def invitation_accept(
             event_action=EventAction.APPLET_INVITE_ACCEPT,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=user.id,
+            user_target_roles=[invitation_role] if invitation_role else None,
             **http_audit_fields(request),
         )
     )
@@ -364,11 +370,13 @@ async def private_invitation_accept(
     session=Depends(get_session),
 ):
     applet_id = None
+    invitation_role = None
     try:
         private_service = PrivateInvitationService(session)
         invitation = await private_service.get_invitation(key)
         if invitation:
             applet_id = invitation.applet_id
+            invitation_role = invitation.role
 
         async with atomic(session):
             await private_service.accept_invitation(user, key)
@@ -378,6 +386,8 @@ async def private_invitation_accept(
                 event_action=EventAction.APPLET_INVITE_ACCEPT,
                 user_id=user.id,
                 curious_applet_id=[applet_id] if applet_id else None,
+                user_target_id=user.id,
+                user_target_roles=[invitation_role] if invitation_role else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -388,6 +398,8 @@ async def private_invitation_accept(
             event_action=EventAction.APPLET_INVITE_ACCEPT,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=user.id,
+            user_target_roles=[invitation_role] if invitation_role else None,
             **http_audit_fields(request),
         )
     )
@@ -415,6 +427,7 @@ async def invitation_decline(
                 event_action=EventAction.APPLET_INVITE_DECLINE,
                 user_id=user.id,
                 curious_applet_id=[applet_id] if applet_id else None,
+                user_target_id=user.id,
                 **http_audit_fields(request, e),
             )
         )
@@ -425,6 +438,7 @@ async def invitation_decline(
             event_action=EventAction.APPLET_INVITE_DECLINE,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=user.id,
             **http_audit_fields(request),
         )
     )

--- a/src/apps/invitations/router.py
+++ b/src/apps/invitations/router.py
@@ -164,7 +164,7 @@ async def create_shell_account(
                 user_id=user.id,
                 curious_applet_id=[applet_id],
                 user_target_email=subject_schema.email,
-                user_target_roles=["shell-account"],
+                # `user_target_roles=None` because shell account grants no role
                 **http_audit_fields(request, e),
             )
         )
@@ -176,7 +176,6 @@ async def create_shell_account(
             user_id=user.id,
             curious_applet_id=[applet_id],
             user_target_email=subject_schema.email,
-            user_target_roles=["shell-account"],
             **http_audit_fields(request),
         )
     )

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -1609,6 +1609,8 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_id == lucy.id
+        assert event.user_target_roles == [Role.MANAGER]
 
     async def test_invitation_accept_audit_event_failure(
         self,
@@ -1625,6 +1627,9 @@ class TestInvite(BaseTest):
         assert event.event_action == EventAction.APPLET_INVITE_ACCEPT
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_id == tom.id
+        assert event.user_target_id == tom.id
+        # The key did not resolve to an invitation, so the role is unknown.
+        assert event.user_target_roles is None
 
     async def test_private_invitation_accept_audit_event(
         self,
@@ -1643,6 +1648,8 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == lucy.id
         assert event.curious_applet_id == [applet_one_with_link.id]
+        assert event.user_target_id == lucy.id
+        assert event.user_target_roles == [Role.RESPONDENT]
 
     async def test_invitation_decline_audit_event(
         self,
@@ -1661,6 +1668,7 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_id == lucy.id
 
     async def test_invitation_decline_audit_event_failure(
         self,
@@ -1677,6 +1685,7 @@ class TestInvite(BaseTest):
         assert event.event_action == EventAction.APPLET_INVITE_DECLINE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_id == tom.id
+        assert event.user_target_id == tom.id
 
     async def test_shell_create_account_audit_event(
         self, client: TestClient, shell_create_data: dict, bob: User, applet_four: AppletFull, mocker

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -1662,4 +1662,4 @@ class TestInvite(BaseTest):
         assert event.user_id == bob.id
         assert event.curious_applet_id == [applet_four.id]
         assert event.user_target_email == "shell@example.com"
-        assert event.user_target_roles == ["shell-account"]
+        assert event.user_target_roles is None  # shell account grants no role

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -1468,6 +1468,7 @@ class TestInvite(BaseTest):
         self,
         client: TestClient,
         tom: User,
+        user: User,
         applet_one: AppletFull,
         invitation_respondent_data: InvitationRespondentRequest,
         mocker,
@@ -1485,13 +1486,39 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
-        assert event.user_target_email == invitation_respondent_data.email
+        assert event.user_target_id == user.id
+        assert event.user_target_email is None
+        assert event.user_target_roles == [Role.RESPONDENT]
+
+    async def test_invite_respondent_audit_event_email_fallback(
+        self,
+        client: TestClient,
+        tom: User,
+        applet_one: AppletFull,
+        invitation_respondent_data: InvitationRespondentRequest,
+        mocker,
+    ):
+        audit_log = mocker.patch("apps.invitations.api.log")
+        invitation_respondent_data.email = "respondent@example.com"
+        client.login(tom)
+        response = await client.post(
+            self.invite_respondent_url.format(applet_id=str(applet_one.id)),
+            invitation_respondent_data,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        audit_log.assert_awaited_once()
+        event = audit_log.call_args[0][0]
+        assert event.event_action == EventAction.APPLET_INVITE_INITIATE
+        assert event.event_outcome == EventOutcome.SUCCESS
+        assert event.user_target_id is None
+        assert event.user_target_email == "respondent@example.com"
         assert event.user_target_roles == [Role.RESPONDENT]
 
     async def test_invite_reviewer_audit_event(
         self,
         client: TestClient,
         tom: User,
+        user: User,
         applet_one: AppletFull,
         invitation_reviewer_data: InvitationReviewerRequest,
         mocker,
@@ -1509,13 +1536,15 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
-        assert event.user_target_email == invitation_reviewer_data.email
+        assert event.user_target_id == user.id
+        assert event.user_target_email is None
         assert event.user_target_roles == [Role.REVIEWER]
 
     async def test_invite_manager_audit_event(
         self,
         client: TestClient,
         tom: User,
+        user: User,
         applet_one: AppletFull,
         invitation_manager_data: InvitationManagersRequest,
         mocker,
@@ -1533,7 +1562,8 @@ class TestInvite(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
-        assert event.user_target_email == invitation_manager_data.email
+        assert event.user_target_id == user.id
+        assert event.user_target_email is None
         assert event.user_target_roles == [invitation_manager_data.role]
 
     async def test_invite_respondent_audit_event_failure(

--- a/src/apps/invitations/test_invite.py
+++ b/src/apps/invitations/test_invite.py
@@ -1570,6 +1570,7 @@ class TestInvite(BaseTest):
         self,
         client: TestClient,
         lucy: User,
+        user: User,
         applet_one: AppletFull,
         invitation_respondent_data: InvitationRespondentRequest,
         mocker,
@@ -1586,6 +1587,8 @@ class TestInvite(BaseTest):
         assert event.event_action == EventAction.APPLET_INVITE_INITIATE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_id == lucy.id
+        assert event.user_target_id == user.id  # failure inviting regsitered user should carry user ID
+        assert event.user_target_email is None
 
     async def test_invitation_accept_audit_event(
         self,

--- a/src/apps/transfer_ownership/api.py
+++ b/src/apps/transfer_ownership/api.py
@@ -10,6 +10,7 @@ from apps.shared.exception import BaseError
 from apps.transfer_ownership.domain import InitiateTransfer
 from apps.transfer_ownership.service import TransferService
 from apps.users.domain import User
+from apps.workspaces.domain.constants import Role
 from apps.workspaces.service.check_access import CheckAccessService
 from infrastructure.database import atomic
 from infrastructure.database.deps import get_session
@@ -66,6 +67,8 @@ async def transfer_accept(
                 event_action=EventAction.APPLET_TRANSFER_ACCEPT,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
+                user_target_id=user.id,
+                user_target_roles=[Role.OWNER],
                 **http_audit_fields(request, e),
             )
         )
@@ -76,6 +79,8 @@ async def transfer_accept(
             event_action=EventAction.APPLET_TRANSFER_ACCEPT,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=user.id,
+            user_target_roles=[Role.OWNER],
             **http_audit_fields(request),
         )
     )
@@ -98,6 +103,7 @@ async def transfer_decline(
                 event_action=EventAction.APPLET_TRANSFER_DECLINE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
+                user_target_id=user.id,
                 **http_audit_fields(request, e),
             )
         )
@@ -108,6 +114,7 @@ async def transfer_decline(
             event_action=EventAction.APPLET_TRANSFER_DECLINE,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=user.id,
             **http_audit_fields(request),
         )
     )

--- a/src/apps/transfer_ownership/api.py
+++ b/src/apps/transfer_ownership/api.py
@@ -9,7 +9,9 @@ from apps.authentication.deps import get_current_user
 from apps.shared.exception import BaseError
 from apps.transfer_ownership.domain import InitiateTransfer
 from apps.transfer_ownership.service import TransferService
+from apps.users import UserNotFound
 from apps.users.domain import User
+from apps.users.services.user import UserService
 from apps.workspaces.domain.constants import Role
 from apps.workspaces.service.check_access import CheckAccessService
 from infrastructure.database import atomic
@@ -24,8 +26,17 @@ async def transfer_initiate(
     session=Depends(get_session),
 ) -> None:
     """Initiate a transfer of ownership of an applet."""
+    target_owner_id: uuid.UUID | None = None
     try:
         async with atomic(session):
+            try:
+                # Resolve the proposed new owner for audit log
+                target_owner = await UserService(session).get_by_email(transfer.email)
+                target_owner_id = target_owner.id
+            except UserNotFound:
+                # Transferring to an email without an user account
+                pass
+
             await AppletService(session, user.id).exist_by_id(applet_id)
             await CheckAccessService(session, user.id).check_create_transfer_ownership_access(applet_id)
             await TransferService(session, user).initiate_transfer(applet_id, transfer)
@@ -35,6 +46,9 @@ async def transfer_initiate(
                 event_action=EventAction.APPLET_TRANSFER_INITIATE,
                 user_id=user.id,
                 curious_applet_id=[applet_id],
+                user_target_id=target_owner_id,
+                user_target_email=None if target_owner_id else transfer.email,
+                user_target_roles=[Role.OWNER],
                 **http_audit_fields(request, e),
             )
         )
@@ -45,6 +59,9 @@ async def transfer_initiate(
             event_action=EventAction.APPLET_TRANSFER_INITIATE,
             user_id=user.id,
             curious_applet_id=[applet_id],
+            user_target_id=target_owner_id,
+            user_target_email=None if target_owner_id else transfer.email,
+            user_target_roles=[Role.OWNER],
             **http_audit_fields(request),
         )
     )

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -617,7 +617,13 @@ class TestTransfer(BaseTest):
     # ── Audit event tests ──
 
     async def test_initiate_transfer_audit_event(
-        self, client: TestClient, applet_one: AppletFull, tom: User, mailbox: TestMail, mocker: MockerFixture
+        self,
+        client: TestClient,
+        applet_one: AppletFull,
+        tom: User,
+        lucy: User,
+        mailbox: TestMail,
+        mocker: MockerFixture,
     ):
         audit_log = mocker.patch("apps.transfer_ownership.api.log")
         client.login(tom)
@@ -633,6 +639,9 @@ class TestTransfer(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == tom.id
         assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_id == lucy.id
+        assert event.user_target_email is None
+        assert event.user_target_roles == [Role.OWNER]
 
     async def test_initiate_transfer_audit_event_failure(self, client: TestClient, tom: User, mocker: MockerFixture):
         audit_log = mocker.patch("apps.transfer_ownership.api.log")
@@ -648,6 +657,9 @@ class TestTransfer(BaseTest):
         assert event.event_action == EventAction.APPLET_TRANSFER_INITIATE
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.user_id == tom.id
+        assert event.user_target_id is None
+        assert event.user_target_email == "aloevdamirkhon@gmail.com"
+        assert event.user_target_roles == [Role.OWNER]
 
     async def test_accept_transfer_audit_event(
         self,

--- a/src/apps/transfer_ownership/tests.py
+++ b/src/apps/transfer_ownership/tests.py
@@ -674,6 +674,8 @@ class TestTransfer(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_id == lucy.id
+        assert event.user_target_roles == [Role.OWNER]
 
     async def test_decline_transfer_audit_event(
         self, client: TestClient, mocker: MockerFixture, applet_one: AppletFull, lucy: User
@@ -694,3 +696,5 @@ class TestTransfer(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.user_id == lucy.id
         assert event.curious_applet_id == [applet_one.id]
+        assert event.user_target_id == lucy.id
+        assert event.user_target_roles is None

--- a/src/apps/users/tests/test_user.py
+++ b/src/apps/users/tests/test_user.py
@@ -114,7 +114,7 @@ class TestUser:
 
     async def test_create_user_not_valid_email(self, client: TestClient, request_data: UserCreateRequest):
         data = request_data.model_dump()
-        data["email"] = "tom2@mindlogger@com"
+        data["email"] = "tom2@gettingcurious@com"
         response = await client.post(self.user_create_url, data=data)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()["result"]


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10745](https://mindlogger.atlassian.net/browse/M2-10745)

Changes include:

- Use `user.target.roles=null` instead of `user.target.roles=["shell-account"]` for shell account invite
- Use `user.target.id` instead of `user.target.email` when possible
- Log `user.target.id` or `user.target.email` when transferring owner 
- Log `user.target.id` when accepting invites

### ✏️ Notes

These fix a few small issues I noticed while reviewing applet IAM audit log events.