### PR TITLE
fix: Clean up data access events (M2-10700)

### DIFF
--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -262,6 +262,7 @@ async def applet_activity_answers_list(
     query_params: QueryParams = Depends(parse_query_params(AppletSubmissionsFilter)),
     answer_session=Depends(get_answer_session),
 ) -> ResponseMulti[AppletActivityAnswerPublic]:
+    target_subject_id = query_params.filters.get("target_subject_id")
     try:
         filters = query_params.filters
         await AppletService(session, user.id).exist_by_id(applet_id)
@@ -283,6 +284,7 @@ async def applet_activity_answers_list(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=[target_subject_id] if target_subject_id else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -293,6 +295,7 @@ async def applet_activity_answers_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
+            curious_subject_id=[target_subject_id] if target_subject_id else None,
             curious_answer_id=[a.answer_id for a in answers if a.answer_id] or None,
             **http_audit_fields(request),
         )
@@ -309,6 +312,7 @@ async def applet_flow_submissions_list(
     session=Depends(get_session),
     answer_session=Depends(get_answer_session),
 ) -> PublicFlowSubmissionsResponse:
+    target_subject_id = query_params.filters.get("target_subject_id")
     try:
         await AppletService(session, user.id).exist_by_id(applet_id)
         await CheckAccessService(session, user.id).check_answer_review_access(applet_id)
@@ -328,6 +332,7 @@ async def applet_flow_submissions_list(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_VIEW,
                 curious_applet_id=[applet_id],
+                curious_subject_id=[target_subject_id] if target_subject_id else None,
                 **http_audit_fields(request, e),
             )
         )
@@ -338,6 +343,7 @@ async def applet_flow_submissions_list(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_VIEW,
             curious_applet_id=[applet_id],
+            curious_subject_id=[target_subject_id] if target_subject_id else None,
             curious_submit_id=[s.submit_id for s in submissions.submissions] or None,
             curious_answer_id=[a.id for s in submissions.submissions for a in s.answers] or None,
             **http_audit_fields(request),

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -371,7 +371,6 @@ async def summary_activity_latest_report_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
                 curious_applet_id=[applet_id],
-                curious_activity_id=[activity_id],
                 curious_subject_id=[subject_id],
                 **http_audit_fields(request, e),
             )
@@ -383,7 +382,6 @@ async def summary_activity_latest_report_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
             curious_applet_id=[applet_id],
-            curious_activity_id=[activity_id],
             curious_subject_id=[subject_id],
             **http_audit_fields(request),
         )
@@ -1339,7 +1337,6 @@ async def applet_ehr_answers_export(
                 event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
                 curious_applet_id=[applet_id],
                 curious_subject_id=query_params.filters.get("target_subject_ids"),
-                curious_activity_id=query_params.filters.get("activity_ids"),
                 **http_audit_fields(request, e),
             )
         )
@@ -1351,7 +1348,6 @@ async def applet_ehr_answers_export(
             event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
             curious_applet_id=[applet_id],
             curious_subject_id=list({a.target_subject_id for a in ehr_answers}) or None,
-            curious_activity_id=list({a.activity_id for a in ehr_answers}) or None,
             curious_submit_id=list({a.submit_id for a in ehr_answers}) or None,
             **http_audit_fields(request),
         )
@@ -1397,7 +1393,6 @@ async def applet_ehr_answers_export(
                     event_action=EventAction.APPLET_ANSWER_EHR_DOWNLOAD,
                     curious_applet_id=[applet_id],
                     curious_subject_id=list({a.target_subject_id for a in ehr_answers}) or None,
-                    curious_activity_id=list({a.activity_id for a in ehr_answers}) or None,
                     curious_submit_id=list({a.submit_id for a in ehr_answers}) or None,
                     event_outcome=EventOutcome.FAILURE,
                     error_type=type(e).__name__,

--- a/src/apps/answers/api.py
+++ b/src/apps/answers/api.py
@@ -424,7 +424,6 @@ async def summary_flow_latest_report_retrieve(
                 user_id=user.id,
                 event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
                 curious_applet_id=[applet_id],
-                curious_flow_id=[flow_id],
                 curious_subject_id=[subject_id],
                 **http_audit_fields(request, e),
             )
@@ -436,7 +435,6 @@ async def summary_flow_latest_report_retrieve(
             user_id=user.id,
             event_action=EventAction.APPLET_ANSWER_REPORT_DOWNLOAD,
             curious_applet_id=[applet_id],
-            curious_flow_id=[flow_id],
             curious_subject_id=[subject_id],
             **http_audit_fields(request),
         )
@@ -1342,7 +1340,6 @@ async def applet_ehr_answers_export(
                 curious_applet_id=[applet_id],
                 curious_subject_id=query_params.filters.get("target_subject_ids"),
                 curious_activity_id=query_params.filters.get("activity_ids"),
-                curious_flow_id=query_params.filters.get("flow_ids"),
                 **http_audit_fields(request, e),
             )
         )

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -954,7 +954,6 @@ class TestAnswersAudit(BaseTest):
         assert event.curious_applet_id == [applet.id]
         assert event.curious_subject_id == [target_subject_id]
         assert event.curious_activity_id == [activity_id]
