### PR TITLE
feat: Export `user:*` events from past applet membership (M2-10698)

### DIFF
--- a/src/apps/audit/crud.py
+++ b/src/apps/audit/crud.py
@@ -57,24 +57,29 @@ class AuditLogCRUD(BaseCRUD[AuditLogSchema]):
         """Events for an applet's audit export.
 
         Returns the applet's own events plus account-level events
-        (``ACCOUNT_LEVEL_EXPORT_ACTIONS``) for its manager-class users. Membership
-        is resolved at query time against current roles, so an account event stops
-        appearing once the user loses their role on the applet, and events from
-        before the user's access was granted are never surfaced.
+        (``ACCOUNT_LEVEL_EXPORT_ACTIONS``) for its manager-class users. Events
+        for current members are included from the time the membership started.
+        Events for past members are included for the time period of the most
+        recent past membership. (Note that we do not store membership history
+        beyond the most recent past membership, so events during older past
+        memberships will not be included.)
         """
         # Users with a manager-class role on this applet. Their account-level events
         # (login/logout/MFA/...) are surfaced in the export even though those events
         # carry no applet id; respondents are intentionally excluded. Only events
-        # from the access grant onwards qualify — adding a member must not expose
-        # their earlier session history (both columns are naive UTC).
+        # inside the most recent membership window qualify — adding a member must
+        # not expose their earlier session history.
         privileged_access = (
             select(UserAppletAccessSchema.id)
             .where(
                 UserAppletAccessSchema.applet_id == applet_id,
                 UserAppletAccessSchema.role.in_(Role.managers()),
-                UserAppletAccessSchema.soft_exists(),
                 UserAppletAccessSchema.user_id == AuditLogSchema.user_id,
                 UserAppletAccessSchema.created_at <= AuditLogSchema.event_timestamp,
+                or_(
+                    UserAppletAccessSchema.soft_exists(),
+                    AuditLogSchema.event_timestamp <= UserAppletAccessSchema.updated_at,
+                ),
             )
             .exists()
         )

--- a/src/apps/audit/tests/test_api.py
+++ b/src/apps/audit/tests/test_api.py
@@ -217,14 +217,40 @@ async def test_owner_does_not_see_manager_account_events_from_before_joining(
     assert body["result"][0]["event.id"] == str(after_join.event_id)
 
 
-async def test_owner_does_not_see_revoked_manager_account_events(
+async def test_owner_sees_revoked_manager_account_events_from_during_membership(
     client: TestClient, session: AsyncSession, tom: User, lucy: User, applet_one_lucy_manager: AppletFull
 ):
+    """Removing a team member keeps their account events from while they were
+    a member visible in the export."""
     applet = applet_one_lucy_manager
-    # After the grant, so revocation alone is what hides it.
-    await _seed_account_event(session, user_id=lucy.id, timestamp=_utcnow() + datetime.timedelta(hours=1))
+    during = await _seed_account_event(session, user_id=lucy.id, timestamp=_utcnow())
 
     # Revoke lucy's access (role removal is a soft delete).
+    await session.execute(
+        update(UserAppletAccessSchema)
+        .where(UserAppletAccessSchema.user_id == lucy.id, UserAppletAccessSchema.applet_id == applet.id)
+        .values(is_deleted=True)
+    )
+
+    client.login(tom)
+    response = await client.get(URL.format(applet_id=applet.id))
+    assert response.status_code == http.HTTPStatus.OK
+    body = response.json()
+    assert body["count"] == 1
+    assert body["result"][0]["event.id"] == str(during.event_id)
+
+
+async def test_owner_does_not_see_revoked_manager_account_events_from_after_removal(
+    client: TestClient, session: AsyncSession, tom: User, lucy: User, applet_one_lucy_manager: AppletFull
+):
+    """Removing a team member ends their membership window: account events
+    from after the revocation stay out of the export."""
+    applet = applet_one_lucy_manager
+
+    # Timestamp event an hour after the revocation below.
+    await _seed_account_event(session, user_id=lucy.id, timestamp=_utcnow() + datetime.timedelta(hours=1))
+
+    # Revoke lucy's access (role removal is a soft delete that bumps updated_at).
     await session.execute(
         update(UserAppletAccessSchema)
         .where(UserAppletAccessSchema.user_id == lucy.id, UserAppletAccessSchema.applet_id == applet.id)


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10698](https://mindlogger.atlassian.net/browse/M2-10698)

Changes include:

- Export `user:*` events from past applet membership
- Exclude events that occur after applet membership ended

### ✏️ Notes

We do not store membership history, so events from older applet memberships are not included in the export.