### PR TITLE
fix: noreply@cmiml.net in non-prod environments (M2-10880)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -63,7 +63,7 @@ MAILING__MAIL__SERVER=localhost
 MAILING__MAIL__PORT=1025
 MAILING__MAIL_STARTTLS=
 MAILING__MAIL_SSL_TLS=
-MAILING__MAIL__FROM_EMAIL="no-reply@mindlogger.org"
+MAILING__MAIL__FROM_EMAIL="noreply@cmiml.net"
 MAILING__MAIL__FROM_NAME="Curious"
 # Currently these settings are not used
 MAILING__USE_CREDENTIALS=False

--- a/copilot/mindlogger-backend/manifest.yml
+++ b/copilot/mindlogger-backend/manifest.yml
@@ -93,8 +93,8 @@ variables:
   MAILING__MAIL__SERVER: email-smtp.us-east-1.amazonaws.com
   MAILING__MAIL__PORT: 2465
   MAILING__MAIL__SSL_TLS: True
-  MAILING__MAIL__FROM_EMAIL: "noreply@gettingcurious.com"
-  MAILING__MAIL__FROM_NAME: "Mindlogger"
+  MAILING__MAIL__FROM_EMAIL: "noreply@cmiml.net"
+  MAILING__MAIL__FROM_NAME: "Curious"
   # Currently these settings are not used
   MAILING__USE_CREDENTIALS: True
   MAILING__VALIDATE_CERTS: True


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10880](https://mindlogger.atlassian.net/browse/M2-10880)

Changes include:

- Stick to noreply@cmiml.net in non-prod environments

### ✏️ Notes

This change is a follow-up to #2079.

As @aweiland noted, using noreply@cmiml.net in non-prod environments avoids the risk of accidentally damaging our reputation for sending emails with noreply@gettingcurious.com.