-        assert event.curious_flow_id == [flow_id]
 
     async def test_ehr_download_zip_failure_emits_error_event(
         self,
@@ -1035,7 +1034,6 @@ class TestAnswersAudit(BaseTest):
         assert event.curious_applet_id == [applet.id]
         assert event.curious_activity_id == [applet.activities[0].id]
         assert event.curious_subject_id == [tom_applet_subject.id]
-        assert event.curious_flow_id is None
 
     async def test_activity_report_download_failure_subject_not_found(
         self,
@@ -1121,7 +1119,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_flow_id == [applet_with_flow.activity_flows[0].id]
         assert event.curious_subject_id == [tom_applet_with_flow_subject.id]
         assert event.curious_activity_id is None
 
@@ -1152,4 +1149,3 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet_with_flow.id]
-        assert event.curious_flow_id == [applet_with_flow.activity_flows[0].id]

--- a/src/apps/answers/tests/test_audit.py
+++ b/src/apps/answers/tests/test_audit.py
@@ -851,7 +851,6 @@ class TestAnswersAudit(BaseTest):
         assert event.curious_applet_id == [applet.id]
         assert event.curious_subject_id is not None
         assert set(event.curious_subject_id) == {subject_id_a, subject_id_b}
-        assert event.curious_activity_id == [activity_id_a]
         assert event.curious_submit_id is not None
         assert set(event.curious_submit_id) == {submit_id_a, submit_id_b}
 
@@ -879,7 +878,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet.id]
         assert event.curious_subject_id is None
-        assert event.curious_activity_id is None
         assert event.curious_submit_id is None
 
     async def test_ehr_download_failure_404_applet(
@@ -953,7 +951,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet.id]
         assert event.curious_subject_id == [target_subject_id]
-        assert event.curious_activity_id == [activity_id]
 
     async def test_ehr_download_zip_failure_emits_error_event(
         self,
@@ -998,7 +995,6 @@ class TestAnswersAudit(BaseTest):
         assert failure_event.error_type == "RuntimeError"
         assert failure_event.curious_applet_id == [applet.id]
         assert failure_event.curious_subject_id == [subject_id]
-        assert failure_event.curious_activity_id == [activity_id]
         assert failure_event.curious_submit_id == [submit_id]
 
     # --- summary_activity_latest_report_retrieve / summary_flow_latest_report_retrieve ---
@@ -1032,7 +1028,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet.id]
-        assert event.curious_activity_id == [applet.activities[0].id]
         assert event.curious_subject_id == [tom_applet_subject.id]
 
     async def test_activity_report_download_failure_subject_not_found(
@@ -1061,7 +1056,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet.id]
-        assert event.curious_activity_id == [applet.activities[0].id]
         assert event.curious_subject_id == [missing_subject_id]
 
     async def test_activity_report_download_failure_403(
@@ -1091,7 +1085,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_action == EventAction.APPLET_ANSWER_REPORT_DOWNLOAD
         assert event.event_outcome == EventOutcome.FAILURE
         assert event.curious_applet_id == [applet.id]
-        assert event.curious_activity_id == [applet.activities[0].id]
 
     async def test_flow_report_download_success(
         self,
@@ -1120,7 +1113,6 @@ class TestAnswersAudit(BaseTest):
         assert event.event_outcome == EventOutcome.SUCCESS
         assert event.curious_applet_id == [applet_with_flow.id]
         assert event.curious_subject_id == [tom_applet_with_flow_subject.id]
-        assert event.curious_activity_id is None
 
     async def test_flow_report_download_failure_403(
         self,

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -55,7 +55,6 @@ class AuditEvent(PublicModel):
     Applicable to Curious database records:
     - curious_applet_id
     - curious_subject_id
-    - curious_flow_id
     - curious_activity_id
     - curious_submit_id
     - curious_answer_id
@@ -108,7 +107,6 @@ class AuditEvent(PublicModel):
     # For Curious database records
     curious_applet_id: Annotated[list[UUID] | None, Field(alias="curious.applet_id")] = None
     curious_subject_id: Annotated[list[UUID] | None, Field(alias="curious.subject_id")] = None
-    curious_flow_id: Annotated[list[UUID] | None, Field(alias="curious.flow_id")] = None
     curious_activity_id: Annotated[list[UUID] | None, Field(alias="curious.activity_id")] = None
     curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
     curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None

--- a/src/apps/audit/domain.py
+++ b/src/apps/audit/domain.py
@@ -55,7 +55,6 @@ class AuditEvent(PublicModel):
     Applicable to Curious database records:
     - curious_applet_id
     - curious_subject_id
-    - curious_activity_id
     - curious_submit_id
     - curious_answer_id
 
@@ -107,7 +106,6 @@ class AuditEvent(PublicModel):
     # For Curious database records
     curious_applet_id: Annotated[list[UUID] | None, Field(alias="curious.applet_id")] = None
     curious_subject_id: Annotated[list[UUID] | None, Field(alias="curious.subject_id")] = None
-    curious_activity_id: Annotated[list[UUID] | None, Field(alias="curious.activity_id")] = None
     curious_submit_id: Annotated[list[UUID] | None, Field(alias="curious.submit_id")] = None
     curious_answer_id: Annotated[list[UUID] | None, Field(alias="curious.answer_id")] = None
 


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10700](https://mindlogger.atlassian.net/browse/M2-10700)

Changes include:

- Remove unused `curious.flow_id`
- Remove unused `curious.activity_id`
- Populate `curious.subject_id` when fetching answers

### ✏️ Notes

This is a follow-up PR with a few small audit log updates for data access events.